### PR TITLE
feat: onboarding profile multi-step flow

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { YoutubeTranscriptModule } from './youtube-transcript';
 import { TierModule } from './tier/tier.module';
 import { MailModule } from './mail';
 import { FeedbackModule } from './feedback/feedback.module';
+import { OnboardingModule } from './onboarding';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { FeedbackModule } from './feedback/feedback.module';
     PostModule,
     EncryptionModule,
     YoutubeTranscriptModule,
+    OnboardingModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -17,6 +17,8 @@ import {
   BillingCustomerSchema,
   Usage,
   UsageSchema,
+  OnboardingProfile,
+  OnboardingProfileSchema,
 } from './schemas';
 
 @Global()
@@ -37,6 +39,7 @@ import {
       { name: Subscription.name, schema: SubscriptionSchema },
       { name: BillingCustomer.name, schema: BillingCustomerSchema },
       { name: Usage.name, schema: UsageSchema },
+      { name: OnboardingProfile.name, schema: OnboardingProfileSchema }
     ]),
   ],
   exports: [MongooseModule],
@@ -44,7 +47,7 @@ import {
 export class DatabaseModule implements OnModuleInit {
   private readonly logger = new Logger(DatabaseModule.name);
 
-  constructor(@InjectConnection() private readonly connection: Connection) {}
+  constructor(@InjectConnection() private readonly connection: Connection) { }
 
   onModuleInit() {
     if (this.connection.readyState === 1) {

--- a/src/database/schemas/index.ts
+++ b/src/database/schemas/index.ts
@@ -5,3 +5,4 @@ export * from './tier.schema';
 export * from './subscription.schema';
 export * from './billing-customer.schema';
 export * from './usage.schema';
+export * from './onboarding-profile.schema'

--- a/src/database/schemas/onboarding-profile.schema.ts
+++ b/src/database/schemas/onboarding-profile.schema.ts
@@ -1,0 +1,94 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { User } from "./user.schema";
+import { Types } from "mongoose";
+
+export enum UserType {
+    CREATOR = 'CREATOR',
+    PRO_WRITER = 'PRO_WRITER',
+}
+export enum CreatorLevel {
+    GETTING_STARTED = 'getting_started',   // <500 followers
+    BUILDING_MOMENTUM = 'building_momentum', // 500-5000
+    SEASONED = 'seasoned',                 // 5000+
+}
+
+export enum Goal {
+    GROW_AUDIENCE = 'grow_audience',
+    THOUGHT_LEADERSHIP = 'thought_leadership',
+    GENERATE_LEADS = 'generate_leads',
+    PERSONAL_BRAND = 'personal_brand',
+    HIRING = 'hiring',
+    BUILD_COMMUNITY = 'build_community',
+    SCALE_OUTPUT = 'scale_output',
+    SHARPER_DRAFTS = 'sharper_drafts',
+    HIT_SCHEDULES = 'hit_schedules',
+    CLEANER_HANDOFF = 'cleaner_handoff',
+    MATCH_EACH_VOICE = 'match_each_voice',
+    CLIENT_REPORTING = 'client_reporting',
+}
+
+export enum PostingFrequency {
+    TWO_PER_WEEK = '2x_week',
+    THREE_PER_WEEK = '3x_week',
+    FIVE_PER_WEEK = '5x_week',
+    EVERY_DAY = 'every_day',
+}
+
+export enum DayOfWeek {
+    MON = 'mon',
+    TUE = 'tue',
+    WED = 'wed',
+    THU = 'thu',
+    FRI = 'fri',
+    SAT = 'sat',
+    SUN = 'sun',
+}
+
+export enum NumberOfClients {
+    ONE_TO_TWO = '1-2',
+    THREE_TO_FIVE = '3-5',
+    SIX_TO_TEN = '6-10',
+    TEN_PLUS = '10+'
+}
+
+export interface CreatorOnboardingData {
+    name?: string;
+    creatorLevel?: CreatorLevel;
+    goals?: Goal[];
+    postingFrequency?: PostingFrequency;
+    postingDays?: DayOfWeek[];
+    topics?: string[];
+}
+
+export interface ProWriterOnboardingData {
+    name?: string;
+    agencyName?: string;
+    numberOfClients?: NumberOfClients;
+    clientGoal?: Goal[];
+    postingFrequency?: PostingFrequency;
+    postingDays?: DayOfWeek[];
+    topics?: string[];
+}
+
+type OnboardingData = CreatorOnboardingData | ProWriterOnboardingData
+
+@Schema({ timestamps: true })
+export class OnboardingProfile {
+    @Prop({ type: Types.ObjectId, ref: User.name, required: true })
+    user: User | Types.ObjectId;
+
+    @Prop({ required: true, enum: UserType })
+    userType: UserType;
+
+    @Prop({ default: 1 })
+    currentStep: number;
+
+    @Prop({ default: false })
+    isComplete: boolean;
+
+    @Prop({ type: Object })
+    data: OnboardingData;
+}
+
+export const OnboardingProfileSchema = SchemaFactory.createForClass(OnboardingProfile);
+

--- a/src/onboarding/dto/index.ts
+++ b/src/onboarding/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './init-onboarding.dto';
+export * from './update-onboarding.dto';

--- a/src/onboarding/dto/init-onboarding.dto.ts
+++ b/src/onboarding/dto/init-onboarding.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserType } from '../../database/schemas';
+
+export class InitOnboardingDto {
+  @IsEnum(UserType)
+  userType: UserType;
+}

--- a/src/onboarding/dto/update-onboarding.dto.ts
+++ b/src/onboarding/dto/update-onboarding.dto.ts
@@ -1,0 +1,64 @@
+import {
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import {
+  CreatorLevel,
+  DayOfWeek,
+  Goal,
+  NumberOfClients,
+  PostingFrequency,
+} from '../../database/schemas';
+
+export class UpdateOnboardingDto {
+  @IsInt()
+  @Min(2)
+  @Max(5)
+  step: number;
+
+  // Step 2 — shared
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  // Step 2 — Creator
+  @IsOptional()
+  @IsEnum(CreatorLevel)
+  creatorLevel?: CreatorLevel;
+
+  // Step 2 — Pro Writer
+  @IsOptional()
+  @IsString()
+  agencyName?: string;
+
+  @IsOptional()
+  @IsEnum(NumberOfClients)
+  numberOfClients?: NumberOfClients;
+
+  // Step 3 — goals (Creator → goals, Pro Writer → clientGoal)
+  @IsOptional()
+  @IsArray()
+  @IsEnum(Goal, { each: true })
+  goals?: Goal[];
+
+  // Step 4
+  @IsOptional()
+  @IsEnum(PostingFrequency)
+  postingFrequency?: PostingFrequency;
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(DayOfWeek, { each: true })
+  postingDays?: DayOfWeek[];
+
+  // Step 5
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  topics?: string[];
+}

--- a/src/onboarding/index.ts
+++ b/src/onboarding/index.ts
@@ -1,0 +1,1 @@
+export * from './onboarding.module';

--- a/src/onboarding/onboarding.controller.ts
+++ b/src/onboarding/onboarding.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../common/guards';
+import { GetUser } from '../common/decorators';
+import { User } from '../database/schemas';
+import { IAppResponse } from '../common/interfaces';
+import { OnboardingService } from './onboarding.service';
+import { InitOnboardingDto, UpdateOnboardingDto } from './dto';
+
+@Controller('onboarding')
+@UseGuards(JwtAuthGuard)
+export class OnboardingController {
+  constructor(private readonly onboardingService: OnboardingService) {}
+
+  @Post()
+  async initOnboarding(
+    @GetUser() user: User,
+    @Body() dto: InitOnboardingDto,
+  ): Promise<IAppResponse> {
+    const data = await this.onboardingService.initOnboarding(user, dto);
+    return {
+      statusCode: HttpStatus.CREATED,
+      message: 'Onboarding profile created',
+      data,
+    };
+  }
+
+  @Patch()
+  async updateStep(
+    @GetUser() user: User,
+    @Body() dto: UpdateOnboardingDto,
+  ): Promise<IAppResponse> {
+    const data = await this.onboardingService.updateOnboardingStep(user, dto);
+    return {
+      statusCode: HttpStatus.OK,
+      message: `Step ${dto.step} saved`,
+      data,
+    };
+  }
+
+  @Get()
+  async getProfile(@GetUser() user: User): Promise<IAppResponse> {
+    const data = await this.onboardingService.getOnboardingProfile(user);
+    return {
+      statusCode: HttpStatus.OK,
+      message: 'Onboarding profile fetched',
+      data,
+    };
+  }
+}

--- a/src/onboarding/onboarding.module.ts
+++ b/src/onboarding/onboarding.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OnboardingController } from './onboarding.controller';
+import { OnboardingService } from './onboarding.service';
+
+@Module({
+  controllers: [OnboardingController],
+  providers: [OnboardingService],
+})
+export class OnboardingModule {}

--- a/src/onboarding/onboarding.service.ts
+++ b/src/onboarding/onboarding.service.ts
@@ -1,0 +1,94 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  OnboardingProfile,
+  User,
+  UserType,
+} from '../database/schemas';
+import { InitOnboardingDto, UpdateOnboardingDto } from './dto';
+
+@Injectable()
+export class OnboardingService {
+  constructor(
+    @InjectModel(OnboardingProfile.name)
+    private readonly onboardingModel: Model<OnboardingProfile>,
+  ) {}
+
+  async initOnboarding(user: User, dto: InitOnboardingDto) {
+    const profile = await this.onboardingModel.findOneAndUpdate(
+      { user: user._id },
+      { userType: dto.userType, currentStep: 1, isComplete: false, data: {} },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+
+    return profile;
+  }
+
+  async updateOnboardingStep(user: User, dto: UpdateOnboardingDto) {
+    const profile = await this.onboardingModel.findOne({ user: user._id });
+    if (!profile) {
+      throw new NotFoundException('Onboarding profile not found');
+    }
+
+    if (dto.step !== profile.currentStep + 1) {
+      throw new BadRequestException(
+        `Expected step ${profile.currentStep + 1}, received step ${dto.step}`,
+      );
+    }
+
+    const update = this.buildStepUpdate(profile.userType, dto);
+    profile.data = { ...profile.data, ...update };
+    profile.currentStep = dto.step;
+
+    if (dto.step === 5) {
+      profile.isComplete = true;
+    }
+
+    await profile.save();
+    return profile;
+  }
+
+  async getOnboardingProfile(user: User) {
+    const profile = await this.onboardingModel.findOne({ user: user._id });
+    if (!profile) {
+      throw new NotFoundException('Onboarding profile not found');
+    }
+    return profile;
+  }
+
+  private buildStepUpdate(
+    userType: UserType,
+    dto: UpdateOnboardingDto,
+  ): Record<string, unknown> {
+    switch (dto.step) {
+      case 2:
+        if (userType === UserType.CREATOR) {
+          return { name: dto.name, creatorLevel: dto.creatorLevel };
+        }
+        return {
+          name: dto.name,
+          agencyName: dto.agencyName,
+          numberOfClients: dto.numberOfClients,
+        };
+      case 3:
+        if (userType === UserType.CREATOR) {
+          return { goals: dto.goals };
+        }
+        return { clientGoal: dto.goals };
+      case 4:
+        return {
+          postingFrequency: dto.postingFrequency,
+          postingDays: dto.postingDays,
+        };
+      case 5:
+        return { topics: dto.topics };
+      default:
+        return {};
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `OnboardingProfile` schema + DB registration for Creator and Pro Writer paths
- `POST /api/v1/onboarding` — upserts the profile with the selected `userType`, resets to step 1 (allows path change)
- `PATCH /api/v1/onboarding` — sequential step submission (2–5); merges step data into the typed `data` object; sets `isComplete: true` on step 5
- `GET /api/v1/onboarding` — returns current onboarding state
- Creator step 3 maps to `goals`; Pro Writer step 3 maps to `clientGoal` to match the schema interfaces

## Test plan

- [x] `POST /api/v1/onboarding` with `{ "userType": "CREATOR" }` creates a profile (currentStep: 1)
- [x] Calling `POST` again with `{ "userType": "PRO_WRITER" }` upserts (changes type, resets data)
- [x] `PATCH` with `step: 3` when `currentStep` is 1 returns 400
- [x] Walk through all 5 steps for Creator path; verify `isComplete: true` and correct field names (`goals`, not `clientGoal`)
- [x] Walk through all 5 steps for Pro Writer path; verify `clientGoal` is set on step 3
- [x] `GET` returns 404 before profile is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)