### PR TITLE
fix: replace colon with hyphen in avatar refresh job ID

### DIFF
--- a/src/workflow/linkedin-avatar-refresh.queue.ts
+++ b/src/workflow/linkedin-avatar-refresh.queue.ts
@@ -28,7 +28,7 @@ export class LinkedinAvatarRefreshQueue implements OnModuleInit, OnModuleDestroy
       LINKEDIN_AVATAR_REFRESH_JOB_NAME,
       { connectedAccountId },
       {
-        jobId: `linkedin-avatar-refresh:${connectedAccountId}`,
+        jobId: `linkedin-avatar-refresh-${connectedAccountId}`,
         attempts: 5,
         backoff: {
           type: 'exponential',


### PR DESCRIPTION
## Summary
- BullMQ uses colons as Redis key separators internally; a colon in a custom `jobId` can collide with that convention
- Changed `linkedin-avatar-refresh:${connectedAccountId}` → `linkedin-avatar-refresh-${connectedAccountId}` in `LinkedinAvatarRefreshQueue`
- Aligns with the hyphen-separated pattern used by every other custom job ID in the codebase (`welcome-email-${email}`, `scheduled-post-published-${postId}`, etc.)

## Test plan
- [ ] Queue a LinkedIn avatar refresh and verify the job appears in Redis/BullMQ dashboard with the corrected ID format (no colon)
- [ ] Confirm deduplication still works: enqueuing twice for the same account should not create duplicate jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)