### PR TITLE
refactor: replace @nestjs/axios with custom apiFetch wrapper

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "linkgenserver",
       "dependencies": {
         "@googleapis/youtube": "^31.0.0",
-        "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -18,7 +17,6 @@
         "@paddle/paddle-node-sdk": "^3.7.0",
         "@supadata/js": "^1.3.2",
         "apify-client": "^2.19.0",
-        "axios": "^1.13.2",
         "bullmq": "^5.65.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -304,8 +302,6 @@
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
-
-    "@nestjs/axios": ["@nestjs/axios@4.0.1", "", { "peerDependencies": { "@nestjs/common": "^10.0.0 || ^11.0.0", "axios": "^1.3.1", "rxjs": "^7.0.0" } }, "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A=="],
 
     "@nestjs/cli": ["@nestjs/cli@11.0.16", "", { "dependencies": { "@angular-devkit/core": "19.2.19", "@angular-devkit/schematics": "19.2.19", "@angular-devkit/schematics-cli": "19.2.19", "@inquirer/prompts": "7.10.1", "@nestjs/schematics": "^11.0.1", "ansis": "4.2.0", "chokidar": "4.0.3", "cli-table3": "0.6.5", "commander": "4.1.1", "fork-ts-checker-webpack-plugin": "9.1.0", "glob": "13.0.0", "node-emoji": "1.11.0", "ora": "5.4.1", "tsconfig-paths": "4.2.0", "tsconfig-paths-webpack-plugin": "4.2.0", "typescript": "5.9.3", "webpack": "5.104.1", "webpack-node-externals": "3.0.0" }, "peerDependencies": { "@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0", "@swc/core": "^1.3.62" }, "optionalPeers": ["@swc/cli", "@swc/core"], "bin": { "nest": "bin/nest.js" } }, "sha512-P0H+Vcjki6P5160E5QnMt3Q0X5FTg4PZkP99Ig4lm/4JWqfw32j3EXv3YBTJ2DmxLwOQ/IS9F7dzKpMAgzKTGg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@googleapis/youtube": "^31.0.0",
-    "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -35,7 +34,6 @@
     "@paddle/paddle-node-sdk": "^3.7.0",
     "@supadata/js": "^1.3.2",
     "apify-client": "^2.19.0",
-    "axios": "^1.13.2",
     "bullmq": "^5.65.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/src/agent/agent.module.ts
+++ b/src/agent/agent.module.ts
@@ -1,11 +1,9 @@
 import { Global, Module } from '@nestjs/common';
 import { AgentService } from './agent.service';
-import { HttpModule } from '@nestjs/axios';
 import { AgentController } from './agent.controller';
 
 @Global()
 @Module({
-  imports: [HttpModule],
   providers: [AgentService],
   controllers: [AgentController],
   exports: [AgentService],

--- a/src/agent/agent.service.spec.ts
+++ b/src/agent/agent.service.spec.ts
@@ -12,9 +12,6 @@ jest.mock('../llm/parsers/responseParser.service', () => ({
 jest.mock('@nestjs/config', () => ({
   ConfigService: class ConfigService {},
 }));
-jest.mock('@nestjs/axios', () => ({
-  HttpService: class HttpService {},
-}));
 jest.mock('@supadata/js', () => ({
   Supadata: class Supadata {},
 }));

--- a/src/agent/agent.service.ts
+++ b/src/agent/agent.service.ts
@@ -19,7 +19,6 @@ import {
   UserIntent,
   YoutubeSearchResult,
 } from './agent.interface';
-import { HttpService } from '@nestjs/axios';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { PostDraft } from 'src/database/schemas';
@@ -34,7 +33,6 @@ export class AgentService {
     private actorsService: ActorsService,
     private parser: ResponseParserService,
     private config: ConfigService,
-    private http: HttpService,
     private youtubeTranscriptService: YoutubeTranscriptService,
     @InjectModel(PostDraft.name) private draftModel: Model<PostDraft>,
   ) {

--- a/src/feedback/feedback.service.spec.ts
+++ b/src/feedback/feedback.service.spec.ts
@@ -6,6 +6,26 @@ import { ConfigService } from '@nestjs/config';
 import { FeedbackService } from './feedback.service';
 import { FeedbackIssueType } from './dto';
 
+jest.mock(
+  '../common/HelperFn',
+  () => ({
+    apiFetch: jest.fn(),
+    ApiError: class ApiError extends Error {
+      constructor(
+        public statusCode: number,
+        public statusText: string,
+        public data: any,
+      ) {
+        super(`HTTP error! status: ${statusCode} ${statusText}`);
+        this.name = 'ApiError';
+      }
+    },
+  }),
+  { virtual: true },
+);
+
+import { ApiError, apiFetch } from '../common/HelperFn';
+
 describe('FeedbackService', () => {
   const createConfigService = (
     overrides: Record<string, string | undefined> = {},
@@ -24,19 +44,17 @@ describe('FeedbackService', () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
-    (global as any).fetch = jest.fn();
+    (apiFetch as jest.Mock).mockReset();
   });
 
   it('creates a bug issue with bug label and reporter metadata', async () => {
     const service = new FeedbackService(createConfigService());
-    const fetchMock = global.fetch as jest.Mock;
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 201,
-      json: jest.fn().mockResolvedValue({
+    (apiFetch as jest.Mock).mockResolvedValue({
+      data: {
         number: 45,
         html_url: 'https://github.com/acme/linkgenserver/issues/45',
-      }),
+      },
+      response: { status: 201 },
     });
 
     const result = await service.submitIssue(
@@ -61,14 +79,14 @@ describe('FeedbackService', () => {
       type: FeedbackIssueType.BUG,
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(apiFetch).toHaveBeenCalledWith(
       'https://api.github.com/repos/acme/linkgenserver/issues',
       expect.objectContaining({
         method: 'POST',
       }),
     );
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const body = JSON.parse((apiFetch as jest.Mock).mock.calls[0][1].body);
     expect(body.title).toBe('Cannot schedule post');
     expect(body.labels).toEqual(['bug']);
     expect(body.body).toContain('## Description');
@@ -88,14 +106,12 @@ describe('FeedbackService', () => {
 
   it('creates a feature issue with feature-request label', async () => {
     const service = new FeedbackService(createConfigService());
-    const fetchMock = global.fetch as jest.Mock;
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 201,
-      json: jest.fn().mockResolvedValue({
+    (apiFetch as jest.Mock).mockResolvedValue({
+      data: {
         number: 46,
         html_url: 'https://github.com/acme/linkgenserver/issues/46',
-      }),
+      },
+      response: { status: 201 },
     });
 
     await service.submitIssue(
@@ -114,7 +130,7 @@ describe('FeedbackService', () => {
       },
     );
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const body = JSON.parse((apiFetch as jest.Mock).mock.calls[0][1].body);
     expect(body.labels).toEqual(['feature-request']);
   });
 
@@ -148,14 +164,9 @@ describe('FeedbackService', () => {
 
   it('maps GitHub 422 errors to BadRequestException', async () => {
     const service = new FeedbackService(createConfigService());
-    const fetchMock = global.fetch as jest.Mock;
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 422,
-      json: jest.fn().mockResolvedValue({
-        message: 'Validation Failed',
-      }),
-    });
+    (apiFetch as jest.Mock).mockRejectedValue(
+      new ApiError(422, 'Unprocessable Entity', { message: 'Validation Failed' }),
+    );
 
     await expect(
       service.submitIssue(
@@ -178,14 +189,9 @@ describe('FeedbackService', () => {
 
   it('maps non-validation GitHub errors to InternalServerErrorException', async () => {
     const service = new FeedbackService(createConfigService());
-    const fetchMock = global.fetch as jest.Mock;
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 500,
-      json: jest.fn().mockResolvedValue({
-        message: 'Server Error',
-      }),
-    });
+    (apiFetch as jest.Mock).mockRejectedValue(
+      new ApiError(500, 'Internal Server Error', { message: 'Server Error' }),
+    );
 
     await expect(
       service.submitIssue(

--- a/src/feedback/feedback.service.ts
+++ b/src/feedback/feedback.service.ts
@@ -6,6 +6,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { User } from '../database/schemas';
 import { CreateFeedbackIssueDto, DeviceReport, FeedbackIssueType } from './dto';
+import { ApiError, apiFetch } from '../common/HelperFn';
 
 type GithubIssueResponse = {
   number?: number;
@@ -31,9 +32,9 @@ export class FeedbackService {
     const label = this.mapLabel(dto.type);
     const issueBody = this.buildIssueBody(user, dto.description, dto.deviceReport);
 
-    let response: Response;
+    let payload: GithubIssueResponse;
     try {
-      response = await fetch(
+      const { data } = await apiFetch<GithubIssueResponse>(
         `https://api.github.com/repos/${owner}/${repo}/issues`,
         {
           method: 'POST',
@@ -51,26 +52,17 @@ export class FeedbackService {
           }),
         },
       );
-    } catch {
-      throw new InternalServerErrorException(
-        'Failed to connect to GitHub issue API',
-      );
-    }
-
-    let payload: GithubIssueResponse;
-    try {
-      payload = (await response.json()) as GithubIssueResponse;
-    } catch {
-      throw new InternalServerErrorException('Invalid response from GitHub API');
-    }
-
-    if (!response.ok) {
-      const message = payload.message ?? 'Failed to create GitHub issue';
-      if (response.status === 400 || response.status === 422) {
-        throw new BadRequestException(message);
+      payload = data;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const message =
+          (err.data as GithubIssueResponse)?.message ?? 'Failed to create GitHub issue';
+        if (err.statusCode === 400 || err.statusCode === 422) {
+          throw new BadRequestException(message);
+        }
+        throw new InternalServerErrorException(message);
       }
-
-      throw new InternalServerErrorException(message);
+      throw new InternalServerErrorException('Failed to connect to GitHub issue API');
     }
 
     return {


### PR DESCRIPTION
## Summary

- Removes unused `HttpModule` and `HttpService` from `AgentModule`/`AgentService` (were injected but never called)
- Migrates `FeedbackService` from raw `fetch()` to the project's `apiFetch` helper (`src/common/HelperFn/apiFetch.helper.ts`) with `ApiError`-based error handling
- Updates `agent.service.spec.ts` to drop the dead `@nestjs/axios` mock
- Rewrites `feedback.service.spec.ts` to mock `apiFetch` (matching the pattern used in `auth.service.spec.ts`)
- Removes `@nestjs/axios` and `axios` from `package.json` — neither is used anywhere after this change

## Test plan

- [ ] `bun run build` compiles cleanly
- [ ] `bun run test` — all suites pass, especially `agent.service.spec.ts` and `feedback.service.spec.ts`
- [ ] `grep -rn "from '@nestjs/axios'\|from 'axios'" src/` returns zero matches
- [ ] Manual smoke: `POST /api/v1/feedback` creates a GitHub issue and maps 422/500 errors to the correct Nest exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)