### PR TITLE
fix: map invoice history response to lean transaction shape

### DIFF
--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -206,7 +206,16 @@ export class PaymentService {
       customerId: billingCustomer.providerCustomerId,
     });
 
-    return { items: transactions };
+    const items = transactions.map((tx) => ({
+      id: tx.id,
+      customer: tx.customData?.name,
+      plan: tx.details?.lineItems?.[0]?.product?.name,
+      amount: tx.details?.totals?.grandTotal,
+      status: tx.status,
+      date: tx.createdAt,
+    }));
+
+    return { items };
   }
 
   async getUsageSummary(userId: string) {


### PR DESCRIPTION
## Summary
- `getInvoiceHistory` previously returned raw Paddle SDK transaction objects
- Now maps each transaction to `{ id, customer, plan, amount, status, date }` extracting only the required fields

## Test plan
- [ ] `GET /api/v1/payment/invoices` returns `{ items: [{ id, customer, plan, amount, status, date }] }`
- [ ] Empty array returned when no Paddle billing customer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)