### PR TITLE
docs: add worktree setup and test writing conventions to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Git Worktres
+.claude/worktrees/
+
 # OS
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,122 @@ Copy `.env.example` and fill in real values. Required keys not in the example:
 - `GOOGLE_API_KEY` — YouTube Data API key (used by `AgentService`)
 - `APIFY_API_TOKEN` — for web research via `ActorsService`
 - `OPENROUTER_API_KEY` — LLM calls
+
+## Worktrees
+
+Always place worktrees under `.claude/worktrees/` — this path is already gitignored.
+
+```bash
+# Create a worktree on a new branch
+git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+
+# Copy all .env files from the repo root into the worktree
+cp .env* .claude/worktrees/<branch-name>/
+
+# Install dependencies in the worktree
+cd .claude/worktrees/<branch-name> && bun install
+```
+
+Rules:
+- After creating a worktree, always copy `.env*` files before doing any work in it — services will fail to start without them.
+- Never commit worktree directories; `.claude/worktrees/` is in `.gitignore`.
+- Remove stale worktrees with `git worktree remove .claude/worktrees/<branch-name>` when done.
+
+## Writing Tests
+
+Test files are colocated with their source files as `<name>.spec.ts`. Run a single file with:
+
+```bash
+bun jest src/auth/auth.service.spec.ts
+```
+
+### Structure
+
+- One outer `describe('<ClassName>')` per file.
+- Nest a `describe('<methodName>')` for each public method under test.
+- Name `it` blocks: `"should <expected behavior> when <condition>"`.
+
+### Service construction
+
+Prefer manual construction over `Test.createTestingModule` for unit tests — it is faster and gives finer control:
+
+```typescript
+const service = new MyService(depA as any, depB as any, depC as any);
+// or for private-constructor patterns:
+const service = Object.create(MyService.prototype) as MyService;
+```
+
+Only use `Test.createTestingModule` when testing NestJS lifecycle hooks or module wiring itself.
+
+### Factory pattern
+
+Wrap setup in a `makeService()` factory and call it in `beforeEach`. Return `{ service, mocks, fixtures }`:
+
+```typescript
+const makeService = () => {
+  const userModel = { findOne: jest.fn(), create: jest.fn() };
+  const configService = { get: jest.fn((key) => envValues[key]) };
+  const service = new MyService(userModel as any, configService as any);
+  const fixtures = { user: { _id: new Types.ObjectId(), email: 'a@b.com' } };
+  return { service, mocks: { userModel, configService }, fixtures };
+};
+
+let service: MyService;
+let mocks: ReturnType<typeof makeService>['mocks'];
+let fixtures: ReturnType<typeof makeService>['fixtures'];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ({ service, mocks, fixtures } = makeService());
+});
+```
+
+### Mocking modules
+
+Use `jest.mock` with `{ virtual: true }` for all module-path mocks (required for Bun compatibility):
+
+```typescript
+jest.mock('src/database/schemas', () => ({
+  PostDraftStatus: { DRAFT: 'DRAFT', SCHEDULED: 'SCHEDULED', PUBLISHED: 'PUBLISHED' },
+  AccountProvider: { LINKEDIN: 'LINKEDIN' },
+}), { virtual: true });
+```
+
+### Mongoose query chains
+
+Mock chained Mongoose queries by composing `jest.fn()` return values:
+
+```typescript
+const exec = jest.fn().mockResolvedValue(results);
+const sort = jest.fn().mockReturnValue({ exec });
+const select = jest.fn().mockReturnValue({ sort });
+const find = jest.fn().mockReturnValue({ select });
+// Simulates: Model.find().select().sort().exec()
+
+// For lean() pattern:
+model.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(doc) });
+```
+
+### Assertions
+
+```typescript
+// Success
+await expect(service.method()).resolves.toEqual(expected);
+
+// Errors
+await expect(service.method()).rejects.toThrow('message');
+await expect(service.method()).rejects.toBeInstanceOf(ConflictException);
+await expect(service.method()).rejects.toMatchObject({ response: { code: 'ERROR_CODE' } });
+
+// Call verification
+expect(mocks.model.save).toHaveBeenCalledTimes(1);
+expect(mocks.model.updateOne).toHaveBeenCalledWith(filter, update, { upsert: true });
+```
+
+### Time-dependent tests
+
+```typescript
+const now = new Date('2026-01-01T00:00:00Z');
+beforeEach(() => jest.useFakeTimers().setSystemTime(now));
+afterEach(() => jest.useRealTimers());
+```


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore` so worktree directories are never accidentally committed
- Documents worktree creation steps: branch creation, `.env*` file copy, and `bun install`
- Documents test writing conventions derived from existing spec files: `makeService()` factory pattern, manual service construction, Bun-compatible `jest.mock({ virtual: true })`, Mongoose query chain mocking, and assertion patterns

## Test plan

- [ ] No code changes — documentation only, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)