### PR TITLE
test: sync failing tests with updated service logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ Rules:
 
 ## Writing Tests
 
+**Every new service must have a corresponding `<name>.spec.ts` file.** When creating a service, write tests for all public methods before considering the task complete. Tests live alongside the source file.
+
 Test files are colocated with their source files as `<name>.spec.ts`. Run a single file with:
 
 ```bash

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -224,7 +224,7 @@ describe('AuthService.linkedinCallback', () => {
     };
   };
 
-  it('enforces connected account limit for new connections', async () => {
+  it('upserts a new LinkedIn account when no existing connection is found', async () => {
     const { service, mocks } = makeService();
     const userId = new Types.ObjectId().toString();
     jest
@@ -244,12 +244,6 @@ describe('AuthService.linkedinCallback', () => {
 
     await service.linkedinCallback('code', userId);
 
-    expect(
-      mocks.featureGatingService.assertConnectedAccountCapacity,
-    ).toHaveBeenCalledWith({
-      userId,
-      isReconnect: false,
-    });
     expect(mocks.connectedAccountModel.findOneAndUpdate).toHaveBeenCalled();
     const updatePayload =
       mocks.connectedAccountModel.findOneAndUpdate.mock.calls[0][1];
@@ -259,7 +253,7 @@ describe('AuthService.linkedinCallback', () => {
     expect(updatePayload.profileMetadata.avatarUrl).toBeUndefined();
   });
 
-  it('treats existing linked account as reconnect and bypasses capacity usage', async () => {
+  it('updates the existing LinkedIn account when the same memberId reconnects', async () => {
     const { service, mocks } = makeService();
     const userId = new Types.ObjectId().toString();
     jest
@@ -285,12 +279,6 @@ describe('AuthService.linkedinCallback', () => {
 
     await service.linkedinCallback('code', userId);
 
-    expect(
-      mocks.featureGatingService.assertConnectedAccountCapacity,
-    ).toHaveBeenCalledWith({
-      userId,
-      isReconnect: true,
-    });
     expect(mocks.connectedAccountModel.findOne).toHaveBeenCalledWith({
       user: new Types.ObjectId(userId),
       provider: AccountProvider.LINKEDIN,
@@ -318,6 +306,7 @@ describe('AuthService.linkedinCallback', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({
         user: userId,
+        isActive: true,
         profileMetadata: { sub: 'existing-sub' },
       });
 
@@ -748,6 +737,7 @@ describe('AuthService.getConnectedAccounts', () => {
 
     expect(connectedAccountModel.find).toHaveBeenCalledWith({
       user: new Types.ObjectId(userId),
+      isActive: true,
     });
     expect(linkedinAvatarRefreshQueue.addAvatarRefreshJob).toHaveBeenCalledTimes(
       2,

--- a/src/feature-gating/feature-gating.service.spec.ts
+++ b/src/feature-gating/feature-gating.service.spec.ts
@@ -120,7 +120,7 @@ describe('FeatureGatingService', () => {
     const tier = {
       _id: new Types.ObjectId(),
       name: 'Broken',
-      limits: { ai_drafts: -1 },
+      limits: {},
     } as any;
 
     expect(() => service.getLimitFromTier(tier, 'ai_drafts')).toThrow(
@@ -234,6 +234,7 @@ describe('FeatureGatingService', () => {
     const tierId = new Types.ObjectId();
     const currentPeriodStart = new Date('2026-03-14T00:00:00.000Z');
     const currentPeriodEnd = new Date('2026-04-14T00:00:00.000Z');
+    jest.useFakeTimers().setSystemTime(new Date('2026-03-20T00:00:00.000Z'));
     const tier = {
       _id: tierId,
       name: 'Starter',
@@ -285,6 +286,7 @@ describe('FeatureGatingService', () => {
         scheduled_posts: { used: 1, limit: 3, remaining: 2 },
       },
     });
+    jest.useRealTimers();
   });
 
   it('returns default cycle usage summary and floors remaining at zero', async () => {

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -694,7 +694,7 @@ describe('PostService.publishOnLinkedIn', () => {
       connectedAccount: new Types.ObjectId(),
       status: 'SCHEDULED',
       content: 'with media',
-      media: [{ id: 'urn:li:image:1', title: 'image-1' }],
+      media: [{ id: 'urn:li:image:1', title: 'image-1', type: 'IMAGE' }],
       save: mocks.save,
     } as any;
     mocks.findById.mockResolvedValue(post);


### PR DESCRIPTION
## Summary

- 7 unit tests were failing because service code was updated without updating the corresponding tests
- No production code was changed — only test files and CLAUDE.md

## Changes

**`feature-gating.service.spec.ts`**
- `getLimitFromTier` invalid-limit test: `-1` is a valid integer (it's the "unlimited" sentinel), changed fixture to use a missing key (`limits: {}`)
- `getDashboardUsage` test: hardcoded `currentPeriodEnd` (2026-04-14) had become stale (past today's date), causing `resolveEntitlement` to fall through to an unmocked default tier lookup; fixed with `jest.useFakeTimers()`

**`auth.service.spec.ts`**
- Two `linkedinCallback` tests asserted `assertConnectedAccountCapacity` was called, but that check was removed from the personal-account flow; removed stale assertions and renamed tests
- Account-mismatch conflict test: existing account mock was missing `isActive: true`, so the conflict guard short-circuited and no exception was thrown
- `getConnectedAccounts` test: assertion on `find()` call was missing the `isActive: true` filter that the service actually uses

**`post.service.spec.ts`**
- Media fixture was missing `type: 'IMAGE'`, so the `filter(m => m.type === 'IMAGE')` call returned an empty array and `content` stayed `undefined`

**`CLAUDE.md`**
- Added convention requiring a spec file for every new service

## Test plan

- [x] `bun run test` — 125/125 passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)