### PR TITLE
fix: plug Resend-per-call allocation, DB listener leak, and missing worker try-catch

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,4 +1,4 @@
-import { Module, Global, Logger, OnModuleInit } from '@nestjs/common';
+import { Module, Global, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule, InjectConnection } from '@nestjs/mongoose';
 import { Connection } from 'mongoose';
@@ -47,8 +47,10 @@ import {
   ],
   exports: [MongooseModule],
 })
-export class DatabaseModule implements OnModuleInit {
+export class DatabaseModule implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(DatabaseModule.name);
+  private readonly onConnected = () => this.logger.log('Database connected successfully');
+  private readonly onError = (err: unknown) => this.logger.error(`Database connection error: ${err}`);
 
   constructor(@InjectConnection() private readonly connection: Connection) { }
 
@@ -57,12 +59,12 @@ export class DatabaseModule implements OnModuleInit {
       this.logger.log('Database connected successfully');
     }
 
-    this.connection.on('connected', () => {
-      this.logger.log('Database connected successfully');
-    });
+    this.connection.on('connected', this.onConnected);
+    this.connection.on('error', this.onError);
+  }
 
-    this.connection.on('error', (err) => {
-      this.logger.error(`Database connection error: ${err}`);
-    });
+  onModuleDestroy() {
+    this.connection.off('connected', this.onConnected);
+    this.connection.off('error', this.onError);
   }
 }

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -17,17 +17,25 @@ describe('MailService', () => {
     } as unknown as ConfigService;
   };
 
-  it('compiles welcome template and sends through Resend', async () => {
-    const service = new MailService(mockConfigService());
+  const makeService = (overrides: Record<string, string | undefined> = {}) => {
+    const service = new MailService(mockConfigService(overrides));
+    service.onModuleInit();
+    return service;
+  };
+
+  const mockResend = (service: MailService) => {
     const send = jest.fn().mockResolvedValue({
       data: { id: 'email_123' },
       error: null,
       headers: null,
     });
+    (service as any).resend = { emails: { send } };
+    return send;
+  };
 
-    jest
-      .spyOn(service as any, 'createResendClient')
-      .mockReturnValue({ emails: { send } });
+  it('compiles welcome template and sends through Resend', async () => {
+    const service = makeService();
+    const send = mockResend(service);
 
     const result = await service.sendTemplate({
       to: 'user@example.com',
@@ -55,24 +63,18 @@ describe('MailService', () => {
     expect(result.error).toBeNull();
   });
 
-  it('fails fast when RESEND_API_KEY is missing', async () => {
+  it('fails fast when RESEND_API_KEY is missing', () => {
     const service = new MailService(
       mockConfigService({ RESEND_API_KEY: undefined }),
     );
 
-    await expect(
-      service.sendTemplate({
-        to: 'user@example.com',
-        template: 'welcome',
-        data: { name: 'Jane Doe' },
-      }),
-    ).rejects.toThrow(
+    expect(() => service.onModuleInit()).toThrow(
       new InternalServerErrorException('RESEND_API_KEY is not configured'),
     );
   });
 
   it('fails fast when MAIL_FROM is missing and no override is provided', async () => {
-    const service = new MailService(mockConfigService({ MAIL_FROM: undefined }));
+    const service = makeService({ MAIL_FROM: undefined });
 
     await expect(
       service.sendTemplate({
@@ -86,16 +88,13 @@ describe('MailService', () => {
   });
 
   it('smoke test: sendTemplate succeeds with mocked Resend', async () => {
-    const service = new MailService(mockConfigService());
+    const service = makeService();
     const send = jest.fn().mockResolvedValue({
       data: { id: 'email_456' },
       error: null,
       headers: null,
     });
-
-    jest
-      .spyOn(service as any, 'createResendClient')
-      .mockReturnValue({ emails: { send } });
+    (service as any).resend = { emails: { send } };
 
     await expect(
       service.sendTemplate({

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
+  OnModuleInit,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { promises as fs } from 'node:fs';
@@ -24,16 +25,21 @@ export interface SendTemplateInput<TTemplate extends MailTemplateKey> {
 export type SendResult = CreateEmailResponse;
 
 @Injectable()
-export class MailService {
+export class MailService implements OnModuleInit {
   private readonly logger = new Logger(MailService.name);
   private readonly templatesDir = join(process.cwd(), 'assets/mail/templates');
+  private resend: Resend;
 
   constructor(private readonly configService: ConfigService) {}
+
+  onModuleInit() {
+    const apiKey = this.getRequiredEnv('RESEND_API_KEY');
+    this.resend = new Resend(apiKey);
+  }
 
   async sendTemplate<TTemplate extends MailTemplateKey>(
     input: SendTemplateInput<TTemplate>,
   ): Promise<SendResult> {
-    const apiKey = this.getRequiredEnv('RESEND_API_KEY');
     const defaultFrom = this.getRequiredEnv('MAIL_FROM');
     const from = input.from ?? defaultFrom;
     const template = mailTemplates[input.template];
@@ -45,8 +51,7 @@ export class MailService {
         : Promise.resolve(undefined),
     ]);
 
-    const client = this.createResendClient(apiKey);
-    const result = await client.emails.send({
+    const result = await this.resend.emails.send({
       from: `"Marquill" <${from}>`,
       to: input.to,
       subject: template.subject(input.data),
@@ -62,10 +67,6 @@ export class MailService {
     }
 
     return result;
-  }
-
-  protected createResendClient(apiKey: string): Resend {
-    return new Resend(apiKey);
   }
 
   private getRequiredEnv(key: 'RESEND_API_KEY' | 'MAIL_FROM'): string {

--- a/src/workflow/workers/workflow.worker.ts
+++ b/src/workflow/workers/workflow.worker.ts
@@ -106,14 +106,19 @@ async function bootstrapWorker() {
   new Worker(
     LINKEDIN_AVATAR_REFRESH_QUEUE_NAME,
     async (job: Job) => {
-      const connectedAccountId = job.data?.connectedAccountId;
-      if (!connectedAccountId) {
-        logger.warn(`Skipping avatar refresh job ${job.id}; missing account id`);
-        return;
-      }
+      try {
+        const connectedAccountId = job.data?.connectedAccountId;
+        if (!connectedAccountId) {
+          logger.warn(`Skipping avatar refresh job ${job.id}; missing account id`);
+          return;
+        }
 
-      logger.log(`Processing LinkedIn avatar refresh for ${connectedAccountId}`);
-      await authService.refreshLinkedinAvatarForAccount(connectedAccountId);
+        logger.log(`Processing LinkedIn avatar refresh for ${connectedAccountId}`);
+        await authService.refreshLinkedinAvatarForAccount(connectedAccountId);
+      } catch (error) {
+        logger.error(error);
+        throw error;
+      }
     },
     {
       connection: {
@@ -127,7 +132,12 @@ async function bootstrapWorker() {
   new Worker(
     EMAIL_QUEUE_NAME,
     async (job: Job) => {
-      await processEmailJob(job, logger, mailService);
+      try {
+        await processEmailJob(job, logger, mailService);
+      } catch (error) {
+        logger.error(error);
+        throw error;
+      }
     },
     {
       connection: {


### PR DESCRIPTION
## Summary

- **`MailService`** — `new Resend(apiKey)` was called on every email send, creating a new HTTP client instance each time. Moved to `onModuleInit()` so one instance is shared for the service lifetime.
- **`DatabaseModule`** — `connection.on('connected')` and `connection.on('error')` were registered in `onModuleInit` with no corresponding cleanup. Added named handler refs and an `onModuleDestroy` implementation that calls `connection.off()`.
- **`workflow.worker.ts`** — The `linkedin-avatar-refresh` and `email` worker processors had no try/catch, unlike the other two workers. Wrapped both to ensure errors are logged before being re-thrown for BullMQ to handle.

None of these are confirmed as the root cause of the production sawtooth (heap snapshot analysis is still needed to identify that). These are real code quality issues discovered during the investigation.

## Test plan

- [ ] `bun test` — all 125 unit tests pass
- [ ] Deploy to staging and observe memory graph over 24h — sawtooth should be unchanged (these fixes target the worker, not the HTTP server leak)
- [ ] Confirm no `MaxListenersExceededWarning` in logs after multiple MongoDB reconnection events

🤖 Generated with [Claude Code](https://claude.com/claude-code)