### PR TITLE
fix: stop re-enqueuing avatar refresh after permanent auth/decrypt failure

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -783,6 +783,104 @@ describe('AuthService.getConnectedAccounts', () => {
       linkedinAvatarRefreshQueue.addAvatarRefreshJob,
     ).not.toHaveBeenCalled();
   });
+
+  it('does not queue refresh when AUTH_EXPIRED failure is recorded', async () => {
+    const userId = new Types.ObjectId().toString();
+    const account = {
+      _id: new Types.ObjectId(),
+      provider: AccountProvider.LINKEDIN,
+      accountType: LinkedinAccountType.PERSON,
+      avatarUrl: null,
+      avatarUrlExpiresAt: null,
+      profileMetadata: {
+        displayImageUrn: 'urn:li:digitalmediaAsset:test',
+        avatarRefreshFailureReason: 'AUTH_EXPIRED',
+      },
+      toObject() {
+        return { ...this };
+      },
+    };
+
+    const { service, linkedinAvatarRefreshQueue } = makeService([account]);
+    await service.getConnectedAccounts(userId);
+
+    expect(
+      linkedinAvatarRefreshQueue.addAvatarRefreshJob,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not queue refresh when DECRYPT_FAILED failure is recorded', async () => {
+    const userId = new Types.ObjectId().toString();
+    const account = {
+      _id: new Types.ObjectId(),
+      provider: AccountProvider.LINKEDIN,
+      accountType: LinkedinAccountType.PERSON,
+      avatarUrl: null,
+      avatarUrlExpiresAt: null,
+      profileMetadata: {
+        displayImageUrn: 'urn:li:digitalmediaAsset:test',
+        avatarRefreshFailureReason: 'DECRYPT_FAILED',
+      },
+      toObject() {
+        return { ...this };
+      },
+    };
+
+    const { service, linkedinAvatarRefreshQueue } = makeService([account]);
+    await service.getConnectedAccounts(userId);
+
+    expect(
+      linkedinAvatarRefreshQueue.addAvatarRefreshJob,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('queues refresh when failure reason is cleared (reconnect path)', async () => {
+    const userId = new Types.ObjectId().toString();
+    const account = {
+      _id: new Types.ObjectId(),
+      provider: AccountProvider.LINKEDIN,
+      accountType: LinkedinAccountType.PERSON,
+      avatarUrl: null,
+      avatarUrlExpiresAt: null,
+      profileMetadata: {
+        displayImageUrn: 'urn:li:digitalmediaAsset:test',
+      },
+      toObject() {
+        return { ...this };
+      },
+    };
+
+    const { service, linkedinAvatarRefreshQueue } = makeService([account]);
+    await service.getConnectedAccounts(userId);
+
+    expect(
+      linkedinAvatarRefreshQueue.addAvatarRefreshJob,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not queue refresh when avatarUrl is set but avatarUrlExpiresAt is null', async () => {
+    const userId = new Types.ObjectId().toString();
+    const account = {
+      _id: new Types.ObjectId(),
+      provider: AccountProvider.LINKEDIN,
+      accountType: LinkedinAccountType.PERSON,
+      avatarUrl: 'https://cdn.example.com/avatar.jpg',
+      avatarUrlExpiresAt: null,
+      profileMetadata: {
+        displayImageUrn: 'urn:li:digitalmediaAsset:test',
+      },
+      toObject() {
+        return { ...this };
+      },
+    };
+
+    const { service, linkedinAvatarRefreshQueue } = makeService([account]);
+    await service.getConnectedAccounts(userId);
+
+    expect(
+      linkedinAvatarRefreshQueue.addAvatarRefreshJob,
+    ).not.toHaveBeenCalled();
+  });
 });
 
 describe('AuthService.refreshLinkedinAvatarForAccount', () => {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -872,13 +872,20 @@ export class AuthService {
       return false;
     }
 
+    // Permanent failure recorded — user must reconnect LinkedIn to clear this.
+    if (account.profileMetadata?.avatarRefreshFailureReason) {
+      return false;
+    }
+
     if (!account.avatarUrl) {
       return true;
     }
 
     const expiresAtMs = this.parseExpiryToMs(account.avatarUrlExpiresAt);
     if (expiresAtMs === null) {
-      return true;
+      // URL is set but LinkedIn returned no expiry — treat as valid rather than
+      // triggering a refresh on every request.
+      return false;
     }
 
     return expiresAtMs <= refreshDeadline;


### PR DESCRIPTION
## Summary

- `shouldEnqueueLinkedinAvatarRefresh` now returns `false` when `profileMetadata.avatarRefreshFailureReason` is set, breaking an infinite re-enqueue loop
- Also stops re-enqueueing when `avatarUrl` is set but `avatarUrlExpiresAt` is `null` (LinkedIn omits the expiry field), which would otherwise refresh on every request
- 4 new tests cover both failure reason variants, the cleared-on-reconnect path, and the null-expiry case

## Root cause

When LinkedIn returns 401/403, `markAvatarRefreshAuthFailure` clears `avatarUrl` and sets `avatarRefreshFailureReason: 'AUTH_EXPIRED'` in `profileMetadata`. The job then **completes normally** (no throw), so BullMQ removes it (`removeOnComplete: true`) and frees the job ID. The next `GET /auth/connected-accounts` call sees `avatarUrl = null` → re-enqueues a fresh job → hits 401 again → loop. The same cycle applies to `DECRYPT_FAILED`.

The failure flag is automatically cleared on LinkedIn reconnect because `linkedinCallback` replaces `profileMetadata` wholesale with fresh data from the OAuth response.

## Test plan

- [x] `bun jest src/auth/auth.service.spec.ts` — 25 tests, all pass
- [ ] Verify in production: after deploy, the repeated debug log for account `69d6de47cd7a32b262321931` should stop — check `profileMetadata.avatarRefreshFailureReason` in MongoDB to confirm the account is in a permanent failure state

🤖 Generated with [Claude Code](https://claude.com/claude-code)