### PR TITLE
Reduce production server memory pressure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "bun dist/main.js",
+    "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -44,7 +44,8 @@ describe('PostService.getPosts', () => {
     const service = Object.create(PostService.prototype) as PostService;
 
     const exec = jest.fn();
-    const sort = jest.fn().mockReturnValue({ exec });
+    const lean = jest.fn().mockReturnValue({ exec });
+    const sort = jest.fn().mockReturnValue({ lean });
     const select = jest.fn().mockReturnValue({ sort });
     const find = jest.fn().mockReturnValue({ select });
     const aggregate = jest.fn();
@@ -62,6 +63,7 @@ describe('PostService.getPosts', () => {
         find,
         select,
         sort,
+        lean,
         exec,
         aggregate,
         distinct,
@@ -90,6 +92,10 @@ describe('PostService.getPosts', () => {
     );
 
     expect(mocks.find).toHaveBeenCalledTimes(1);
+    expect(mocks.select).toHaveBeenCalledWith(
+      '-userIntent -compressionResult -youtubeResearch',
+    );
+    expect(mocks.lean).toHaveBeenCalledTimes(1);
     const filter = mocks.find.mock.calls[0][0];
     expect(filter.user).toEqual(userId);
     expect(filter.status).toBe('DRAFT');

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -114,8 +114,9 @@ export class PostService {
 
     const postsQuery = this.postDraftModel
       .find(filter)
-      .select('-userIntent')
+      .select('-userIntent -compressionResult -youtubeResearch')
       .sort({ createdAt: -1 })
+      .lean()
       .exec();
 
     const availableMonthsQuery = this.postDraftModel.aggregate<{


### PR DESCRIPTION
## Summary
- run the production Nest server with Node instead of Bun to match the stable worker runtime
- reduce memory allocation on the posts list endpoint by excluding large generation internals
- use lean Mongoose results for the posts list query

## Tests
- npm test -- post.service.spec.ts --runInBand
- npm run build