### PR TITLE
fix: use NestJS rawBody option for Paddle webhook signature verification

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,7 +26,6 @@ import { MailModule } from './mail';
 import { FeedbackModule } from './feedback/feedback.module';
 import { OnboardingModule } from './onboarding';
 import { DiagnosticsModule } from './diagnostics/diagnostics.module';
-import { raw } from 'express';
 
 @Module({
   imports: [
@@ -57,9 +56,6 @@ import { raw } from 'express';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer
-      .apply(raw({ type: 'application/json' }))
-      .forRoutes({ path: '*payment/webhooks', method: RequestMethod.POST })
     consumer
       .apply(RequestLoggerMiddleware)
       .forRoutes({ path: '*v1', method: RequestMethod.ALL });

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { rawBody: true });
   const logger = new Logger(
     bootstrap.name.charAt(0).toUpperCase() + bootstrap.name.slice(1),
   );

--- a/src/payment/payment.webhook.controller.ts
+++ b/src/payment/payment.webhook.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Req,
 } from '@nestjs/common';
+import type { RawBodyRequest } from '@nestjs/common';
 import type { Request } from 'express';
 import { PaymentService } from './payment.service';
 
@@ -18,12 +19,10 @@ export class PaymentWebhookController {
 
   @Post('paddle')
   @HttpCode(HttpStatus.OK)
-  async handlePaddleWebhook(@Req() request: Request) {
-    const rawBody = request.body as Buffer;
-    if (!Buffer.isBuffer(rawBody)) {
-      this.logger.error(
-        'Paddle webhook missing raw body. Ensure raw() middleware is applied.',
-      );
+  async handlePaddleWebhook(@Req() request: RawBodyRequest<Request>) {
+    const rawBody = request.rawBody;
+    if (!rawBody || !Buffer.isBuffer(rawBody)) {
+      this.logger.error('Paddle webhook missing raw body.');
       throw new BadRequestException('Webhook raw body not available');
     }
 


### PR DESCRIPTION
## Summary

- Enables `rawBody: true` in `NestFactory.create` so NestJS captures raw request bytes into `req.rawBody` before its own JSON parser runs
- Removes the `raw()` express middleware workaround in `AppModule.configure` — it was applied too late (after the body stream was already consumed) and never worked
- Updates `PaymentWebhookController` to read `request.rawBody` via the `RawBodyRequest<Request>` type instead of casting `request.body` as a Buffer

## Test plan

- [ ] `bun jest src/payment/` — all payment tests pass
- [ ] `npm run build` — compiles without errors
- [ ] Deploy to staging and send a real Paddle test webhook — confirm no 400 and the signature check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)