### PR TITLE
feat: integrate Clerk auth via dual-guard strangler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ JWT_SECRET=change_me
 FRONTEND_URL=http://localhost:3000
 FRONTEND_URL_DEV=http://localhost:3000
 
+# Clerk (auth migration) — https://dashboard.clerk.com → API keys
+CLERK_PUBLISHABLE_KEY=pk_test_change_me
+CLERK_SECRET_KEY=sk_test_change_me
+# PEM public key for networkless session-token verification (JWKS public key)
+CLERK_JWT_KEY=change_me
+
 PADDLE_ENVIRONMENT=sandbox
 PADDLE_API_KEY=your_paddle_api_key_here
 PADDLE_WEBHOOK_SECRET=your_paddle_webhook_secret_here

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "linkgenserver",
       "dependencies": {
+        "@clerk/backend": "^3.7.0",
         "@googleapis/youtube": "^31.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -152,6 +153,10 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
+    "@clerk/backend": ["@clerk/backend@3.7.0", "", { "dependencies": { "@clerk/shared": "^4.17.1", "standardwebhooks": "^1.0.0", "tslib": "2.8.1" } }, "sha512-tdURxlfJ8sYR+zM6bUNsG4/BpxH7MV66E5NmHbjIoggUm48SdVoBtKUSjxT0uVa8MpdYHqPk/I0mMdI/EC1B/g=="],
+
+    "@clerk/shared": ["@clerk/shared@4.17.1", "", { "dependencies": { "@tanstack/query-core": "^5.100.6", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.7" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-9Ej2bLA7pWY1e07/PHmPNtQwiV1594rwacNYbppoDUPq9yRkBRZ+pDcpySkfpokS5YXvOUv6aFoPPbEMbQUVgw=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -348,6 +353,8 @@
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@supadata/js": ["@supadata/js@1.3.2", "", { "dependencies": { "cross-fetch": "^4.0.0" } }, "sha512-1jKz27pcjYDKys5spim2z6gy9zkZbAktWf3AohKc1m0iIVSRdOA0xOTBwEArwhZUmkSH1QjOsd7IUdj6NcYxHQ=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.0", "", {}, "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -763,6 +770,8 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
@@ -1076,6 +1085,8 @@
     "jest-watcher": ["jest-watcher@30.2.0", "", { "dependencies": { "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "emittery": "^0.13.1", "jest-util": "30.2.0", "string-length": "^4.0.2" } }, "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg=="],
 
     "jest-worker": ["jest-worker@27.5.1", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg=="],
+
+    "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/docs/clerk-integration-analysis.md
+++ b/docs/clerk-integration-analysis.md
@@ -1,0 +1,222 @@
+# Clerk Integration Analysis
+
+> Status: proposal / decision doc. Branch: `feat/clerk-auth-integration`.
+> Author: generated for Christopher Pam.
+
+## 1. How authentication works today
+
+### Login (Google only)
+- `GoogleStrategy` (`passport-google-oauth20`) handles the OAuth dance via `@nestjs/passport`.
+- `AuthService.validateGoogleUser` finds or creates a `User`, keyed on `googleId` with an
+  email fallback, assigns the default `Tier`, and enqueues a welcome email.
+- `AuthService.login` signs a **self-issued JWT** (`{ email, sub: userId }`, `JWT_SECRET`,
+  30-day cookie) and `AuthController` sets it as an `httpOnly` `access_token` cookie on
+  `.marquill.com` (prod), plus a **non-httpOnly `user` cookie** holding the serialized user.
+
+### Session validation
+- `JwtStrategy` (`passport-jwt`) pulls `access_token` from the cookie, verifies it with
+  `JWT_SECRET`, then **loads the Mongo `User` and populates `tier`**.
+- `JwtAuthGuard` (`AuthGuard('jwt')`) protects routes; `@GetUser()` injects the full
+  Mongoose `User` document onto the request.
+
+### Blast radius
+- **8 controllers** use `JwtAuthGuard` + `@GetUser()` (12 route guards): `post`, `auth`,
+  `payment`, `feedback`, `workflow`, `users`, `onboarding`, `tier`.
+- `SubscriptionAccessGuard` reads `request.user._id` to resolve entitlement — it depends on
+  the guard having attached a **local** user with a Mongo `_id`.
+- The **worker process** bootstraps an `ApplicationContext` and does no HTTP auth — unaffected.
+
+### What is NOT authentication (leave alone)
+- **LinkedIn** is *not* a login provider today. It is a **connected publishing account**:
+  hand-rolled OAuth, AES-256-GCM encrypted tokens in `ConnectedAccount`, avatar refresh, org
+  support. See §8 for how LinkedIn-as-login relates to this.
+
+### Key constraints any option must preserve
+1. Downstream code expects `request.user` to be the **local Mongo `User`** (with `_id` and a
+   populated `tier`), not a raw token payload.
+2. `SubscriptionAccessGuard`, feature gating, and `ConnectedAccount.user` references all key off
+   the Mongo `_id`. We need a stable mapping from the external identity to that `_id`.
+3. The frontend currently reads a `user` cookie and relies on a same-site cookie session.
+
+---
+
+## 2. The mapping problem (applies to every option)
+
+Whatever we adopt, we must map a Clerk identity to the existing `User._id`. Recommended:
+
+- Add a sparse-unique `clerkId` field to the `User` schema (alongside, not replacing, `googleId`).
+- On first authenticated request (or via webhook — see §6), find-or-create the local user by
+  `clerkId`, falling back to `email` to **link existing Google users** so nobody loses data.
+
+```ts
+// user.schema.ts (additive)
+@Prop({ unique: true, sparse: true })
+clerkId?: string;
+```
+
+This means existing users keep their `_id`, drafts, subscriptions, and connected accounts.
+
+---
+
+## 3. Option A — Full cutover: Clerk-issued tokens, networkless verification *(RECOMMENDED target)*
+
+Clerk becomes the only identity provider. The frontend uses Clerk's components/SDK for sign-in
+(Google, email/magic-link, LinkedIn, etc.). The backend stops minting JWTs and instead
+**verifies the Clerk session token** on every request.
+
+### Mechanism
+- Frontend sends the Clerk session token via the `__session` cookie (same-origin — see §8).
+- A new `ClerkAuthGuard` replaces `JwtAuthGuard`. It verifies the token **networklessly** using
+  Clerk's `jwtKey` (the JWKS public key, cached) — no per-request call to Clerk's API:
+
+```ts
+// clerk-auth.guard.ts (sketch)
+import { verifyToken } from '@clerk/backend';
+
+const token = request.cookies?.__session; // same-origin cookie transport
+const claims = await verifyToken(token, {
+  jwtKey: this.config.getOrThrow('CLERK_JWT_KEY'),      // networkless
+  authorizedParties: [this.config.get('FRONTEND_URL')], // anti-CSRF / subdomain leakage
+});
+// claims.sub === Clerk user id
+const user = await this.userProvisioning.findOrCreate(claims); // -> local Mongo User
+request.user = user; // keeps @GetUser() and SubscriptionAccessGuard working unchanged
+```
+
+- `AuthService.login`, the self-issued JWT, `JwtStrategy`, `GoogleStrategy`, and the manual
+  Google OAuth controller routes are **deleted**. `passport`, `passport-jwt`,
+  `passport-google-oauth20`, and `@nestjs/jwt` can be dropped.
+
+### Advantages
+- **Single source of truth** for identity; no two-session drift.
+- **Offloads the hard parts**: MFA, social providers, magic links, bot/abuse protection,
+  session revocation, password resets, account recovery, email verification — all Clerk's job.
+- **Networkless verification** keeps the hot path fast (one cached public key, no API round-trip).
+- Removes hand-rolled JWT/cookie/CSRF surface (`JWT_SECRET`, the non-httpOnly `user` cookie,
+  manual cookie domain juggling) — net **less security-sensitive code we own**.
+- Easy to add providers later with zero backend changes.
+
+### Disadvantages
+- **Vendor lock-in** and a new **per-MAU cost** once past the free tier.
+- **External dependency / availability**: Clerk outage or JWKS rotation issues affect login
+  (mitigated: networkless verify survives brief API outages; tokens are short-lived though).
+- **Frontend rewrite** of the sign-in flow and session handling (cookie → Clerk SDK).
+- **Migration**: existing 30-day cookies are invalidated at cutover unless we run a transition
+  window (see Option B). Need the `clerkId`/email linking from §2 to avoid orphaning users.
+- Data residency / privacy review: user PII now lives in Clerk.
+
+---
+
+## 4. Option B — Incremental strangler: dual guard *(RECOMMENDED migration path to reach A)*
+
+Don't flip everything at once. Ship a `ClerkAuthGuard` that **accepts a Clerk token if present,
+otherwise falls back to the legacy `access_token` JWT**. Both produce the same `request.user`.
+
+### Mechanism
+- One composite guard tries Clerk verification first, then the existing `passport-jwt` path.
+- Roll out per-route or globally behind a flag. New logins go through Clerk; existing cookies
+  keep working until they expire (≤30 days), then everyone is on Clerk.
+- Once legacy JWT traffic hits zero, delete the fallback → you are now at Option A.
+
+### Advantages
+- **Zero forced logout**; existing sessions drain naturally.
+- De-risks the frontend cutover — can A/B or roll back per route.
+- Same end-state as A with a safe path there.
+
+### Disadvantages
+- Temporarily **two auth code paths** to maintain and test.
+- Slightly more complex guard logic during the window.
+- Requires discipline to actually finish the migration and remove the fallback.
+
+---
+
+## 5. Option C — Hybrid façade: Clerk for login, keep minting our own JWT *(NOT recommended)*
+
+Use Clerk only for the credential UI, but after Clerk sign-in, exchange the Clerk token once and
+**continue issuing our own `access_token` cookie** as today.
+
+### Advantages
+- Minimal change to backend guards and the frontend session model.
+- Keeps cookie-based same-site session ergonomics.
+
+### Disadvantages
+- **Two session systems** running at once — the worst of both: we still own JWT signing,
+  rotation, revocation, and the `JWT_SECRET`, *plus* now depend on Clerk.
+- Session **revocation in Clerk doesn't propagate** to our long-lived cookie → security gap.
+- We keep nearly all the code Clerk was supposed to remove. Low payoff for the added dependency.
+
+Only consider this if a hard requirement forbids sending a token on every request.
+
+---
+
+## 6. User provisioning: webhook vs lazy (orthogonal to A/B/C)
+
+- **Lazy (find-or-create on first authenticated request)** — simplest, no webhook infra, always
+  consistent because it runs inline. Slight first-request latency. **Recommended to start.**
+- **Webhook-driven (`user.created`, `user.updated`, `user.deleted`)** — keeps Mongo eagerly in
+  sync (good for the welcome-email enqueue and for soft-deletes), but adds an endpoint,
+  signature verification, and eventual-consistency edge cases.
+
+A pragmatic combo: **lazy provisioning now**, add the `user.created` webhook later only to move
+the welcome-email enqueue off the request path.
+
+---
+
+## 7. Recommendation
+
+**Adopt Option A (Clerk-issued tokens, networkless verification) as the target architecture, and
+get there via Option B (dual-guard strangler).** Provision users **lazily** at first, keyed on a
+new sparse-unique `clerkId` with email-based linking for existing Google users.
+
+Rationale:
+- The custom JWT/cookie/Google-OAuth stack is exactly the kind of undifferentiated, security-
+  sensitive code Clerk eliminates, and the blast radius is contained: `@GetUser()` and
+  `SubscriptionAccessGuard` keep working as long as the guard still attaches the local Mongo user.
+- LinkedIn *publishing* (the actually-valuable, domain-specific integration) is untouched (§8).
+- The strangler path means **no forced logout** and a reversible rollout.
+
+Avoid Option C — it doubles the session surface instead of shrinking it.
+
+---
+
+## 8. Decisions (locked)
+
+| Question | Decision | Implication |
+|---|---|---|
+| **Sign-in methods** | Google, Email + magic link, **LinkedIn** | Adds two new login paths beyond today's Google-only. All resolve to one local `User` via `clerkId`/email linking. |
+| **LinkedIn login vs publishing** | **Keep separate** | Clerk's LinkedIn connection provides **identity only** (`openid profile email`). The existing hand-rolled publishing OAuth + `ConnectedAccount` + encrypted-token flow is **unchanged**. |
+| **Token transport** | **`__session` cookie** (same-origin) | Frontend and API share a domain (already `.marquill.com` in prod). Guard reads the `__session` cookie; keep CSRF in mind for state-changing routes. CORS stays `credentials: true`. |
+| **Replace `user` cookie** | **Backend `GET /users/me`** | Drop the non-httpOnly `user` cookie. Frontend loads the local Mongo user (incl. `tier`) from an authenticated `/users/me`; identity (name/avatar/email) can also come from Clerk's SDK. |
+
+### Consequences of "LinkedIn login, kept separate"
+- A user can sign in **with LinkedIn** (identity) yet still have **no posting capability** until
+  they run the existing "connect LinkedIn" flow — login ≠ publishing token. The connect-to-publish
+  step stays mandatory for every user regardless of how they logged in.
+- LinkedIn OAuth therefore happens **twice** for a LinkedIn-login user (once for identity via
+  Clerk, once for publishing via our flow). Accepted tradeoff for keeping the publishing path
+  untouched and low-risk.
+- Future option if the double-authorize UX becomes a complaint: configure Clerk's LinkedIn
+  connection with our custom credentials + posting scopes and pull the token via
+  `clerkClient.users.getUserOauthAccessToken(userId, 'linkedin_oidc')` — unifies the two without
+  re-architecting the org-ACL / `impersonatorUrn` logic, which would still be needed.
+
+### Consequences of the `__session` cookie choice
+- Verify with `verifyToken`/`authenticateRequest` reading the `__session` cookie (not just Bearer).
+- Set `authorizedParties` to the frontend origin(s) to prevent subdomain cookie leakage.
+- Same-site cookie semantics mirror today's `access_token` cookie, so the prod cookie-domain setup
+  on `.marquill.com` carries over conceptually.
+
+### Migration sequence (reflecting decisions)
+1. Add `clerkId` (sparse-unique) to `User`; `UserProvisioningService.findOrCreate(claims)` with
+   email linking.
+2. Add `@clerk/backend`; `ClerkAuthGuard` verifies the **`__session` cookie** networklessly
+   (`jwtKey` + `authorizedParties`), then attaches the local Mongo `User`.
+3. Ship as a **dual guard** (Clerk → legacy JWT fallback). Env: `CLERK_PUBLISHABLE_KEY`,
+   `CLERK_SECRET_KEY`, `CLERK_JWT_KEY`.
+4. In Clerk, enable Google, Email/magic-link, and LinkedIn (identity-only) connections.
+5. Add `GET /users/me`; frontend migrates from the `user` cookie to that endpoint + Clerk SDK.
+6. Frontend sign-in moves to Clerk; new sessions are Clerk-only.
+7. After legacy cookie TTL (≤30 days), remove the JWT fallback, `JwtStrategy`, `GoogleStrategy`,
+   `AuthService.login`, the `user` cookie, and unused passport/jwt deps.
+8. **Untouched throughout:** the entire LinkedIn *publishing* flow (`ConnectedAccount`, encryption,
+   org ACLs, avatar refresh).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "seed:tiers:temp": "ts-node src/scripts/temp-seed-tiers.ts"
   },
   "dependencies": {
+    "@clerk/backend": "^3.7.0",
     "@googleapis/youtube": "^31.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { ActorsModule } from './actors/actors.module';
 import { WorkflowModule } from './workflow/workflow.module';
 import { DatabaseModule } from './database/database.module';
 import { AuthModule } from './auth/auth.module';
+import { ClerkAuthModule } from './auth/clerk';
 import { UserModule } from './users/users.module';
 import { PostModule } from './post/post.module';
 import { EncryptionModule } from './encryption/encryption.module';
@@ -44,6 +45,7 @@ import { DiagnosticsModule } from './diagnostics/diagnostics.module';
     WorkflowModule,
     DatabaseModule,
     AuthModule,
+    ClerkAuthModule,
     UserModule,
     PostModule,
     EncryptionModule,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -16,7 +16,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { GetUser } from '../common/decorators';
 import { User } from '../database/schemas';
-import { JwtAuthGuard } from 'src/common/guards';
+import { ClerkAuthGuard } from './clerk';
 import type { IAppResponse } from 'src/common/interfaces';
 import { ConnectLinkedinOrganizationsDto } from './dto/connect-linkedin-organizations.dto';
 
@@ -63,7 +63,7 @@ export class AuthController {
     };
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(ClerkAuthGuard)
   @Post('linkedin')
   async linkedinAuth(@GetUser() user: User): Promise<IAppResponse> {
     const url = await this.authService.createLinkedinOath(user);
@@ -110,7 +110,7 @@ export class AuthController {
     }
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(ClerkAuthGuard)
   @Get('linkedin/orgs')
   async getLinkedinOrganizations(@GetUser() user: User): Promise<IAppResponse> {
     return {
@@ -122,7 +122,7 @@ export class AuthController {
     };
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(ClerkAuthGuard)
   @Post('linkedin/orgs')
   async connectLinkedinOrganizations(
     @GetUser() user: User,
@@ -138,7 +138,7 @@ export class AuthController {
     };
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(ClerkAuthGuard)
   @Get('connected-accounts')
   async getConnectedAccounts(@GetUser() user: User): Promise<IAppResponse> {
     const accounts = await this.authService.getConnectedAccounts(
@@ -151,7 +151,7 @@ export class AuthController {
     };
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(ClerkAuthGuard)
   @Delete('connected-accounts/:connectedAccountId')
   async disconnectConnectedAccount(
     @GetUser() user: User,

--- a/src/auth/clerk/clerk-auth.guard.spec.ts
+++ b/src/auth/clerk/clerk-auth.guard.spec.ts
@@ -1,0 +1,120 @@
+import { ExecutionContext } from '@nestjs/common';
+import { ClerkAuthGuard } from './clerk-auth.guard';
+
+const verifyToken = jest.fn();
+jest.mock('@clerk/backend', () => ({ verifyToken: (...args: any[]) => verifyToken(...args) }), {
+  virtual: true,
+});
+
+const makeContext = (request: any): ExecutionContext =>
+  ({
+    switchToHttp: () => ({ getRequest: () => request }),
+  }) as unknown as ExecutionContext;
+
+const makeGuard = () => {
+  const pem = '-----BEGIN PUBLIC KEY-----\nabc123\n-----END PUBLIC KEY-----';
+  const configService = {
+    getOrThrow: jest.fn((key: string) =>
+      key === 'CLERK_SECRET_KEY' ? 'sk_test_123' : undefined,
+    ),
+    get: jest.fn((key: string) => {
+      if (key === 'FRONTEND_URL') return 'https://app.example.com';
+      if (key === 'CLERK_JWT_KEY') return pem;
+      return undefined;
+    }),
+  };
+  const userProvisioning = { findOrCreate: jest.fn() };
+  const jwtAuthGuard = { canActivate: jest.fn() };
+
+  const guard = new ClerkAuthGuard(
+    configService as any,
+    userProvisioning as any,
+    jwtAuthGuard as any,
+  );
+
+  return { guard, mocks: { configService, userProvisioning, jwtAuthGuard } };
+};
+
+describe('ClerkAuthGuard', () => {
+  let guard: ClerkAuthGuard;
+  let mocks: ReturnType<typeof makeGuard>['mocks'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ({ guard, mocks } = makeGuard());
+  });
+
+  describe('canActivate', () => {
+    it('should verify the __session cookie, provision, and attach the local user', async () => {
+      const user = { _id: 'mongo_1' };
+      const request: any = { cookies: { __session: 'clerk.jwt' }, headers: {} };
+      verifyToken.mockResolvedValueOnce({ sub: 'user_clerk_1' });
+      mocks.userProvisioning.findOrCreate.mockResolvedValueOnce(user);
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+
+      expect(verifyToken).toHaveBeenCalledWith('clerk.jwt', {
+        secretKey: 'sk_test_123',
+        authorizedParties: ['https://app.example.com'],
+        jwtKey: expect.stringContaining('BEGIN PUBLIC KEY'),
+      });
+      expect(mocks.userProvisioning.findOrCreate).toHaveBeenCalledWith('user_clerk_1');
+      expect(request.user).toBe(user);
+      expect(mocks.jwtAuthGuard.canActivate).not.toHaveBeenCalled();
+    });
+
+    it('should omit jwtKey and verify via secretKey when CLERK_JWT_KEY is not a real PEM', async () => {
+      mocks.configService.get.mockImplementation((key: string) => {
+        if (key === 'FRONTEND_URL') return 'https://app.example.com';
+        if (key === 'CLERK_JWT_KEY') return 'change_me';
+        return undefined;
+      });
+      const request: any = { cookies: { __session: 'clerk.jwt' }, headers: {} };
+      verifyToken.mockResolvedValueOnce({ sub: 'user_clerk_3' });
+      mocks.userProvisioning.findOrCreate.mockResolvedValueOnce({ _id: 'm3' });
+
+      await guard.canActivate(makeContext(request));
+
+      expect(verifyToken).toHaveBeenCalledWith('clerk.jwt', {
+        secretKey: 'sk_test_123',
+        authorizedParties: ['https://app.example.com'],
+      });
+      const [, options] = verifyToken.mock.calls[0];
+      expect(options).not.toHaveProperty('jwtKey');
+    });
+
+    it('should read the token from the Authorization header when no cookie is present', async () => {
+      const request: any = {
+        cookies: {},
+        headers: { authorization: 'Bearer header.jwt' },
+      };
+      verifyToken.mockResolvedValueOnce({ sub: 'user_clerk_2' });
+      mocks.userProvisioning.findOrCreate.mockResolvedValueOnce({ _id: 'm2' });
+
+      await guard.canActivate(makeContext(request));
+
+      expect(verifyToken).toHaveBeenCalledWith('header.jwt', expect.anything());
+    });
+
+    it('should fall back to the legacy JwtAuthGuard when no Clerk token is present', async () => {
+      const request: any = { cookies: {}, headers: {} };
+      mocks.jwtAuthGuard.canActivate.mockResolvedValueOnce(true);
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+
+      expect(verifyToken).not.toHaveBeenCalled();
+      expect(mocks.jwtAuthGuard.canActivate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to the legacy JwtAuthGuard when Clerk verification fails', async () => {
+      const request: any = { cookies: { __session: 'bad.jwt' }, headers: {} };
+      verifyToken.mockRejectedValueOnce(new Error('expired'));
+      mocks.jwtAuthGuard.canActivate.mockResolvedValueOnce(true);
+
+      await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+
+      expect(mocks.userProvisioning.findOrCreate).not.toHaveBeenCalled();
+      expect(mocks.jwtAuthGuard.canActivate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/auth/clerk/clerk-auth.guard.ts
+++ b/src/auth/clerk/clerk-auth.guard.ts
@@ -1,0 +1,105 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { verifyToken, type VerifyTokenOptions } from '@clerk/backend';
+import type { Request } from 'express';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { UserProvisioningService } from './user-provisioning.service';
+
+/**
+ * Strangler guard for the Clerk migration.
+ *
+ * 1. If a Clerk session token is present (the `__session` cookie, or a Bearer
+ *    header as a fallback), verify it networklessly and attach the local Mongo
+ *    `User` to the request.
+ * 2. Otherwise, delegate to the legacy passport-jwt {@link JwtAuthGuard} so
+ *    existing `access_token` cookies keep working until they expire.
+ *
+ * Once legacy JWT traffic drains, drop the fallback and this becomes a plain
+ * Clerk-only guard.
+ */
+@Injectable()
+export class ClerkAuthGuard implements CanActivate {
+  private readonly logger = new Logger(ClerkAuthGuard.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly userProvisioning: UserProvisioningService,
+    private readonly jwtAuthGuard: JwtAuthGuard,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const token = this.extractClerkToken(request);
+
+    if (!token) {
+      return this.legacyFallback(context);
+    }
+
+    try {
+      const claims = await verifyToken(token, this.verifyOptions());
+
+      const user = await this.userProvisioning.findOrCreate(claims.sub);
+      (request as Request & { user: unknown }).user = user;
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.debug(`Clerk token verification failed: ${message}`);
+      return this.legacyFallback(context);
+    }
+  }
+
+  private async legacyFallback(context: ExecutionContext): Promise<boolean> {
+    const result = await this.jwtAuthGuard.canActivate(context);
+    return result as boolean;
+  }
+
+  private extractClerkToken(request: Request): string | null {
+    const cookieToken = (request as Request & { cookies?: Record<string, string> })
+      .cookies?.__session;
+    if (cookieToken) {
+      return cookieToken;
+    }
+
+    const authHeader = request.headers?.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      return authHeader.slice('Bearer '.length);
+    }
+
+    return null;
+  }
+
+  private authorizedParties(): string[] {
+    return [
+      this.configService.get<string>('FRONTEND_URL'),
+      this.configService.get<string>('FRONTEND_URL_DEV'),
+    ].filter((value): value is string => Boolean(value));
+  }
+
+  /**
+   * Verify via the instance's JWKS (fetched + cached by the SDK from
+   * `secretKey`) so we never have to hand-manage a PEM. Networkless `jwtKey`
+   * is only used when a real PEM public key is actually configured — a
+   * placeholder or a value mangled by `.env` newline handling is ignored so it
+   * can't cause spurious "JWT signature is invalid" errors.
+   */
+  private verifyOptions(): VerifyTokenOptions {
+    const options: VerifyTokenOptions = {
+      secretKey: this.configService.getOrThrow<string>('CLERK_SECRET_KEY'),
+      authorizedParties: this.authorizedParties(),
+    };
+
+    const jwtKey = this.configService
+      .get<string>('CLERK_JWT_KEY')
+      ?.replace(/\\n/g, '\n');
+    if (jwtKey?.includes('BEGIN PUBLIC KEY')) {
+      options.jwtKey = jwtKey;
+    }
+
+    return options;
+  }
+}

--- a/src/auth/clerk/clerk-auth.module.ts
+++ b/src/auth/clerk/clerk-auth.module.ts
@@ -1,0 +1,29 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { WorkflowModule } from '../../workflow/workflow.module';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { clerkClientProvider } from './clerk.client';
+import { UserProvisioningService } from './user-provisioning.service';
+import { ClerkAuthGuard } from './clerk-auth.guard';
+
+/**
+ * Provides the Clerk strangler guard and its dependencies app-wide so any
+ * controller can swap `@UseGuards(JwtAuthGuard)` for `@UseGuards(ClerkAuthGuard)`
+ * without re-wiring providers per module.
+ *
+ * `JwtAuthGuard` is provided here so it can be injected into `ClerkAuthGuard`
+ * for the legacy fallback. The passport `jwt` strategy itself is still
+ * registered by `AuthModule` (via `JwtStrategy`).
+ */
+@Global()
+@Module({
+  imports: [ConfigModule, WorkflowModule],
+  providers: [
+    clerkClientProvider,
+    UserProvisioningService,
+    JwtAuthGuard,
+    ClerkAuthGuard,
+  ],
+  exports: [ClerkAuthGuard, UserProvisioningService, JwtAuthGuard],
+})
+export class ClerkAuthModule {}

--- a/src/auth/clerk/clerk.client.ts
+++ b/src/auth/clerk/clerk.client.ts
@@ -1,0 +1,17 @@
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClerkClient, ClerkClient } from '@clerk/backend';
+
+export const CLERK_CLIENT = 'CLERK_CLIENT';
+
+export const clerkClientProvider: Provider = {
+  provide: CLERK_CLIENT,
+  inject: [ConfigService],
+  useFactory: (configService: ConfigService): ClerkClient =>
+    createClerkClient({
+      secretKey: configService.getOrThrow<string>('CLERK_SECRET_KEY'),
+      publishableKey: configService.getOrThrow<string>(
+        'CLERK_PUBLISHABLE_KEY',
+      ),
+    }),
+};

--- a/src/auth/clerk/index.ts
+++ b/src/auth/clerk/index.ts
@@ -1,0 +1,4 @@
+export * from './clerk.client';
+export * from './clerk-auth.guard';
+export * from './user-provisioning.service';
+export * from './clerk-auth.module';

--- a/src/auth/clerk/user-provisioning.service.spec.ts
+++ b/src/auth/clerk/user-provisioning.service.spec.ts
@@ -1,0 +1,131 @@
+import { Types } from 'mongoose';
+import { UserProvisioningService } from './user-provisioning.service';
+
+const makeService = () => {
+  const userModel = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  };
+  const tierModel = {
+    findOne: jest.fn(),
+  };
+  const clerkClient = {
+    users: {
+      getUser: jest.fn(),
+    },
+  };
+  const emailQueue = {
+    addWelcomeEmailJob: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const service = new UserProvisioningService(
+    userModel as any,
+    tierModel as any,
+    clerkClient as any,
+    emailQueue as any,
+  );
+
+  const fixtures = {
+    clerkUserId: 'user_clerk_123',
+    defaultTier: { _id: new Types.ObjectId() },
+    clerkUser: {
+      id: 'user_clerk_123',
+      primaryEmailAddressId: 'idn_1',
+      emailAddresses: [
+        { id: 'idn_1', emailAddress: 'a@b.com' },
+        { id: 'idn_2', emailAddress: 'old@b.com' },
+      ],
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      username: 'ada',
+      imageUrl: 'https://img/ada.png',
+    },
+  };
+
+  return { service, mocks: { userModel, tierModel, clerkClient, emailQueue }, fixtures };
+};
+
+describe('UserProvisioningService', () => {
+  let service: UserProvisioningService;
+  let mocks: ReturnType<typeof makeService>['mocks'];
+  let fixtures: ReturnType<typeof makeService>['fixtures'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ({ service, mocks, fixtures } = makeService());
+  });
+
+  describe('findOrCreate', () => {
+    it('should return the existing user without calling Clerk when clerkId is already linked', async () => {
+      const existing = { _id: new Types.ObjectId(), clerkId: fixtures.clerkUserId };
+      mocks.userModel.findOne.mockResolvedValueOnce(existing);
+
+      const result = await service.findOrCreate(fixtures.clerkUserId);
+
+      expect(result).toBe(existing);
+      expect(mocks.clerkClient.users.getUser).not.toHaveBeenCalled();
+      expect(mocks.userModel.create).not.toHaveBeenCalled();
+    });
+
+    it('should link an existing user by email when clerkId is not yet set', async () => {
+      const linked = {
+        _id: new Types.ObjectId(),
+        email: 'a@b.com',
+        avatar: undefined,
+        clerkId: undefined as string | undefined,
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      mocks.userModel.findOne
+        .mockResolvedValueOnce(null) // by clerkId
+        .mockResolvedValueOnce(linked); // by email
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+
+      const result = await service.findOrCreate(fixtures.clerkUserId);
+
+      expect(result).toBe(linked);
+      expect(linked.clerkId).toBe(fixtures.clerkUserId);
+      expect(linked.avatar).toBe('https://img/ada.png');
+      expect(linked.save).toHaveBeenCalledTimes(1);
+      expect(mocks.userModel.create).not.toHaveBeenCalled();
+      expect(mocks.emailQueue.addWelcomeEmailJob).not.toHaveBeenCalled();
+    });
+
+    it('should create a new user with the default tier and enqueue a welcome email when no match exists', async () => {
+      const created = { _id: new Types.ObjectId(), clerkId: fixtures.clerkUserId };
+      mocks.userModel.findOne
+        .mockResolvedValueOnce(null) // by clerkId
+        .mockResolvedValueOnce(null); // by email
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+      mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
+      mocks.userModel.create.mockResolvedValueOnce(created);
+
+      const result = await service.findOrCreate(fixtures.clerkUserId);
+
+      expect(result).toBe(created);
+      expect(mocks.userModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clerkId: fixtures.clerkUserId,
+          email: 'a@b.com',
+          name: 'Ada Lovelace',
+          avatar: 'https://img/ada.png',
+          tier: fixtures.defaultTier._id,
+        }),
+      );
+      expect(mocks.emailQueue.addWelcomeEmailJob).toHaveBeenCalledWith(
+        'a@b.com',
+        'Ada Lovelace',
+      );
+    });
+
+    it('should still create the user when the welcome email enqueue fails', async () => {
+      const created = { _id: new Types.ObjectId() };
+      mocks.userModel.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+      mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
+      mocks.userModel.create.mockResolvedValueOnce(created);
+      mocks.emailQueue.addWelcomeEmailJob.mockRejectedValueOnce(new Error('queue down'));
+
+      await expect(service.findOrCreate(fixtures.clerkUserId)).resolves.toBe(created);
+    });
+  });
+});

--- a/src/auth/clerk/user-provisioning.service.ts
+++ b/src/auth/clerk/user-provisioning.service.ts
@@ -1,0 +1,94 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import type { ClerkClient, User as ClerkUser } from '@clerk/backend';
+import { User } from '../../database/schemas/user.schema';
+import { Tier } from '../../database/schemas/tier.schema';
+import { EmailQueue } from '../../workflow/email.queue';
+import { CLERK_CLIENT } from './clerk.client';
+
+/**
+ * Maps a verified Clerk identity to the local Mongo `User`.
+ *
+ * Lazy provisioning: resolve by `clerkId`, then fall back to `email` so existing
+ * Google users keep their `_id` (and all drafts / subscriptions / connected
+ * accounts), then create as a last resort. The Clerk Backend API is only hit on
+ * the first request for a given identity (when `clerkId` is not yet linked).
+ */
+@Injectable()
+export class UserProvisioningService {
+  private readonly logger = new Logger(UserProvisioningService.name);
+
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<User>,
+    @InjectModel(Tier.name) private readonly tierModel: Model<Tier>,
+    @Inject(CLERK_CLIENT) private readonly clerkClient: ClerkClient,
+    private readonly emailQueue: EmailQueue,
+  ) {}
+
+  async findOrCreate(clerkUserId: string): Promise<User> {
+    const existing = await this.userModel.findOne({ clerkId: clerkUserId });
+    if (existing) {
+      return existing;
+    }
+
+    const clerkUser = await this.clerkClient.users.getUser(clerkUserId);
+    const email = this.resolvePrimaryEmail(clerkUser);
+    const name = this.resolveName(clerkUser);
+    const avatar = clerkUser.imageUrl ?? undefined;
+
+    if (email) {
+      const linked = await this.userModel.findOne({ email });
+      if (linked) {
+        linked.clerkId = clerkUserId;
+        if (!linked.avatar && avatar) {
+          linked.avatar = avatar;
+        }
+        await linked.save();
+        return linked;
+      }
+    }
+
+    const defaultTier = await this.tierModel.findOne({ isDefault: true });
+    const created = await this.userModel.create({
+      clerkId: clerkUserId,
+      email,
+      name,
+      avatar,
+      tier: defaultTier ? defaultTier._id : undefined,
+    });
+
+    if (email) {
+      try {
+        await this.emailQueue.addWelcomeEmailJob(email, name);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown queue error';
+        this.logger.warn(
+          `Welcome email enqueue failed for new Clerk signup (${email}): ${message}`,
+        );
+      }
+    }
+
+    return created;
+  }
+
+  private resolvePrimaryEmail(clerkUser: ClerkUser): string {
+    const primary = clerkUser.emailAddresses.find(
+      (entry) => entry.id === clerkUser.primaryEmailAddressId,
+    );
+    return (
+      primary?.emailAddress ??
+      clerkUser.emailAddresses[0]?.emailAddress ??
+      ''
+    );
+  }
+
+  private resolveName(clerkUser: ClerkUser): string {
+    const fullName = [clerkUser.firstName, clerkUser.lastName]
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+    return fullName || clerkUser.username || 'New User';
+  }
+}

--- a/src/database/schemas/user.schema.ts
+++ b/src/database/schemas/user.schema.ts
@@ -13,6 +13,9 @@ export class User extends Document {
   @Prop({ unique: true })
   googleId?: string;
 
+  @Prop({ unique: true, sparse: true })
+  clerkId?: string;
+
   @Prop()
   avatar?: string;
 

--- a/src/feedback/feedback.controller.spec.ts
+++ b/src/feedback/feedback.controller.spec.ts
@@ -1,9 +1,13 @@
 import { HttpStatus } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 
-jest.mock('../common/guards', () => ({
-  JwtAuthGuard: class JwtAuthGuard {},
-}));
+jest.mock(
+  '../auth/clerk',
+  () => ({
+    ClerkAuthGuard: class ClerkAuthGuard {},
+  }),
+  { virtual: true },
+);
 jest.mock(
   '../common/decorators',
   () => ({
@@ -19,7 +23,7 @@ jest.mock(
   { virtual: true },
 );
 
-import { JwtAuthGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackIssueType } from './dto';
 
@@ -73,8 +77,8 @@ describe('FeedbackController', () => {
     });
   });
 
-  it('is guarded by JwtAuthGuard', () => {
+  it('is guarded by ClerkAuthGuard', () => {
     const guards = Reflect.getMetadata(GUARDS_METADATA, FeedbackController);
-    expect(guards).toEqual(expect.arrayContaining([JwtAuthGuard]));
+    expect(guards).toEqual(expect.arrayContaining([ClerkAuthGuard]));
   });
 });

--- a/src/feedback/feedback.controller.ts
+++ b/src/feedback/feedback.controller.ts
@@ -7,13 +7,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { GetUser } from '../common/decorators';
-import { JwtAuthGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { IAppResponse } from '../common/interfaces';
 import { User } from '../database/schemas';
 import { CreateFeedbackIssueDto } from './dto';
 import { FeedbackService } from './feedback.service';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(ClerkAuthGuard)
 @Controller('feedback')
 export class FeedbackController {
   constructor(private readonly feedbackService: FeedbackService) {}

--- a/src/onboarding/onboarding.controller.ts
+++ b/src/onboarding/onboarding.controller.ts
@@ -7,7 +7,7 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
-import { JwtAuthGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { GetUser } from '../common/decorators';
 import { User } from '../database/schemas';
 import { IAppResponse } from '../common/interfaces';
@@ -15,7 +15,7 @@ import { OnboardingService } from './onboarding.service';
 import { InitOnboardingDto, UpdateOnboardingDto } from './dto';
 
 @Controller('onboarding')
-@UseGuards(JwtAuthGuard)
+@UseGuards(ClerkAuthGuard)
 export class OnboardingController {
   constructor(private readonly onboardingService: OnboardingService) {}
 

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -8,13 +8,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { PaymentService } from './payment.service';
-import { JwtAuthGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { GetUser } from '../common/decorators';
 import { User } from '../database/schemas';
 import { CreateCheckoutDto } from './payment.dto';
 import { IAppResponse } from '../common/interfaces';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(ClerkAuthGuard)
 @Controller('payment')
 export class PaymentController {
   constructor(private readonly paymentService: PaymentService) {}

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -17,7 +17,8 @@ import {
 import { PostService } from './post.service';
 import { InputDto } from '../agent/dto';
 import { UpdatePostDto, SchedulePostDto } from './dto';
-import { JwtAuthGuard, SubscriptionAccessGuard } from '../common/guards';
+import { SubscriptionAccessGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { IAppResponse } from 'src/common/interfaces';
 import { GetUser } from 'src/common/decorators';
 import { User } from 'src/database/schemas';
@@ -27,7 +28,7 @@ import { tmpdir } from 'os';
 import { extname } from 'path';
 import type { GetPostsResult } from './post.service';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(ClerkAuthGuard)
 @Controller('posts')
 export class PostController {
   constructor(private readonly postService: PostService) {}

--- a/src/tier/tier.controller.ts
+++ b/src/tier/tier.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
 import { TierService } from './tier.service';
 import { IAppResponse } from '../common/interfaces';
-import { JwtAuthGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { GetUser } from '../common/decorators';
 import { User } from '../database/schemas';
 
@@ -18,7 +18,7 @@ export class TierController {
     };
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(ClerkAuthGuard)
   @Get('me')
   async getMyTier(@GetUser() user: User): Promise<IAppResponse> {
     return {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { JwtAuthGuard } from '../common/guards';
+import { ClerkAuthGuard } from '../auth/clerk';
 import { GetUser } from '../common/decorators';
 import { User } from '../database/schemas';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(ClerkAuthGuard)
 @Controller('users')
 export class UserController {
   @Get('me')

--- a/src/workflow/workflow.controller.ts
+++ b/src/workflow/workflow.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Logger, UseGuards } from '@nestjs/common';
 import { WorkflowQueue } from './workflow.queue';
-import { JwtAuthGuard } from '../common/guards';
+// Direct file import (not the ../auth/clerk barrel) to avoid a require cycle:
+// the barrel loads ClerkAuthModule, which imports WorkflowModule.
+import { ClerkAuthGuard } from '../auth/clerk/clerk-auth.guard';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(ClerkAuthGuard)
 @Controller('workflow')
 export class WorkflowController {
   private logger: Logger;


### PR DESCRIPTION
## Summary
Introduces **Clerk** as the identity provider, integrated behind a strangler-style `ClerkAuthGuard` so the migration ships with **zero forced logout**: the guard verifies a Clerk session token (`__session` cookie or `Authorization: Bearer`) and falls back to the legacy passport-jwt guard, so existing `access_token` cookies keep working until they expire.

Decisions captured in `docs/clerk-integration-analysis.md`: sign-in via Google + email/magic-link + LinkedIn (identity only), `__session` same-origin transport, and `GET /users/me` replacing the `user` cookie. **LinkedIn publishing (`ConnectedAccount`, encrypted tokens, org ACLs, avatar refresh) is untouched.**

## Changes
- **User schema**: add sparse-unique `clerkId` (additive; keeps `googleId`).
- **`UserProvisioningService`**: lazy find-or-create — resolve by `clerkId`, then link an existing user by `email` (so Google users keep their `_id`/data), else create with the default tier + welcome email.
- **`ClerkAuthGuard`**: verifies via the instance JWKS (fetched + cached from `CLERK_SECRET_KEY`); uses networkless `jwtKey` only when a genuine PEM is configured, so a placeholder/`.env`-mangled `CLERK_JWT_KEY` can't cause `JWT signature is invalid`. Legacy JWT fallback on absence/failure.
- **`@Global() ClerkAuthModule`** exports the guard + its deps; rolled out across protected controllers (`users`, `post`, `payment`, `feedback`, `workflow`, `tier`, `onboarding`, and `auth`'s protected routes). `workflow.controller` imports the guard by direct path to avoid a require cycle.
- **Env**: add `CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `CLERK_JWT_KEY` to `.env.example`.
- **Docs**: `docs/clerk-integration-analysis.md` decision record.

## Testing
- `bun run build` clean.
- New specs: `user-provisioning.service.spec.ts`, `clerk-auth.guard.spec.ts` (9 tests). Updated `feedback.controller.spec.ts` for the new guard.
- Manual: server boots (DI resolves across all modules); protected routes return 401 unauthenticated; bogus `__session` correctly falls through to legacy; verified end-to-end with a real Clerk token from the frontend.

> Note: a pre-existing `post.service.spec.ts` failure (a `select()` projection assertion) is unrelated to this change — `post.service.ts` is untouched here.

## Follow-ups (not in this PR)
- Frontend: Clerk sign-in + send `__session` same-origin + use `GET /users/me`.
- After legacy cookie TTL (≤30 days) drains: remove the JWT fallback, `JwtStrategy`, `GoogleStrategy`, `AuthService.login`, and the `user` cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
