### PR TITLE
feat: async direct-to-R2 LinkedIn media upload

### DIFF
--- a/docs/async-media-upload-handoff.md
+++ b/docs/async-media-upload-handoff.md
@@ -1,38 +1,114 @@
 # Handoff: Async LinkedIn Media Upload (client-side changes)
 
-**Branch:** `fix/linkedin-image-upload` · **Date:** 2026-07-06
+**Branch:** `fix/linkedin-image-upload` · **Updated:** 2026-07-06
 
-Media upload used to be synchronous: `PUT /posts/:id/media` uploaded to LinkedIn
-inline and returned only when everything (including LinkedIn's video
-processing) was done — which is why large uploads died with connection
-timeouts around 30 seconds. Uploads are now **asynchronous**: the endpoint
-stores the files, returns immediately with `202 Accepted`, and a background
-worker performs the LinkedIn upload. The client must now track media status
-and gate the publish action on it.
+Media upload is now fully asynchronous **and** direct-to-storage. The client
+uploads file bytes straight to Cloudflare R2 with presigned URLs — files no
+longer pass through the API server — and a background worker performs the
+LinkedIn upload. The client must request upload slots, PUT the files itself,
+confirm, then track media status and gate the publish action on it.
+
+The old `multipart/form-data` endpoint (`PUT /posts/:id/media`) still works
+during the migration (see §9) but is **deprecated** and will be removed once
+the client has switched.
 
 All paths below are relative to the API prefix `api/v1`.
 
 ---
 
-## 1. What changed at a glance
+## 1. The new flow at a glance
 
-| | Before | After |
-|---|---|---|
-| `PUT /posts/:id/media` HTTP status | `200` | `202` |
-| Response `data` | none | array of pending media entries |
-| Media entry `id` | final LinkedIn URN | temp UUID until upload finishes, then replaced by the URN |
-| Media entry `status` | did not exist | `UPLOADING` → `READY` \| `FAILED` |
-| Publish during upload | impossible (request blocked) | rejected with `409` until media is `READY` |
-| Request duration | up to minutes (usually timed out) | fast — file transfer to the server + a queue write |
+```
+1. POST /posts/:id/media/uploads            declare files → 201 with presigned URLs
+2. PUT <uploadUrl>                          client → R2 directly, one per file
+3. POST /posts/:id/media/uploads/complete   confirm → 202, background upload starts
+4. GET /posts/:id                           poll media[].status until no
+                                            PENDING/UPLOADING entries remain
+```
 
-The **request format is unchanged**: `multipart/form-data`, field name `files`,
-up to 20 files, 200 MB per-file limit, JPEG/PNG images **or** exactly one
-video, no mixing images and videos in one request.
+File rules (unchanged from before): up to 20 files, 200 MB per-file limit,
+JPEG/PNG images **or** exactly one video, no mixing images and videos in one
+batch.
 
-## 2. New response of `PUT /posts/:id/media`
+## 2. Step 1 — initiate: `POST /posts/:id/media/uploads`
+
+Declare every file you intend to upload:
 
 ```json
-// HTTP 202
+{
+  "files": [
+    { "fileName": "photo.jpg", "mimeType": "image/jpeg", "sizeBytes": 1048576 }
+  ]
+}
+```
+
+`sizeBytes` must be the **exact** byte size of the file (`File.size` in the
+browser) and `mimeType` its exact type (`File.type`) — both are baked into the
+presigned URL signature, so R2 will reject the PUT if they don't match.
+
+Response `201`:
+
+```json
+{
+  "statusCode": 201,
+  "message": "Upload slots created",
+  "data": {
+    "expiresAt": "2026-07-06T13:00:00.000Z",
+    "uploads": [
+      {
+        "mediaId": "3f1c9a1e-6c9d-4e0f-9d2a-6f7b8c9d0e1f",
+        "uploadUrl": "https://<bucket>.r2.cloudflarestorage.com/media-uploads/…?X-Amz-…",
+        "requiredHeaders": {
+          "Content-Type": "image/jpeg",
+          "Content-Length": "1048576"
+        }
+      }
+    ]
+  }
+}
+```
+
+- `mediaId` is a **temporary UUID**; it also appears as a new entry in
+  `post.media[]` with `status: "PENDING"`. After the LinkedIn upload succeeds
+  it is replaced server-side by the LinkedIn URN (`urn:li:image:…` /
+  `urn:li:video:…`). Do not persist it beyond this upload flow.
+- Slots expire at `expiresAt` (**30 minutes**). All PUTs and the complete call
+  must happen before then; afterwards, re-initiate.
+
+## 3. Step 2 — PUT the files directly to R2
+
+One request per file, straight from the browser:
+
+```js
+await fetch(upload.uploadUrl, {
+  method: 'PUT',
+  headers: upload.requiredHeaders,
+  body: file, // the File/Blob itself
+});
+```
+
+- Send **exactly** the `requiredHeaders` returned by initiate. A mismatched
+  `Content-Type` or `Content-Length` (i.e. a different file than declared) is
+  rejected by R2 with a 403.
+- PUTs can run in parallel. This is a plain `fetch`/XHR, so you get real
+  per-file upload progress (XHR `upload.onprogress`) — something the old
+  multipart endpoint never gave you.
+- A failed or interrupted PUT can simply be retried against the same URL until
+  the slot expires.
+
+## 4. Step 3 — confirm: `POST /posts/:id/media/uploads/complete`
+
+```json
+{ "mediaIds": ["3f1c9a1e-6c9d-4e0f-9d2a-6f7b8c9d0e1f"] }
+```
+
+The server verifies each file actually landed in R2 with the declared
+size/type, flips the entries to `UPLOADING`, and enqueues the background
+LinkedIn upload.
+
+Response `202`, same shape as the old media endpoint:
+
+```json
 {
   "statusCode": 202,
   "message": "Media upload started",
@@ -48,97 +124,135 @@ video, no mixing images and videos in one request.
 }
 ```
 
-- `id` is a **temporary UUID**. When the background upload succeeds it is
-  replaced server-side by the LinkedIn URN (`urn:li:image:…` /
-  `urn:li:video:…`). Do not cache or persist the temp id beyond the polling
-  loop; re-read it from the post.
-- `type` is `IMAGE` or `VIDEO`. Videos have no `altText`.
+Partial confirms are allowed: if one PUT failed, confirm the ones that
+succeeded and re-initiate the failed file (after its slot expires, or
+immediately — a new initiate is blocked only while another batch is `PENDING`
+or `UPLOADING`, so wait for/confirm the current batch first).
 
-## 3. The media `status` field
+## 5. The media `status` field
 
-Every entry in `post.media[]` now carries a status:
+Every entry in `post.media[]` carries a status:
 
 | Status | Meaning | Client behavior |
 |---|---|---|
-| `UPLOADING` | Background job is transferring the file to LinkedIn | Show spinner/progress placeholder; disable Publish |
-| `READY` | Uploaded; `id` is now the real LinkedIn URN | Render normally; Publish allowed |
-| `FAILED` | Upload failed after 3 attempts | Show error state; offer re-upload (see §6) |
+| `PENDING` | Slot issued; waiting for the client's PUT + confirm | Treat like `UPLOADING` in the UI (it's your own in-flight upload) |
+| `UPLOADING` | Background job is transferring the file to LinkedIn | Show spinner/placeholder; disable Publish |
+| `READY` | Done; `id` is now the real LinkedIn URN | Render normally; Publish allowed |
+| `FAILED` | LinkedIn upload failed after 3 attempts | Show error state; offer re-upload (see §8) |
 | *(absent)* | Entry predates this change | Treat exactly like `READY` |
 
-## 4. Polling for completion
+Expired `PENDING` entries (abandoned uploads) are purged automatically the
+next time anything touches the post's media (initiate, confirm, publish), so
+they may briefly appear in `GET /posts/:id` — hide `PENDING` entries you don't
+recognize from the current session.
 
-There is no webhook/SSE yet — poll the post:
+## 6. Polling for completion
+
+Unchanged from before — after the `202`, poll the post:
 
 ```
 GET /posts/:id        → data.media[].status
 ```
 
-Suggested cadence: every **3 s for images**, every **5 s for videos**. Budget
-expectations: images normally settle in a few seconds; videos can take
-**several minutes** (LinkedIn processes the video after upload; the worker
-waits up to 5 minutes for that, plus transfer time, plus up to 2 retries with
-10 s/20 s backoff on failure). A sane client-side ceiling before showing a
-"still processing" notice is ~10 minutes for video.
+Suggested cadence: every **3 s for images**, every **5 s for videos**. Images
+normally settle in a few seconds; videos can take **several minutes**
+(LinkedIn processes the video after upload; the worker waits up to 5 minutes
+for that, plus transfer time, plus up to 2 retries with 10 s/20 s backoff). A
+sane client-side ceiling before showing a "still processing" notice is ~10
+minutes for video.
 
-Stop polling when no entry is `UPLOADING` anymore. Each entry ends as either
-`READY` (with its `id` swapped to the LinkedIn URN) or `FAILED`.
+Stop polling when no entry is `PENDING` or `UPLOADING` anymore. Each entry
+ends as either `READY` (with its `id` swapped to the LinkedIn URN) or
+`FAILED`.
 
 `GET /posts/linkedin/image/:urn` (thumbnail/download URL lookup) only works
-with a real URN — **do not call it while an entry is still `UPLOADING`**; the
-temp UUID will error.
+with a real URN — **do not call it with a temp UUID** (`PENDING`/`UPLOADING`
+entries).
 
-## 5. Publishing
+## 7. Publishing
 
-`POST /posts/:id/publish` and scheduled publishes now enforce:
+`POST /posts/:id/publish` and scheduled publishes enforce:
 
-- Any entry `UPLOADING` → **`409 Conflict`**, message
-  `"Media uploads are still in progress. Try again shortly."` The client
-  should disable the Publish button while it knows an upload is in flight, and
-  treat this 409 as a retryable state, not an error toast.
+- Any entry `UPLOADING` or unexpired `PENDING` → **`409 Conflict`**, message
+  `"Media uploads are still in progress. Try again shortly."` Disable the
+  Publish button while an upload is in flight and treat this 409 as a
+  retryable state, not an error toast.
 - `FAILED` entries are **silently excluded** from the LinkedIn post payload.
   A post with one `READY` image and one `FAILED` image publishes with just the
   `READY` image. Surface this to the user before they publish (e.g. "1 of 2
   images failed to upload and won't be included").
+- Expired `PENDING` entries never block publishing (they're purged).
 
-## 6. Error cases on `PUT /posts/:id/media`
+## 8. Error cases
 
-| HTTP | Message (in `message`) | When |
+### `POST /posts/:id/media/uploads` (initiate)
+
+| HTTP | Message | When |
 |---|---|---|
-| `409` | `A media upload is already in progress for this post` | A previous batch on this post is still `UPLOADING`. Wait for it to finish (poll), then retry. **New.** |
-| `400` | `No files provided` / `Cannot mix images and videos in one post` / `Only one video per post is allowed` / `Unsupported image format: …` / `Post is already published` | Same validations as before |
+| `400` | class-validator errors | Missing/invalid `fileName`/`mimeType`/`sizeBytes`, >20 files, `sizeBytes` > 200 MB |
+| `400` | `Unsupported file type: …` / `Cannot mix images and videos in one post` / `Only one video per post is allowed` / `Unsupported image format: …` / `Post is already published` | Same media rules as before, now checked against declared metadata |
 | `403` | `You are not authorized to edit this post` | Not the owner |
 | `404` | `Post not found` | Bad post id |
+| `409` | `A media upload is already in progress for this post` | Another batch is `PENDING` (unexpired) or `UPLOADING`. Finish/confirm it first, or wait ≤30 min for the stale slot to expire. |
 | `409` | `Reconnect connected account to upload media.` | LinkedIn account disconnected/expired |
 
-Failures **after** the 202 (i.e., in the background job) never surface as an
-HTTP error on the upload request — they appear as `status: "FAILED"` on the
-media entry during polling.
+### `PUT <uploadUrl>` (direct to R2)
 
-**Recovering from `FAILED`:** there is currently no endpoint to remove a media
-entry. A failed entry stays on the post but never blocks publishing (it is
-excluded, per §5). To retry, simply upload the file again — this appends a new
-entry. The failed one remains visible in `post.media[]`; hide `FAILED` entries
-from the composer UI once the user has acknowledged them, or after a
-successful re-upload.
+| HTTP | When |
+|---|---|
+| `403` | Signature mismatch: wrong `Content-Type`/`Content-Length` (different file than declared) or the slot expired. Re-initiate. |
 
-## 7. Suggested UI flow
+### `POST /posts/:id/media/uploads/complete`
 
-1. User attaches files → `PUT /posts/:id/media` → on `202`, render the
-   returned entries as uploading placeholders (keyed by the temp `id`).
-2. Poll `GET /posts/:id`; reconcile `media[]` by position/temp-id until no
-   entry is `UPLOADING`.
-3. `READY` → swap placeholder for the real media (fetch image preview via
-   `GET /posts/linkedin/image/:urn` using the new URN).
+| HTTP | Message | When |
+|---|---|---|
+| `400` | `File for media <id> was not uploaded` | The PUT never happened or didn't finish |
+| `400` | `Uploaded file for media <id> does not match the declared size or type` | Different bytes than declared |
+| `404` | `Unknown media id: <id>` | Wrong/typo'd id (or the slot expired and was purged) |
+| `409` | `Media <id> is not awaiting upload confirmation` | Entry already confirmed (`UPLOADING`/`READY`/`FAILED`) |
+| `409` | `Upload slot expired. Re-initiate the upload.` | >30 min since initiate |
+| `403`/`404`/`400`/`409` | ownership / post / published / reconnect errors as on initiate | |
+
+**Failures after the 202** (in the background job) never surface as an HTTP
+error — they appear as `status: "FAILED"` on the media entry during polling.
+
+**Recovering from `FAILED`:** there is no endpoint to remove a media entry. A
+failed entry stays on the post but never blocks publishing (it is excluded,
+per §7). To retry, run the initiate → PUT → complete flow again — this appends
+a new entry. Hide `FAILED` entries from the composer UI once acknowledged or
+re-uploaded.
+
+## 9. Deprecated: `PUT /posts/:id/media` (multipart)
+
+The old endpoint still accepts `multipart/form-data` (`files` field) and
+returns the same `202` + `UPLOADING` entries as before. It shares the
+in-progress lock with the new flow (a `PENDING`/`UPLOADING` batch from either
+path blocks both). Migrate to the presigned flow; this endpoint will be
+removed in a later release.
+
+## 10. Suggested UI flow
+
+1. User attaches files → **initiate** → render returned `uploads` as
+   local-progress placeholders (keyed by `mediaId`).
+2. **PUT** each file to its `uploadUrl` in parallel, driving per-file progress
+   bars from XHR `upload.onprogress`.
+3. When all PUTs succeed → **complete** with all `mediaIds`. If some PUTs
+   failed, complete the successful ones and offer retry for the rest.
+4. Poll `GET /posts/:id` until no entry is `PENDING`/`UPLOADING`.
+   `READY` → swap placeholder for the real media (image preview via
+   `GET /posts/linkedin/image/:urn` with the new URN).
    `FAILED` → error state + re-upload affordance.
-4. Keep Publish disabled while any entry is `UPLOADING`; if the user races it,
-   handle the `409` gracefully.
+5. Keep Publish disabled while any entry is `PENDING`/`UPLOADING`; if the user
+   races it, handle the `409` gracefully.
 
-## 8. Compatibility notes
+## 11. Compatibility notes
 
 - Old posts have media entries **without** a `status` field — treat as `READY`.
-- The response envelope (`statusCode` / `message` / `data`) is unchanged; only
-  the status code, message text, and presence of `data` on the media endpoint
-  changed.
+- Media entries may now also carry `mimeType`, `sizeBytes`, and
+  `pendingExpiresAt` fields (bookkeeping for `PENDING` slots) — ignore them.
+- The response envelope (`statusCode` / `message` / `data`) is unchanged.
 - Requires the backend worker process to be running; in environments where it
   isn't, media will remain `UPLOADING` indefinitely (backend concern, but
   useful for debugging "stuck" uploads in dev).
+- Requires CORS to be configured on the R2 bucket for the app origins
+  (backend/infra concern); without it, the direct PUTs fail preflight.

--- a/docs/async-media-upload-handoff.md
+++ b/docs/async-media-upload-handoff.md
@@ -1,0 +1,144 @@
+# Handoff: Async LinkedIn Media Upload (client-side changes)
+
+**Branch:** `fix/linkedin-image-upload` · **Date:** 2026-07-06
+
+Media upload used to be synchronous: `PUT /posts/:id/media` uploaded to LinkedIn
+inline and returned only when everything (including LinkedIn's video
+processing) was done — which is why large uploads died with connection
+timeouts around 30 seconds. Uploads are now **asynchronous**: the endpoint
+stores the files, returns immediately with `202 Accepted`, and a background
+worker performs the LinkedIn upload. The client must now track media status
+and gate the publish action on it.
+
+All paths below are relative to the API prefix `api/v1`.
+
+---
+
+## 1. What changed at a glance
+
+| | Before | After |
+|---|---|---|
+| `PUT /posts/:id/media` HTTP status | `200` | `202` |
+| Response `data` | none | array of pending media entries |
+| Media entry `id` | final LinkedIn URN | temp UUID until upload finishes, then replaced by the URN |
+| Media entry `status` | did not exist | `UPLOADING` → `READY` \| `FAILED` |
+| Publish during upload | impossible (request blocked) | rejected with `409` until media is `READY` |
+| Request duration | up to minutes (usually timed out) | fast — file transfer to the server + a queue write |
+
+The **request format is unchanged**: `multipart/form-data`, field name `files`,
+up to 20 files, 200 MB per-file limit, JPEG/PNG images **or** exactly one
+video, no mixing images and videos in one request.
+
+## 2. New response of `PUT /posts/:id/media`
+
+```json
+// HTTP 202
+{
+  "statusCode": 202,
+  "message": "Media upload started",
+  "data": [
+    {
+      "id": "3f1c9a1e-6c9d-4e0f-9d2a-6f7b8c9d0e1f",
+      "type": "IMAGE",
+      "title": "photo.jpg",
+      "altText": "photo.jpg",
+      "status": "UPLOADING"
+    }
+  ]
+}
+```
+
+- `id` is a **temporary UUID**. When the background upload succeeds it is
+  replaced server-side by the LinkedIn URN (`urn:li:image:…` /
+  `urn:li:video:…`). Do not cache or persist the temp id beyond the polling
+  loop; re-read it from the post.
+- `type` is `IMAGE` or `VIDEO`. Videos have no `altText`.
+
+## 3. The media `status` field
+
+Every entry in `post.media[]` now carries a status:
+
+| Status | Meaning | Client behavior |
+|---|---|---|
+| `UPLOADING` | Background job is transferring the file to LinkedIn | Show spinner/progress placeholder; disable Publish |
+| `READY` | Uploaded; `id` is now the real LinkedIn URN | Render normally; Publish allowed |
+| `FAILED` | Upload failed after 3 attempts | Show error state; offer re-upload (see §6) |
+| *(absent)* | Entry predates this change | Treat exactly like `READY` |
+
+## 4. Polling for completion
+
+There is no webhook/SSE yet — poll the post:
+
+```
+GET /posts/:id        → data.media[].status
+```
+
+Suggested cadence: every **3 s for images**, every **5 s for videos**. Budget
+expectations: images normally settle in a few seconds; videos can take
+**several minutes** (LinkedIn processes the video after upload; the worker
+waits up to 5 minutes for that, plus transfer time, plus up to 2 retries with
+10 s/20 s backoff on failure). A sane client-side ceiling before showing a
+"still processing" notice is ~10 minutes for video.
+
+Stop polling when no entry is `UPLOADING` anymore. Each entry ends as either
+`READY` (with its `id` swapped to the LinkedIn URN) or `FAILED`.
+
+`GET /posts/linkedin/image/:urn` (thumbnail/download URL lookup) only works
+with a real URN — **do not call it while an entry is still `UPLOADING`**; the
+temp UUID will error.
+
+## 5. Publishing
+
+`POST /posts/:id/publish` and scheduled publishes now enforce:
+
+- Any entry `UPLOADING` → **`409 Conflict`**, message
+  `"Media uploads are still in progress. Try again shortly."` The client
+  should disable the Publish button while it knows an upload is in flight, and
+  treat this 409 as a retryable state, not an error toast.
+- `FAILED` entries are **silently excluded** from the LinkedIn post payload.
+  A post with one `READY` image and one `FAILED` image publishes with just the
+  `READY` image. Surface this to the user before they publish (e.g. "1 of 2
+  images failed to upload and won't be included").
+
+## 6. Error cases on `PUT /posts/:id/media`
+
+| HTTP | Message (in `message`) | When |
+|---|---|---|
+| `409` | `A media upload is already in progress for this post` | A previous batch on this post is still `UPLOADING`. Wait for it to finish (poll), then retry. **New.** |
+| `400` | `No files provided` / `Cannot mix images and videos in one post` / `Only one video per post is allowed` / `Unsupported image format: …` / `Post is already published` | Same validations as before |
+| `403` | `You are not authorized to edit this post` | Not the owner |
+| `404` | `Post not found` | Bad post id |
+| `409` | `Reconnect connected account to upload media.` | LinkedIn account disconnected/expired |
+
+Failures **after** the 202 (i.e., in the background job) never surface as an
+HTTP error on the upload request — they appear as `status: "FAILED"` on the
+media entry during polling.
+
+**Recovering from `FAILED`:** there is currently no endpoint to remove a media
+entry. A failed entry stays on the post but never blocks publishing (it is
+excluded, per §5). To retry, simply upload the file again — this appends a new
+entry. The failed one remains visible in `post.media[]`; hide `FAILED` entries
+from the composer UI once the user has acknowledged them, or after a
+successful re-upload.
+
+## 7. Suggested UI flow
+
+1. User attaches files → `PUT /posts/:id/media` → on `202`, render the
+   returned entries as uploading placeholders (keyed by the temp `id`).
+2. Poll `GET /posts/:id`; reconcile `media[]` by position/temp-id until no
+   entry is `UPLOADING`.
+3. `READY` → swap placeholder for the real media (fetch image preview via
+   `GET /posts/linkedin/image/:urn` using the new URN).
+   `FAILED` → error state + re-upload affordance.
+4. Keep Publish disabled while any entry is `UPLOADING`; if the user races it,
+   handle the `409` gracefully.
+
+## 8. Compatibility notes
+
+- Old posts have media entries **without** a `status` field — treat as `READY`.
+- The response envelope (`statusCode` / `message` / `data`) is unchanged; only
+  the status code, message text, and presence of `data` on the media endpoint
+  changed.
+- Requires the backend worker process to be running; in environments where it
+  isn't, media will remain `UPLOADING` indefinitely (backend concern, but
+  useful for debugging "stuck" uploads in dev).

--- a/docs/presigned-media-upload-spec.md
+++ b/docs/presigned-media-upload-spec.md
@@ -1,0 +1,229 @@
+# Spec: Direct-to-R2 media upload via presigned URLs
+
+**Status:** implemented on `fix/linkedin-image-upload` · **Date:** 2026-07-06
+
+## Goal
+
+Remove the client → server file hop on media uploads. Today `PUT /posts/:id/media`
+receives the full multipart body (up to 200 MB/file), buffers it, and re-uploads
+it to R2. After this change the client uploads bytes **directly to R2** with a
+presigned PUT URL; the server only issues slots, verifies the result, and
+enqueues the existing `media-upload` worker job.
+
+The server → LinkedIn hop (worker downloads from R2, pushes to LinkedIn) is
+**out of scope and unchanged** — LinkedIn's API requires us to push bytes.
+
+## Flow overview
+
+```
+1. POST /posts/:id/media/uploads            client declares files
+      → server validates, creates PENDING media entries,
+        returns presigned PUT URLs
+2. PUT <presigned R2 URL>                    client → R2, one per file (CORS)
+3. POST /posts/:id/media/uploads/complete    client confirms
+      → server HeadObject-verifies each file, flips PENDING → UPLOADING,
+        enqueues media-upload job, returns 202
+4. (unchanged) worker: R2 → LinkedIn → READY/FAILED, delete R2 object
+5. (unchanged) client polls GET /posts/:id until no UPLOADING entries
+```
+
+## Media entry lifecycle
+
+New first state, everything else as-is:
+
+```
+PENDING ──(confirm ok)──► UPLOADING ──► READY | FAILED
+   │
+   └─(expiry / purge)──► entry removed, R2 object reaped by lifecycle rule
+```
+
+| Status | Meaning |
+|---|---|
+| `PENDING` *(new)* | Slot issued; waiting for the client's direct PUT + confirm |
+| `UPLOADING` | Confirmed; background worker is transferring to LinkedIn |
+| `READY` / `FAILED` / *(absent)* | unchanged |
+
+## API
+
+### 1. `POST /posts/:id/media/uploads` — initiate
+
+Request:
+
+```json
+{
+  "files": [
+    { "fileName": "photo.jpg", "mimeType": "image/jpeg", "sizeBytes": 1048576 }
+  ]
+}
+```
+
+Validation (mirrors today's rules, but against *declared* metadata):
+
+- post exists (404), owned by caller (403), not `PUBLISHED` (400)
+- 1–20 files; no image/video mixing; ≤ 1 video (400)
+- images: `image/jpeg` | `image/png` only (400)
+- `sizeBytes` > 0 and ≤ 200 MB per file (400)
+- no existing entry in `UPLOADING` or unexpired `PENDING` (409, same
+  "already in progress" semantics as today)
+- connected account owned + usable (409 reconnect message)
+
+Side effects: purge any **expired** `PENDING` entries on this post, then append
+one media entry per file:
+
+```
+{ id: <uuid>, type, title: fileName, altText (images), status: 'PENDING',
+  mimeType, sizeBytes, pendingExpiresAt: now + TTL }
+```
+
+Response `201`:
+
+```json
+{
+  "statusCode": 201,
+  "message": "Upload slots created",
+  "data": {
+    "expiresAt": "2026-07-06T13:00:00.000Z",
+    "uploads": [
+      {
+        "mediaId": "3f1c9a1e-…",
+        "uploadUrl": "https://<bucket>.<account>.r2.cloudflarestorage.com/media-uploads/…?X-Amz-…",
+        "requiredHeaders": {
+          "Content-Type": "image/jpeg",
+          "Content-Length": "1048576"
+        }
+      }
+    ]
+  }
+}
+```
+
+- R2 key stays `media-uploads/{postId}/{mediaId}`.
+- **TTL: 30 minutes** (covers a 200 MB video on a slow uplink; short enough
+  that abandoned slots don't block the post for long).
+- The presigned URL is generated from a `PutObjectCommand` with `ContentType`
+  and `ContentLength` set, so those headers are **part of the signature** — R2
+  rejects a PUT whose actual type/length differ from what was declared. This is
+  the primary server-side enforcement of size/type.
+
+### 2. Client PUT to R2 (no server involvement)
+
+Single `PUT` with the returned headers and the raw file body. 200 MB is well
+under the 5 GB single-PUT ceiling, so no multipart upload is needed.
+
+### 3. `POST /posts/:id/media/uploads/complete` — confirm
+
+Request:
+
+```json
+{ "mediaIds": ["3f1c9a1e-…"] }
+```
+
+Validation:
+
+- post exists / owned / not published (as above)
+- every `mediaId` is an entry on this post with `status: 'PENDING'` and
+  unexpired `pendingExpiresAt` (else 409 `"Upload slot expired, re-initiate"`
+  or 404 for unknown ids)
+- connected account still owned + usable (re-checked; tokens can expire
+  between initiate and confirm)
+- for each id: `headFile(r2Key)` → object exists (else 400
+  `"File was not uploaded"`), `ContentLength === sizeBytes`,
+  `ContentType === mimeType` (belt-and-braces on top of the signed headers)
+
+Side effects, in order:
+
+1. flip each confirmed entry `PENDING → UPLOADING`
+   (positional `updateOne`, same pattern the worker uses)
+2. enqueue the **existing** `MediaUploadQueue.addMediaUploadJob` with
+   `{ postId, connectedAccountId, ownerUrn, items }` — job shape, worker,
+   retries, FAILED handling, R2 cleanup all unchanged
+3. respond `202` with the same body shape as today's media endpoint
+   (`"Media upload started"` + the entries), so the client's polling logic
+   from `docs/async-media-upload-handoff.md` applies verbatim from here on
+
+Partial confirms are allowed (confirm the images that made it, re-initiate the
+one that failed) **except**: a batch containing the post's single video must be
+confirmed whole, and mixing is impossible because initiate rejects it.
+
+### Old endpoint
+
+`PUT /posts/:id/media` (multipart) is kept as-is during migration and removed
+in a later release once the client has switched. Its `UPLOADING`-in-progress
+409 also considers unexpired `PENDING` entries, and vice versa, so the two
+paths can't interleave on one post.
+
+## Abandoned slots
+
+Two independent reapers, both required:
+
+1. **Lazy purge (Mongo):** any entry with `status: 'PENDING'` and
+   `pendingExpiresAt < now` is deleted from `post.media[]` whenever it gets in
+   the way — on initiate, on confirm, and in the publish guard. No cron needed.
+2. **R2 lifecycle rule (infra, one-time):** expire objects under the
+   `media-uploads/` prefix after **2 days**. Catches objects whose PUT
+   succeeded but whose confirm never came, plus any leaked staging objects
+   from the current flow. A healthy upload is deleted by the worker within
+   minutes, so nothing legitimate is old enough to be reaped.
+
+## Publish guard changes
+
+In `publishOnLinkedIn`:
+
+- unexpired `PENDING` or `UPLOADING` → `409` (same message as today)
+- expired `PENDING` → lazily purged, does not block
+- `FAILED` → excluded from payload (unchanged)
+
+## Code changes
+
+| File | Change |
+|---|---|
+| `src/s3/s3.client.ts` | `getSignedUploadUrl(key, mimeType, sizeBytes, expiresIn)` — presign `PutObjectCommand` with signed `ContentType`/`ContentLength`; `headFile(key): Promise<{ sizeBytes; mimeType }>` via `HeadObjectCommand` |
+| `src/database/schemas/post-draft.schema.ts` | media status enum + `'PENDING'`; optional `mimeType`, `sizeBytes`, `pendingExpiresAt` on the subdoc |
+| `src/post/dto/` | `InitiateMediaUploadDto` (`files[]`, class-validator: `@IsMimeType`-style allowlist, `@Max(200 MB)`, `@ArrayMaxSize(20)`), `CompleteMediaUploadDto` (`mediaIds[]`) |
+| `src/post/post.controller.ts` | two new JSON routes (no multer); old multipart route untouched |
+| `src/post/post.service.ts` | `initiateMediaUpload`, `completeMediaUpload`, shared `purgeExpiredPendingMedia(post)`; extend the in-progress checks; publish guard tweak |
+| `src/post/*.spec.ts`, `src/s3/s3.client.spec.ts` | specs for all of the above per CLAUDE.md conventions |
+
+Not touched: `media-upload.queue.ts`, `linkedin-media.service.ts`, the worker,
+the `FAILED`/retry semantics, `GET /posts/:id` polling contract.
+
+## Infra prerequisites (before client rollout)
+
+1. **R2 bucket CORS** — required or every browser PUT fails preflight:
+
+```json
+[
+  {
+    "AllowedOrigins": ["https://<app-domain>", "http://localhost:3000"],
+    "AllowedMethods": ["PUT"],
+    "AllowedHeaders": ["Content-Type", "Content-Length"],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+2. **R2 lifecycle rule** — expire `media-uploads/` prefix after 2 days.
+
+## Client-facing changes (handoff delta)
+
+- Replace the single multipart request with: initiate → parallel PUTs to R2
+  (native `fetch`/XHR gives real per-file progress, which multipart never did)
+  → complete. Everything after the 202 (polling, statuses, publish gating,
+  FAILED recovery) is identical to the current handoff doc.
+- New states to render: `PENDING` (treat like `UPLOADING` in the UI), slot
+  expiry (`409` on complete → re-initiate).
+- On a failed/interrupted PUT: just re-initiate; the abandoned slot expires
+  on its own.
+
+## Risks / notes
+
+- **Trust boundary moves**: type/size are enforced by the signed headers +
+  Head check, but the server never sees the bytes, so it can no longer sniff
+  actual file content. Mitigation if ever needed: magic-byte check in the
+  worker after `getFile` (it has the buffer anyway) → mark `FAILED`.
+- **Two more round-trips** per upload; negligible next to the transfer itself.
+- **Orphaned `PENDING` entries** are visible in `GET /posts/:id` until purged;
+  the client should hide expired `PENDING` entries (or we filter them out of
+  the GET response server-side — decide during implementation).
+- Rollout order: infra (CORS + lifecycle) → server endpoints (old route still
+  live) → client switch → remove multipart route.

--- a/src/database/schemas/post-draft.schema.ts
+++ b/src/database/schemas/post-draft.schema.ts
@@ -51,6 +51,11 @@ export class PostDraft extends Document {
         type: { type: String, enum: ['IMAGE', 'VIDEO'], required: true },
         title: { type: String },
         altText: { type: String },
+        status: {
+          type: String,
+          enum: ['UPLOADING', 'READY', 'FAILED'],
+          default: 'READY',
+        },
       },
     ]),
   )
@@ -59,6 +64,7 @@ export class PostDraft extends Document {
     type: 'IMAGE' | 'VIDEO';
     title?: string;
     altText?: string;
+    status?: 'UPLOADING' | 'READY' | 'FAILED';
   }[];
 
   @Prop({ type: Array<object> })

--- a/src/database/schemas/post-draft.schema.ts
+++ b/src/database/schemas/post-draft.schema.ts
@@ -53,9 +53,12 @@ export class PostDraft extends Document {
         altText: { type: String },
         status: {
           type: String,
-          enum: ['UPLOADING', 'READY', 'FAILED'],
+          enum: ['PENDING', 'UPLOADING', 'READY', 'FAILED'],
           default: 'READY',
         },
+        mimeType: { type: String },
+        sizeBytes: { type: Number },
+        pendingExpiresAt: { type: Date },
       },
     ]),
   )
@@ -64,7 +67,10 @@ export class PostDraft extends Document {
     type: 'IMAGE' | 'VIDEO';
     title?: string;
     altText?: string;
-    status?: 'UPLOADING' | 'READY' | 'FAILED';
+    status?: 'PENDING' | 'UPLOADING' | 'READY' | 'FAILED';
+    mimeType?: string;
+    sizeBytes?: number;
+    pendingExpiresAt?: Date;
   }[];
 
   @Prop({ type: Array<object> })

--- a/src/post/dto/complete-media-upload.dto.ts
+++ b/src/post/dto/complete-media-upload.dto.ts
@@ -1,0 +1,10 @@
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsString } from 'class-validator';
+import { MAX_MEDIA_FILES_PER_UPLOAD } from './initiate-media-upload.dto';
+
+export class CompleteMediaUploadDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(MAX_MEDIA_FILES_PER_UPLOAD)
+  @IsString({ each: true })
+  mediaIds: string[];
+}

--- a/src/post/dto/index.ts
+++ b/src/post/dto/index.ts
@@ -1,2 +1,4 @@
 export * from './update-post.dto';
 export * from './schedule-post.dto';
+export * from './initiate-media-upload.dto';
+export * from './complete-media-upload.dto';

--- a/src/post/dto/initiate-media-upload.dto.ts
+++ b/src/post/dto/initiate-media-upload.dto.ts
@@ -1,0 +1,41 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export const MAX_MEDIA_FILE_SIZE_BYTES = 200 * 1024 * 1024;
+export const MAX_MEDIA_FILES_PER_UPLOAD = 20;
+
+export class MediaUploadFileDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  fileName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  mimeType: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(MAX_MEDIA_FILE_SIZE_BYTES)
+  sizeBytes: number;
+}
+
+export class InitiateMediaUploadDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(MAX_MEDIA_FILES_PER_UPLOAD)
+  @ValidateNested({ each: true })
+  @Type(() => MediaUploadFileDto)
+  files: MediaUploadFileDto[];
+}

--- a/src/post/linkedin-media.service.spec.ts
+++ b/src/post/linkedin-media.service.spec.ts
@@ -1,0 +1,308 @@
+jest.mock(
+  'src/database/schemas',
+  () => ({
+    ConnectedAccount: { name: 'ConnectedAccount' },
+    PostDraft: { name: 'PostDraft' },
+  }),
+  { virtual: true },
+);
+jest.mock(
+  'src/common/HelperFn/apiFetch.helper',
+  () => ({
+    apiFetch: jest.fn(),
+    ApiError: class ApiError extends Error {
+      constructor(
+        public statusCode: number,
+        public statusText: string,
+        public data: any,
+      ) {
+        super(`HTTP error! status: ${statusCode} ${statusText}`);
+      }
+    },
+  }),
+  { virtual: true },
+);
+jest.mock(
+  'src/common/HelperFn',
+  () => ({ delay: jest.fn().mockResolvedValue(undefined) }),
+  { virtual: true },
+);
+jest.mock(
+  'src/encryption/encryption.service',
+  () => ({ EncryptionService: class EncryptionService {} }),
+  { virtual: true },
+);
+jest.mock(
+  'src/s3',
+  () => ({
+    getFile: jest.fn(),
+    deleteFile: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+import { Types } from 'mongoose';
+import { LinkedinMediaService } from './linkedin-media.service';
+import { apiFetch } from 'src/common/HelperFn/apiFetch.helper';
+import { deleteFile, getFile } from 'src/s3';
+
+const makeService = () => {
+  (deleteFile as jest.Mock).mockResolvedValue(undefined);
+  const postDraftModel = {
+    findById: jest.fn(),
+    exists: jest.fn(),
+    updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+  };
+  const connectedAccountModel = {
+    findById: jest.fn(),
+  };
+  const encryptionService = {
+    decrypt: jest.fn().mockResolvedValue('token'),
+  };
+  const service = new LinkedinMediaService(
+    postDraftModel as any,
+    connectedAccountModel as any,
+    encryptionService as any,
+  );
+
+  const postId = new Types.ObjectId().toString();
+  const connectedAccountId = new Types.ObjectId().toString();
+  const fixtures = {
+    jobData: {
+      postId,
+      connectedAccountId,
+      ownerUrn: 'urn:li:person:abc',
+      items: [
+        {
+          mediaId: 'media-1',
+          r2Key: `media-uploads/${postId}/media-1`,
+          mediaType: 'IMAGE' as const,
+        },
+      ],
+    },
+    post: { _id: postId, media: [{ id: 'media-1', status: 'UPLOADING' }] },
+    connectedAccount: { accessToken: 'encrypted-token' },
+  };
+
+  return {
+    service,
+    mocks: { postDraftModel, connectedAccountModel, encryptionService },
+    fixtures,
+  };
+};
+
+let service: LinkedinMediaService;
+let mocks: ReturnType<typeof makeService>['mocks'];
+let fixtures: ReturnType<typeof makeService>['fixtures'];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ({ service, mocks, fixtures } = makeService());
+});
+
+describe('LinkedinMediaService', () => {
+  describe('processMediaUpload', () => {
+    it('should upload pending media, mark it READY, and delete the R2 object when the job runs', async () => {
+      mocks.postDraftModel.findById.mockResolvedValue(fixtures.post);
+      mocks.connectedAccountModel.findById.mockResolvedValue(
+        fixtures.connectedAccount,
+      );
+      mocks.postDraftModel.exists.mockResolvedValue({ _id: 'x' });
+      (getFile as jest.Mock).mockResolvedValue(Buffer.from('image-bytes'));
+      const uploadImage = jest
+        .spyOn(service, 'uploadImage')
+        .mockResolvedValue('urn:li:image:1');
+
+      await service.processMediaUpload(fixtures.jobData);
+
+      expect(getFile).toHaveBeenCalledWith(fixtures.jobData.items[0].r2Key);
+      expect(uploadImage).toHaveBeenCalledWith(
+        'urn:li:person:abc',
+        'token',
+        Buffer.from('image-bytes'),
+      );
+      expect(mocks.postDraftModel.updateOne).toHaveBeenCalledWith(
+        { _id: fixtures.jobData.postId, 'media.id': 'media-1' },
+        { $set: { 'media.$.id': 'urn:li:image:1', 'media.$.status': 'READY' } },
+      );
+      expect(deleteFile).toHaveBeenCalledWith(fixtures.jobData.items[0].r2Key);
+    });
+
+    it('should use the video upload path when mediaType is VIDEO', async () => {
+      fixtures.jobData.items[0].mediaType = 'VIDEO' as any;
+      mocks.postDraftModel.findById.mockResolvedValue(fixtures.post);
+      mocks.connectedAccountModel.findById.mockResolvedValue(
+        fixtures.connectedAccount,
+      );
+      mocks.postDraftModel.exists.mockResolvedValue({ _id: 'x' });
+      (getFile as jest.Mock).mockResolvedValue(Buffer.from('video-bytes'));
+      const uploadVideo = jest
+        .spyOn(service, 'uploadVideo')
+        .mockResolvedValue('urn:li:video:1');
+
+      await service.processMediaUpload(fixtures.jobData);
+
+      expect(uploadVideo).toHaveBeenCalledTimes(1);
+      expect(mocks.postDraftModel.updateOne).toHaveBeenCalledWith(
+        { _id: fixtures.jobData.postId, 'media.id': 'media-1' },
+        { $set: { 'media.$.id': 'urn:li:video:1', 'media.$.status': 'READY' } },
+      );
+    });
+
+    it('should skip items whose media entry no longer exists when retrying', async () => {
+      mocks.postDraftModel.findById.mockResolvedValue(fixtures.post);
+      mocks.connectedAccountModel.findById.mockResolvedValue(
+        fixtures.connectedAccount,
+      );
+      mocks.postDraftModel.exists.mockResolvedValue(null);
+
+      await service.processMediaUpload(fixtures.jobData);
+
+      expect(getFile).not.toHaveBeenCalled();
+      expect(mocks.postDraftModel.updateOne).not.toHaveBeenCalled();
+    });
+
+    it('should discard the job and delete R2 objects when the post is gone', async () => {
+      mocks.postDraftModel.findById.mockResolvedValue(null);
+
+      await service.processMediaUpload(fixtures.jobData);
+
+      expect(deleteFile).toHaveBeenCalledWith(fixtures.jobData.items[0].r2Key);
+      expect(mocks.connectedAccountModel.findById).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the connected account has no access token', async () => {
+      mocks.postDraftModel.findById.mockResolvedValue(fixtures.post);
+      mocks.connectedAccountModel.findById.mockResolvedValue({
+        accessToken: null,
+      });
+
+      await expect(
+        service.processMediaUpload(fixtures.jobData),
+      ).rejects.toThrow('missing or has no access token');
+    });
+  });
+
+  describe('handleMediaUploadFailure', () => {
+    it('should mark items FAILED and delete R2 objects when retries are exhausted', async () => {
+      await service.handleMediaUploadFailure(fixtures.jobData);
+
+      expect(mocks.postDraftModel.updateOne).toHaveBeenCalledWith(
+        { _id: fixtures.jobData.postId, 'media.id': 'media-1' },
+        { $set: { 'media.$.status': 'FAILED' } },
+      );
+      expect(deleteFile).toHaveBeenCalledWith(fixtures.jobData.items[0].r2Key);
+    });
+  });
+
+  describe('uploadImage', () => {
+    it('should initialize the upload, PUT the buffer, and return the image urn when successful', async () => {
+      const mockedApiFetch = apiFetch as jest.Mock;
+      mockedApiFetch
+        .mockResolvedValueOnce({
+          data: {
+            value: {
+              uploadUrl: 'https://upload.example.com/img',
+              image: 'urn:li:image:9',
+            },
+          },
+        })
+        .mockResolvedValueOnce({ data: {}, response: {} });
+
+      const fileBuffer = Buffer.from('image-bytes');
+      const urn = await service.uploadImage(
+        'urn:li:person:abc',
+        'token',
+        fileBuffer,
+      );
+
+      expect(urn).toBe('urn:li:image:9');
+      const [putUrl, putOptions] = mockedApiFetch.mock.calls[1];
+      expect(putUrl).toBe('https://upload.example.com/img');
+      expect(putOptions.method).toBe('PUT');
+      expect(putOptions.body).toBe(fileBuffer);
+      expect(putOptions.headers.Authorization).toBe('Bearer token');
+    });
+  });
+
+  describe('uploadVideo', () => {
+    const initResponse = {
+      data: {
+        value: {
+          video: 'urn:li:video:1',
+          uploadToken: 'upload-token',
+          uploadInstructions: [
+            { uploadUrl: 'https://u1', firstByte: 0, lastByte: 3 },
+            { uploadUrl: 'https://u2', firstByte: 4, lastByte: 7 },
+          ],
+        },
+      },
+    };
+
+    it('should upload chunks, strip ETag quotes, finalize, and poll until available when successful', async () => {
+      const mockedApiFetch = apiFetch as jest.Mock;
+      mockedApiFetch
+        .mockResolvedValueOnce(initResponse)
+        .mockResolvedValueOnce({
+          response: { headers: { get: jest.fn().mockReturnValue('"etag-1"') } },
+        })
+        .mockResolvedValueOnce({
+          response: { headers: { get: jest.fn().mockReturnValue('"etag-2"') } },
+        })
+        .mockResolvedValueOnce({ data: {}, response: {} })
+        .mockResolvedValueOnce({ data: { status: 'AVAILABLE' } });
+
+      const fileBuffer = Buffer.from('abcdefgh');
+      const urn = await service.uploadVideo(
+        'urn:li:person:abc',
+        'token',
+        fileBuffer,
+      );
+
+      expect(urn).toBe('urn:li:video:1');
+      expect(mockedApiFetch.mock.calls[1][1].body).toEqual(Buffer.from('abcd'));
+      expect(mockedApiFetch.mock.calls[2][1].body).toEqual(Buffer.from('efgh'));
+      const finalizeBody = JSON.parse(mockedApiFetch.mock.calls[3][1].body);
+      expect(finalizeBody.finalizeUploadRequest.uploadedPartIds).toEqual([
+        'etag-1',
+        'etag-2',
+      ]);
+    });
+
+    it('should throw when a chunk response has no ETag', async () => {
+      const mockedApiFetch = apiFetch as jest.Mock;
+      mockedApiFetch.mockResolvedValueOnce(initResponse).mockResolvedValueOnce({
+        response: { headers: { get: jest.fn().mockReturnValue(null) } },
+      });
+
+      await expect(
+        service.uploadVideo('urn:li:person:abc', 'token', Buffer.from('abcd')),
+      ).rejects.toThrow('did not return an ETag');
+    });
+
+    it('should throw when video processing fails', async () => {
+      const mockedApiFetch = apiFetch as jest.Mock;
+      mockedApiFetch
+        .mockResolvedValueOnce({
+          data: {
+            value: {
+              video: 'urn:li:video:1',
+              uploadToken: 'upload-token',
+              uploadInstructions: [
+                { uploadUrl: 'https://u1', firstByte: 0, lastByte: 3 },
+              ],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          response: { headers: { get: jest.fn().mockReturnValue('etag-1') } },
+        })
+        .mockResolvedValueOnce({ data: {}, response: {} })
+        .mockResolvedValueOnce({ data: { status: 'PROCESSING_FAILED' } });
+
+      await expect(
+        service.uploadVideo('urn:li:person:abc', 'token', Buffer.from('abcd')),
+      ).rejects.toThrow('LinkedIn video processing failed');
+    });
+  });
+});

--- a/src/post/linkedin-media.service.ts
+++ b/src/post/linkedin-media.service.ts
@@ -1,0 +1,276 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ConnectedAccount, PostDraft } from 'src/database/schemas';
+import { EncryptionService } from 'src/encryption/encryption.service';
+import { ApiError, apiFetch } from 'src/common/HelperFn/apiFetch.helper';
+import { delay } from 'src/common/HelperFn';
+import { deleteFile, getFile } from 'src/s3';
+import { IVideoInitResponse } from './post.interface';
+import {
+  MediaUploadJobData,
+  MediaUploadJobItem,
+} from '../workflow/media-upload.queue';
+
+@Injectable()
+export class LinkedinMediaService {
+  private readonly logger = new Logger(LinkedinMediaService.name);
+  private readonly LINKEDIN_API_BASE = 'https://api.linkedin.com/rest';
+
+  constructor(
+    @InjectModel(PostDraft.name)
+    private readonly postDraftModel: Model<PostDraft>,
+    @InjectModel(ConnectedAccount.name)
+    private readonly connectedAccountModel: Model<ConnectedAccount>,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  async processMediaUpload(data: MediaUploadJobData): Promise<void> {
+    const { postId, connectedAccountId, ownerUrn, items } = data;
+
+    const post = await this.postDraftModel.findById(postId);
+    if (!post) {
+      this.logger.warn(
+        `Post ${postId} no longer exists; discarding media upload job`,
+      );
+      await this.deleteR2Objects(items);
+      return;
+    }
+
+    const connectedAccount =
+      await this.connectedAccountModel.findById(connectedAccountId);
+    if (!connectedAccount?.accessToken) {
+      throw new Error(
+        `Connected account ${connectedAccountId} is missing or has no access token`,
+      );
+    }
+
+    const accessToken = await this.encryptionService.decrypt(
+      connectedAccount.accessToken,
+    );
+
+    for (const item of items) {
+      const pending = await this.postDraftModel.exists({
+        _id: postId,
+        'media.id': item.mediaId,
+      });
+      if (!pending) continue;
+
+      const fileBuffer = await getFile(item.r2Key);
+      const urn =
+        item.mediaType === 'VIDEO'
+          ? await this.uploadVideo(ownerUrn, accessToken, fileBuffer)
+          : await this.uploadImage(ownerUrn, accessToken, fileBuffer);
+
+      await this.postDraftModel.updateOne(
+        { _id: postId, 'media.id': item.mediaId },
+        { $set: { 'media.$.id': urn, 'media.$.status': 'READY' } },
+      );
+
+      await deleteFile(item.r2Key).catch((error) =>
+        this.logger.warn(
+          `Failed to delete R2 object ${item.r2Key}: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+    }
+  }
+
+  async handleMediaUploadFailure(data: MediaUploadJobData): Promise<void> {
+    for (const item of data.items) {
+      await this.postDraftModel
+        .updateOne(
+          { _id: data.postId, 'media.id': item.mediaId },
+          { $set: { 'media.$.status': 'FAILED' } },
+        )
+        .catch((error) =>
+          this.logger.error(
+            `Failed to mark media ${item.mediaId} as FAILED: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
+    }
+    await this.deleteR2Objects(data.items);
+  }
+
+  private async deleteR2Objects(items: MediaUploadJobItem[]): Promise<void> {
+    await Promise.allSettled(
+      items.map((item) =>
+        deleteFile(item.r2Key).catch((error) =>
+          this.logger.warn(
+            `Failed to delete R2 object ${item.r2Key}: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        ),
+      ),
+    );
+  }
+
+  async uploadImage(
+    ownerUrn: string,
+    accessToken: string,
+    fileBuffer: Buffer,
+  ): Promise<string> {
+    interface IResponse {
+      value: {
+        uploadUrlExpiresAt: number;
+        uploadUrl: string;
+        image: string;
+      };
+    }
+    try {
+      const initializeUploadRequest = await apiFetch<IResponse>(
+        `${this.LINKEDIN_API_BASE}/images?action=initializeUpload`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Restli-Protocol-Version': '2.0.0',
+            'LinkedIn-Version': '202601',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({
+            initializeUploadRequest: {
+              owner: ownerUrn,
+            },
+          }),
+        },
+      );
+
+      await apiFetch(initializeUploadRequest.data.value.uploadUrl, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'LinkedIn-Version': '202601',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: fileBuffer as unknown as BodyInit,
+      });
+
+      return initializeUploadRequest.data.value.image;
+    } catch (error) {
+      const message: unknown =
+        error instanceof ApiError
+          ? (error.data as { message?: unknown } | undefined)?.message
+          : undefined;
+      if (
+        error instanceof ApiError &&
+        error.statusCode === 400 &&
+        typeof message === 'string' &&
+        message.includes('Organization permissions must be used')
+      ) {
+        throw new BadRequestException(
+          'Your LinkedIn account needs to be reconnected to enable company page posting. Please disconnect and reconnect your LinkedIn account.',
+        );
+      }
+      throw error;
+    }
+  }
+
+  async uploadVideo(
+    ownerUrn: string,
+    accessToken: string,
+    fileBuffer: Buffer,
+  ): Promise<string> {
+    const linkedinHeaders = {
+      'Content-Type': 'application/json',
+      'X-Restli-Protocol-Version': '2.0.0',
+      'LinkedIn-Version': '202601',
+      Authorization: `Bearer ${accessToken}`,
+    };
+
+    const initRes = await apiFetch<IVideoInitResponse>(
+      `${this.LINKEDIN_API_BASE}/videos?action=initializeUpload`,
+      {
+        method: 'POST',
+        headers: linkedinHeaders,
+        body: JSON.stringify({
+          initializeUploadRequest: {
+            owner: ownerUrn,
+            fileSizeBytes: fileBuffer.length,
+            uploadCaptions: false,
+            uploadThumbnail: false,
+          },
+        }),
+      },
+    );
+
+    const {
+      video: videoUrn,
+      uploadToken,
+      uploadInstructions,
+    } = initRes.data.value;
+
+    const eTags: string[] = [];
+    for (const instruction of uploadInstructions) {
+      const chunk = fileBuffer.subarray(
+        instruction.firstByte,
+        instruction.lastByte + 1,
+      );
+      const { response } = await apiFetch<void>(instruction.uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: chunk as unknown as BodyInit,
+      });
+      const etag = response.headers.get('etag') ?? response.headers.get('ETag');
+      if (!etag) {
+        throw new InternalServerErrorException(
+          'LinkedIn video chunk upload did not return an ETag',
+        );
+      }
+      eTags.push(etag.replaceAll('"', ''));
+    }
+
+    await apiFetch(`${this.LINKEDIN_API_BASE}/videos?action=finalizeUpload`, {
+      method: 'POST',
+      headers: linkedinHeaders,
+      body: JSON.stringify({
+        finalizeUploadRequest: {
+          video: videoUrn,
+          uploadToken,
+          uploadedPartIds: eTags,
+        },
+      }),
+    });
+
+    await this.waitForVideoAvailable(videoUrn, accessToken);
+    return videoUrn;
+  }
+
+  private async waitForVideoAvailable(
+    videoUrn: string,
+    accessToken: string,
+    timeoutMs = 300_000,
+  ): Promise<void> {
+    const encodedUrn = encodeURIComponent(videoUrn);
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      await delay(3000);
+      const { data } = await apiFetch<{ status: string }>(
+        `${this.LINKEDIN_API_BASE}/videos/${encodedUrn}`,
+        {
+          method: 'GET',
+          headers: {
+            'X-Restli-Protocol-Version': '2.0.0',
+            'LinkedIn-Version': '202601',
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+
+      if (data.status === 'AVAILABLE') return;
+      if (data.status === 'PROCESSING_FAILED') {
+        throw new InternalServerErrorException(
+          'LinkedIn video processing failed',
+        );
+      }
+    }
+
+    throw new InternalServerErrorException(
+      'Timed out waiting for LinkedIn video to become available',
+    );
+  }
+}

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -16,7 +16,12 @@ import {
 } from '@nestjs/common';
 import { PostService } from './post.service';
 import { InputDto } from '../agent/dto';
-import { UpdatePostDto, SchedulePostDto } from './dto';
+import {
+  UpdatePostDto,
+  SchedulePostDto,
+  InitiateMediaUploadDto,
+  CompleteMediaUploadDto,
+} from './dto';
 import { SubscriptionAccessGuard } from '../common/guards';
 import { ClerkAuthGuard } from '../auth/clerk';
 import { IAppResponse } from 'src/common/interfaces';
@@ -72,6 +77,34 @@ export class PostController {
       statusCode: HttpStatus.ACCEPTED,
       message: 'Media upload started',
       data: await this.postService.addLinkedinMedia(user, id, files),
+    };
+  }
+
+  @HttpCode(HttpStatus.CREATED)
+  @Post(':id/media/uploads')
+  async initiateMediaUpload(
+    @GetUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: InitiateMediaUploadDto,
+  ): Promise<IAppResponse> {
+    return {
+      statusCode: HttpStatus.CREATED,
+      message: 'Upload slots created',
+      data: await this.postService.initiateMediaUpload(user, id, dto),
+    };
+  }
+
+  @HttpCode(HttpStatus.ACCEPTED)
+  @Post(':id/media/uploads/complete')
+  async completeMediaUpload(
+    @GetUser() user: User,
+    @Param('id') id: string,
+    @Body() dto: CompleteMediaUploadDto,
+  ): Promise<IAppResponse> {
+    return {
+      statusCode: HttpStatus.ACCEPTED,
+      message: 'Media upload started',
+      data: await this.postService.completeMediaUpload(user, id, dto),
     };
   }
 

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -48,6 +48,7 @@ export class PostController {
     };
   }
 
+  @HttpCode(HttpStatus.ACCEPTED)
   @Put(':id/media')
   @UseInterceptors(
     FilesInterceptor('files', 20, {
@@ -67,10 +68,10 @@ export class PostController {
     @Param('id') id: string,
     @UploadedFiles() files: Express.Multer.File[],
   ): Promise<IAppResponse> {
-    await this.postService.addLinkedinMedia(user, id, files);
     return {
-      statusCode: HttpStatus.OK,
-      message: 'Media uploaded successfully',
+      statusCode: HttpStatus.ACCEPTED,
+      message: 'Media upload started',
+      data: await this.postService.addLinkedinMedia(user, id, files),
     };
   }
 

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { PostController } from './post.controller';
 import { PostService } from './post.service';
+import { LinkedinMediaService } from './linkedin-media.service';
 import { WorkflowModule } from '../workflow/workflow.module';
 import { FeatureGatingModule } from '../feature-gating';
 
 @Module({
   imports: [WorkflowModule, FeatureGatingModule],
   controllers: [PostController],
-  providers: [PostService],
+  providers: [PostService, LinkedinMediaService],
+  exports: [LinkedinMediaService],
 })
 export class PostModule {}

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -39,6 +39,8 @@ jest.mock(
   () => ({
     uploadFile: jest.fn(),
     deleteFile: jest.fn(),
+    getSignedUploadUrl: jest.fn(),
+    headFile: jest.fn(),
   }),
   { virtual: true },
 );
@@ -48,7 +50,7 @@ jest.mock('fs/promises', () => ({
 }));
 
 import { PostService } from './post.service';
-import { deleteFile, uploadFile } from 'src/s3';
+import { deleteFile, getSignedUploadUrl, headFile, uploadFile } from 'src/s3';
 import { unlink } from 'fs/promises';
 import { apiFetch } from 'src/common/HelperFn/apiFetch.helper';
 import { formatLinkedinContent } from 'src/common/HelperFn';
@@ -734,6 +736,85 @@ describe('PostService.publishOnLinkedIn', () => {
     expect(mocks.mockedApiFetch).not.toHaveBeenCalled();
   });
 
+  it('should reject publishing when a pending upload slot has not expired', async () => {
+    const { service, mocks } = createService();
+    const userId = new Types.ObjectId();
+    const postId = new Types.ObjectId();
+    const post = {
+      _id: postId,
+      user: userId,
+      connectedAccount: new Types.ObjectId(),
+      status: 'DRAFT',
+      content: 'with media',
+      media: [
+        {
+          id: 'media-1',
+          type: 'IMAGE',
+          status: 'PENDING',
+          pendingExpiresAt: new Date(Date.now() + 60_000),
+        },
+      ],
+      save: mocks.save,
+    } as any;
+    mocks.findById.mockResolvedValue(post);
+    mocks.findConnectedAccountById.mockResolvedValue({
+      user: userId,
+      provider: 'LINKEDIN',
+      isActive: true,
+      accessToken: 'encrypted-token',
+      accountType: 'PERSON',
+      impersonatorUrn: 'urn:li:person:abc',
+      profileMetadata: {},
+    });
+
+    await expect(
+      service.publishOnLinkedIn({ _id: userId } as any, postId.toString()),
+    ).rejects.toThrow('Media uploads are still in progress');
+    expect(mocks.mockedApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('should purge expired pending slots and publish without them', async () => {
+    const { service, mocks } = createService();
+    const userId = new Types.ObjectId();
+    const postId = new Types.ObjectId();
+    const post = {
+      _id: postId,
+      user: userId,
+      connectedAccount: new Types.ObjectId(),
+      status: 'DRAFT',
+      content: 'with media',
+      media: [
+        { id: 'urn:li:image:1', title: 'ok', type: 'IMAGE', status: 'READY' },
+        {
+          id: 'media-2',
+          type: 'IMAGE',
+          status: 'PENDING',
+          pendingExpiresAt: new Date(Date.now() - 60_000),
+        },
+      ],
+      save: mocks.save,
+    } as any;
+    mocks.findById.mockResolvedValue(post);
+    mocks.findConnectedAccountById.mockResolvedValue({
+      user: userId,
+      provider: 'LINKEDIN',
+      isActive: true,
+      accessToken: 'encrypted-token',
+      accountType: 'PERSON',
+      impersonatorUrn: 'urn:li:person:abc',
+      profileMetadata: {},
+    });
+
+    await service.publishOnLinkedIn({ _id: userId } as any, postId.toString());
+
+    expect(post.media).toHaveLength(1);
+    const request = mocks.mockedApiFetch.mock.calls[0][1];
+    const body = JSON.parse(request.body);
+    expect(body.content).toEqual({
+      media: { id: 'urn:li:image:1', title: 'ok' },
+    });
+  });
+
   it('should exclude failed media from the publish payload', async () => {
     const { service, mocks } = createService();
     const userId = new Types.ObjectId();
@@ -1169,5 +1250,405 @@ describe('PostService.addLinkedinMedia', () => {
     expect(deleteFile).toHaveBeenCalledWith(firstKey);
     expect(mocks.addMediaUploadJob).not.toHaveBeenCalled();
     expect(mocks.save).not.toHaveBeenCalled();
+  });
+});
+
+const createMediaUploadService = () => {
+  const service = Object.create(PostService.prototype) as PostService;
+  const findById = jest.fn();
+  const save = jest.fn().mockResolvedValue(undefined);
+  const markModified = jest.fn();
+  const findConnectedAccountById = jest.fn();
+  const addMediaUploadJob = jest.fn().mockResolvedValue(undefined);
+
+  (service as any).postDraftModel = { findById };
+  (service as any).connectedAccountModel = {
+    findById: findConnectedAccountById,
+  };
+  (service as any).mediaUploadQueue = { addMediaUploadJob };
+  (service as any).MEDIA_UPLOAD_SLOT_TTL_MS = 30 * 60 * 1000;
+
+  const userId = new Types.ObjectId();
+  const postId = new Types.ObjectId();
+  const connectedAccountId = new Types.ObjectId();
+  const post = {
+    _id: postId,
+    user: userId,
+    connectedAccount: connectedAccountId,
+    status: 'DRAFT',
+    media: [] as any[],
+    save,
+    markModified,
+  } as any;
+  const connectedAccount = {
+    user: userId,
+    provider: 'LINKEDIN',
+    isActive: true,
+    accessToken: 'encrypted-token',
+    accountType: 'PERSON',
+    profileMetadata: { sub: 'abc' },
+  };
+  findById.mockResolvedValue(post);
+  findConnectedAccountById.mockResolvedValue(connectedAccount);
+
+  return {
+    service,
+    mocks: {
+      findById,
+      save,
+      markModified,
+      findConnectedAccountById,
+      addMediaUploadJob,
+    },
+    fixtures: { userId, postId, connectedAccountId, post, connectedAccount },
+  };
+};
+
+describe('PostService.initiateMediaUpload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSignedUploadUrl as jest.Mock).mockResolvedValue(
+      'https://r2-signed/put',
+    );
+  });
+
+  const imageDto = (fileName = 'a.jpg') => ({
+    fileName,
+    mimeType: 'image/jpeg',
+    sizeBytes: 1024,
+  });
+
+  it('should create presigned slots and append PENDING media when files are valid', async () => {
+    const { service, mocks, fixtures } = createMediaUploadService();
+
+    const result = await service.initiateMediaUpload(
+      { _id: fixtures.userId } as any,
+      fixtures.postId.toString(),
+      { files: [imageDto()] } as any,
+    );
+
+    expect(getSignedUploadUrl).toHaveBeenCalledTimes(1);
+    const [r2Key, mimeType, sizeBytes, expiresIn] = (
+      getSignedUploadUrl as jest.Mock
+    ).mock.calls[0];
+    expect(r2Key).toMatch(
+      new RegExp(`^media-uploads/${fixtures.postId.toString()}/`),
+    );
+    expect(mimeType).toBe('image/jpeg');
+    expect(sizeBytes).toBe(1024);
+    expect(expiresIn).toBe(1800);
+
+    expect(result.uploads).toHaveLength(1);
+    expect(result.uploads[0]).toMatchObject({
+      uploadUrl: 'https://r2-signed/put',
+      requiredHeaders: {
+        'Content-Type': 'image/jpeg',
+        'Content-Length': '1024',
+      },
+    });
+    expect(result.expiresAt).toBeInstanceOf(Date);
+
+    expect(fixtures.post.media).toHaveLength(1);
+    expect(fixtures.post.media[0]).toMatchObject({
+      id: result.uploads[0].mediaId,
+      type: 'IMAGE',
+      title: 'a.jpg',
+      status: 'PENDING',
+      mimeType: 'image/jpeg',
+      sizeBytes: 1024,
+    });
+    expect(fixtures.post.media[0].pendingExpiresAt).toBeInstanceOf(Date);
+    expect(mocks.save).toHaveBeenCalledTimes(1);
+    expect(mocks.addMediaUploadJob).not.toHaveBeenCalled();
+  });
+
+  it('should mark video slots as VIDEO without altText when a video is declared', async () => {
+    const { service, fixtures } = createMediaUploadService();
+
+    await service.initiateMediaUpload(
+      { _id: fixtures.userId } as any,
+      fixtures.postId.toString(),
+      {
+        files: [{ fileName: 'v.mp4', mimeType: 'video/mp4', sizeBytes: 5000 }],
+      } as any,
+    );
+
+    expect(fixtures.post.media[0]).toMatchObject({
+      type: 'VIDEO',
+      title: 'v.mp4',
+      altText: undefined,
+      status: 'PENDING',
+    });
+  });
+
+  it('should reject when images and videos are mixed', async () => {
+    const { service, fixtures } = createMediaUploadService();
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        {
+          files: [
+            imageDto(),
+            { fileName: 'v.mp4', mimeType: 'video/mp4', sizeBytes: 1 },
+          ],
+        } as any,
+      ),
+    ).rejects.toThrow('Cannot mix images and videos in one post');
+    expect(getSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('should reject when more than one video is declared', async () => {
+    const { service, fixtures } = createMediaUploadService();
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        {
+          files: [
+            { fileName: 'a.mp4', mimeType: 'video/mp4', sizeBytes: 1 },
+            { fileName: 'b.mp4', mimeType: 'video/mp4', sizeBytes: 1 },
+          ],
+        } as any,
+      ),
+    ).rejects.toThrow('Only one video per post is allowed');
+  });
+
+  it('should reject an unsupported file type', async () => {
+    const { service, fixtures } = createMediaUploadService();
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        {
+          files: [
+            { fileName: 'a.pdf', mimeType: 'application/pdf', sizeBytes: 1 },
+          ],
+        } as any,
+      ),
+    ).rejects.toThrow('Unsupported file type: application/pdf');
+  });
+
+  it('should reject a non-JPEG/PNG image format', async () => {
+    const { service, fixtures } = createMediaUploadService();
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        {
+          files: [{ fileName: 'a.gif', mimeType: 'image/gif', sizeBytes: 1 }],
+        } as any,
+      ),
+    ).rejects.toThrow('Unsupported image format: image/gif. Use JPEG or PNG');
+  });
+
+  it('should reject when a media upload is already in progress', async () => {
+    const { service, fixtures } = createMediaUploadService();
+    fixtures.post.media = [
+      { id: 'media-1', type: 'IMAGE', status: 'UPLOADING' },
+    ];
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { files: [imageDto()] } as any,
+      ),
+    ).rejects.toThrow('A media upload is already in progress for this post');
+  });
+
+  it('should reject when an unexpired pending slot exists', async () => {
+    const { service, fixtures } = createMediaUploadService();
+    fixtures.post.media = [
+      {
+        id: 'media-1',
+        type: 'IMAGE',
+        status: 'PENDING',
+        pendingExpiresAt: new Date(Date.now() + 60_000),
+      },
+    ];
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { files: [imageDto()] } as any,
+      ),
+    ).rejects.toThrow('A media upload is already in progress for this post');
+  });
+
+  it('should purge expired pending slots and proceed', async () => {
+    const { service, mocks, fixtures } = createMediaUploadService();
+    fixtures.post.media = [
+      {
+        id: 'stale-1',
+        type: 'IMAGE',
+        status: 'PENDING',
+        pendingExpiresAt: new Date(Date.now() - 60_000),
+      },
+    ];
+
+    const result = await service.initiateMediaUpload(
+      { _id: fixtures.userId } as any,
+      fixtures.postId.toString(),
+      { files: [imageDto()] } as any,
+    );
+
+    expect(result.uploads).toHaveLength(1);
+    expect(fixtures.post.media).toHaveLength(1);
+    expect(fixtures.post.media[0].id).toBe(result.uploads[0].mediaId);
+    expect(mocks.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject when the post is not owned by the user', async () => {
+    const { service, fixtures } = createMediaUploadService();
+
+    await expect(
+      service.initiateMediaUpload(
+        { _id: new Types.ObjectId() } as any,
+        fixtures.postId.toString(),
+        { files: [imageDto()] } as any,
+      ),
+    ).rejects.toThrow('You are not authorized to edit this post');
+  });
+});
+
+describe('PostService.completeMediaUpload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (headFile as jest.Mock).mockResolvedValue({
+      sizeBytes: 1024,
+      mimeType: 'image/jpeg',
+    });
+  });
+
+  const pendingEntry = (id = 'media-1') => ({
+    id,
+    type: 'IMAGE',
+    title: 'a.jpg',
+    status: 'PENDING',
+    mimeType: 'image/jpeg',
+    sizeBytes: 1024,
+    pendingExpiresAt: new Date(Date.now() + 60_000),
+  });
+
+  it('should verify the uploaded file, flip the entry to UPLOADING, and enqueue a job', async () => {
+    const { service, mocks, fixtures } = createMediaUploadService();
+    fixtures.post.media = [pendingEntry()];
+
+    const result = await service.completeMediaUpload(
+      { _id: fixtures.userId } as any,
+      fixtures.postId.toString(),
+      { mediaIds: ['media-1'] } as any,
+    );
+
+    const expectedKey = `media-uploads/${fixtures.postId.toString()}/media-1`;
+    expect(headFile).toHaveBeenCalledWith(expectedKey);
+    expect(fixtures.post.media[0].status).toBe('UPLOADING');
+    expect(mocks.save).toHaveBeenCalledTimes(1);
+    expect(mocks.addMediaUploadJob).toHaveBeenCalledWith({
+      postId: fixtures.postId.toString(),
+      connectedAccountId: fixtures.connectedAccountId.toString(),
+      ownerUrn: 'urn:li:person:abc',
+      items: [{ mediaId: 'media-1', r2Key: expectedKey, mediaType: 'IMAGE' }],
+    });
+    expect(result).toEqual([fixtures.post.media[0]]);
+  });
+
+  it('should reject an unknown media id', async () => {
+    const { service, mocks, fixtures } = createMediaUploadService();
+    fixtures.post.media = [pendingEntry()];
+
+    await expect(
+      service.completeMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { mediaIds: ['nope'] } as any,
+      ),
+    ).rejects.toThrow('Unknown media id: nope');
+    expect(mocks.addMediaUploadJob).not.toHaveBeenCalled();
+  });
+
+  it('should reject a media entry that is not awaiting confirmation', async () => {
+    const { service, fixtures } = createMediaUploadService();
+    fixtures.post.media = [{ ...pendingEntry(), status: 'READY' }];
+
+    await expect(
+      service.completeMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { mediaIds: ['media-1'] } as any,
+      ),
+    ).rejects.toThrow('Media media-1 is not awaiting upload confirmation');
+  });
+
+  it('should reject when the upload slot has expired', async () => {
+    const { service, fixtures } = createMediaUploadService();
+    fixtures.post.media = [
+      { ...pendingEntry(), pendingExpiresAt: new Date(Date.now() - 60_000) },
+    ];
+
+    await expect(
+      service.completeMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { mediaIds: ['media-1'] } as any,
+      ),
+    ).rejects.toThrow('Upload slot expired. Re-initiate the upload.');
+  });
+
+  it('should reject when the file was never uploaded to R2', async () => {
+    const { service, mocks, fixtures } = createMediaUploadService();
+    fixtures.post.media = [pendingEntry()];
+    (headFile as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      service.completeMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { mediaIds: ['media-1'] } as any,
+      ),
+    ).rejects.toThrow('File for media media-1 was not uploaded');
+    expect(mocks.save).not.toHaveBeenCalled();
+    expect(mocks.addMediaUploadJob).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the uploaded file size does not match the declared size', async () => {
+    const { service, fixtures } = createMediaUploadService();
+    fixtures.post.media = [pendingEntry()];
+    (headFile as jest.Mock).mockResolvedValue({
+      sizeBytes: 999,
+      mimeType: 'image/jpeg',
+    });
+
+    await expect(
+      service.completeMediaUpload(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        { mediaIds: ['media-1'] } as any,
+      ),
+    ).rejects.toThrow(
+      'Uploaded file for media media-1 does not match the declared size or type',
+    );
+  });
+
+  it('should deduplicate repeated media ids in the request', async () => {
+    const { service, mocks, fixtures } = createMediaUploadService();
+    fixtures.post.media = [pendingEntry()];
+
+    await service.completeMediaUpload(
+      { _id: fixtures.userId } as any,
+      fixtures.postId.toString(),
+      { mediaIds: ['media-1', 'media-1'] } as any,
+    );
+
+    expect(headFile).toHaveBeenCalledTimes(1);
+    expect(
+      (mocks.addMediaUploadJob as jest.Mock).mock.calls[0][0].items,
+    ).toHaveLength(1);
   });
 });

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -34,8 +34,22 @@ jest.mock(
   () => ({ FeatureGatingService: class FeatureGatingService {} }),
   { virtual: true },
 );
+jest.mock(
+  'src/s3',
+  () => ({
+    uploadFile: jest.fn(),
+    deleteFile: jest.fn(),
+  }),
+  { virtual: true },
+);
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn().mockResolvedValue(Buffer.from('file-bytes')),
+  unlink: jest.fn().mockResolvedValue(undefined),
+}));
 
 import { PostService } from './post.service';
+import { deleteFile, uploadFile } from 'src/s3';
+import { unlink } from 'fs/promises';
 import { apiFetch } from 'src/common/HelperFn/apiFetch.helper';
 import { formatLinkedinContent } from 'src/common/HelperFn';
 
@@ -92,9 +106,7 @@ describe('PostService.getPosts', () => {
     );
 
     expect(mocks.find).toHaveBeenCalledTimes(1);
-    expect(mocks.select).toHaveBeenCalledWith(
-      '-userIntent -compressionResult -youtubeResearch',
-    );
+    expect(mocks.select).toHaveBeenCalledWith('-userIntent -compressionResult');
     expect(mocks.lean).toHaveBeenCalledTimes(1);
     const filter = mocks.find.mock.calls[0][0];
     expect(filter.user).toEqual(userId);
@@ -692,6 +704,75 @@ describe('PostService.publishOnLinkedIn', () => {
     expect(body.commentary).toBe('text only');
   });
 
+  it('should reject publishing when media uploads are still in progress', async () => {
+    const { service, mocks } = createService();
+    const userId = new Types.ObjectId();
+    const postId = new Types.ObjectId();
+    const post = {
+      _id: postId,
+      user: userId,
+      connectedAccount: new Types.ObjectId(),
+      status: 'DRAFT',
+      content: 'with media',
+      media: [{ id: 'media-1', type: 'IMAGE', status: 'UPLOADING' }],
+      save: mocks.save,
+    } as any;
+    mocks.findById.mockResolvedValue(post);
+    mocks.findConnectedAccountById.mockResolvedValue({
+      user: userId,
+      provider: 'LINKEDIN',
+      isActive: true,
+      accessToken: 'encrypted-token',
+      accountType: 'PERSON',
+      impersonatorUrn: 'urn:li:person:abc',
+      profileMetadata: {},
+    });
+
+    await expect(
+      service.publishOnLinkedIn({ _id: userId } as any, postId.toString()),
+    ).rejects.toThrow('Media uploads are still in progress');
+    expect(mocks.mockedApiFetch).not.toHaveBeenCalled();
+  });
+
+  it('should exclude failed media from the publish payload', async () => {
+    const { service, mocks } = createService();
+    const userId = new Types.ObjectId();
+    const postId = new Types.ObjectId();
+    const post = {
+      _id: postId,
+      user: userId,
+      connectedAccount: new Types.ObjectId(),
+      status: 'DRAFT',
+      content: 'with media',
+      media: [
+        { id: 'urn:li:image:1', title: 'ok', type: 'IMAGE', status: 'READY' },
+        { id: 'media-2', title: 'broken', type: 'IMAGE', status: 'FAILED' },
+      ],
+      save: mocks.save,
+    } as any;
+    mocks.findById.mockResolvedValue(post);
+    mocks.findConnectedAccountById.mockResolvedValue({
+      user: userId,
+      provider: 'LINKEDIN',
+      isActive: true,
+      accessToken: 'encrypted-token',
+      accountType: 'PERSON',
+      impersonatorUrn: 'urn:li:person:abc',
+      profileMetadata: {},
+    });
+
+    await service.publishOnLinkedIn({ _id: userId } as any, postId.toString());
+
+    const request = mocks.mockedApiFetch.mock.calls[0][1];
+    const body = JSON.parse(request.body);
+    expect(body.content).toEqual({
+      media: {
+        id: 'urn:li:image:1',
+        title: 'ok',
+      },
+    });
+  });
+
   it('includes media payload when media exists', async () => {
     const { service, mocks } = createService();
     const userId = new Types.ObjectId();
@@ -936,5 +1017,157 @@ describe('PostService.deletePost', () => {
       'Reconnect account to delete published posts from LinkedIn safely.',
     );
     expect(mocks.deleteOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('PostService.addLinkedinMedia', () => {
+  const createService = () => {
+    const service = Object.create(PostService.prototype) as PostService;
+    const findById = jest.fn();
+    const save = jest.fn().mockResolvedValue(undefined);
+    const findConnectedAccountById = jest.fn();
+    const addMediaUploadJob = jest.fn().mockResolvedValue(undefined);
+
+    (service as any).postDraftModel = { findById };
+    (service as any).connectedAccountModel = {
+      findById: findConnectedAccountById,
+    };
+    (service as any).mediaUploadQueue = { addMediaUploadJob };
+
+    const userId = new Types.ObjectId();
+    const postId = new Types.ObjectId();
+    const connectedAccountId = new Types.ObjectId();
+    const post = {
+      _id: postId,
+      user: userId,
+      connectedAccount: connectedAccountId,
+      status: 'DRAFT',
+      media: [],
+      save,
+    } as any;
+    const connectedAccount = {
+      user: userId,
+      provider: 'LINKEDIN',
+      isActive: true,
+      accessToken: 'encrypted-token',
+      accountType: 'PERSON',
+      profileMetadata: { sub: 'abc' },
+    };
+
+    return {
+      service,
+      mocks: { findById, save, findConnectedAccountById, addMediaUploadJob },
+      fixtures: { userId, postId, connectedAccountId, post, connectedAccount },
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const imageFile = (name: string) =>
+    ({
+      path: `/tmp/${name}`,
+      mimetype: 'image/jpeg',
+      originalname: name,
+    }) as any;
+
+  it('should upload files to R2, append UPLOADING media, and enqueue a job when files are valid', async () => {
+    const { service, mocks, fixtures } = createService();
+    mocks.findById.mockResolvedValue(fixtures.post);
+    mocks.findConnectedAccountById.mockResolvedValue(fixtures.connectedAccount);
+    (uploadFile as jest.Mock).mockResolvedValue('https://r2/url');
+
+    const result = await service.addLinkedinMedia(
+      { _id: fixtures.userId } as any,
+      fixtures.postId.toString(),
+      [imageFile('a.jpg')],
+    );
+
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    const [r2Key, body, mimeType] = (uploadFile as jest.Mock).mock.calls[0];
+    expect(r2Key).toMatch(
+      new RegExp(`^media-uploads/${fixtures.postId.toString()}/`),
+    );
+    expect(body).toEqual(Buffer.from('file-bytes'));
+    expect(mimeType).toBe('image/jpeg');
+
+    expect(mocks.addMediaUploadJob).toHaveBeenCalledWith({
+      postId: fixtures.postId.toString(),
+      connectedAccountId: fixtures.connectedAccountId.toString(),
+      ownerUrn: 'urn:li:person:abc',
+      items: [expect.objectContaining({ r2Key, mediaType: 'IMAGE' })],
+    });
+
+    expect(fixtures.post.media).toHaveLength(1);
+    expect(fixtures.post.media[0]).toMatchObject({
+      type: 'IMAGE',
+      title: 'a.jpg',
+      status: 'UPLOADING',
+    });
+    expect(mocks.save).toHaveBeenCalledTimes(1);
+    expect(unlink).toHaveBeenCalledWith('/tmp/a.jpg');
+    expect(result).toEqual(fixtures.post.media);
+  });
+
+  it('should reject when a media upload is already in progress', async () => {
+    const { service, mocks, fixtures } = createService();
+    fixtures.post.media = [
+      { id: 'media-1', type: 'IMAGE', status: 'UPLOADING' },
+    ];
+    mocks.findById.mockResolvedValue(fixtures.post);
+
+    await expect(
+      service.addLinkedinMedia(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        [imageFile('a.jpg')],
+      ),
+    ).rejects.toThrow('A media upload is already in progress for this post');
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(mocks.addMediaUploadJob).not.toHaveBeenCalled();
+  });
+
+  it('should reject when images and videos are mixed', async () => {
+    const { service, mocks, fixtures } = createService();
+    mocks.findById.mockResolvedValue(fixtures.post);
+
+    await expect(
+      service.addLinkedinMedia(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        [
+          imageFile('a.jpg'),
+          {
+            path: '/tmp/b.mp4',
+            mimetype: 'video/mp4',
+            originalname: 'b.mp4',
+          } as any,
+        ],
+      ),
+    ).rejects.toThrow('Cannot mix images and videos in one post');
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('should delete already-uploaded R2 objects when a later upload fails', async () => {
+    const { service, mocks, fixtures } = createService();
+    mocks.findById.mockResolvedValue(fixtures.post);
+    mocks.findConnectedAccountById.mockResolvedValue(fixtures.connectedAccount);
+    (uploadFile as jest.Mock)
+      .mockResolvedValueOnce('https://r2/url')
+      .mockRejectedValueOnce(new Error('R2 unavailable'));
+
+    await expect(
+      service.addLinkedinMedia(
+        { _id: fixtures.userId } as any,
+        fixtures.postId.toString(),
+        [imageFile('a.jpg'), imageFile('b.jpg')],
+      ),
+    ).rejects.toThrow('R2 unavailable');
+
+    const firstKey = (uploadFile as jest.Mock).mock.calls[0][0];
+    expect(deleteFile).toHaveBeenCalledWith(firstKey);
+    expect(mocks.addMediaUploadJob).not.toHaveBeenCalled();
+    expect(mocks.save).not.toHaveBeenCalled();
   });
 });

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -14,7 +14,12 @@ import {
   MediaUploadQueue,
 } from '../workflow/media-upload.queue';
 import { InputDto } from '../agent/dto';
-import { UpdatePostDto, SchedulePostDto } from './dto';
+import {
+  UpdatePostDto,
+  SchedulePostDto,
+  InitiateMediaUploadDto,
+  CompleteMediaUploadDto,
+} from './dto';
 import {
   AccountProvider,
   ConnectedAccount,
@@ -32,7 +37,7 @@ import { formatLinkedinContent } from 'src/common/HelperFn';
 import { FeatureGatingService } from '../feature-gating/feature-gating.service';
 import { readFile, unlink } from 'fs/promises';
 import { randomUUID } from 'crypto';
-import { deleteFile, uploadFile } from 'src/s3';
+import { deleteFile, getSignedUploadUrl, headFile, uploadFile } from 'src/s3';
 
 interface PostFilters {
   availableMonths: string[];
@@ -44,10 +49,13 @@ export interface GetPostsResult {
   filters: PostFilters;
 }
 
+type PostMediaEntry = NonNullable<PostDraft['media']>[number];
+
 @Injectable()
 export class PostService {
   private readonly logger = new Logger(PostService.name);
   private readonly LINKEDIN_API_BASE = 'https://api.linkedin.com/rest';
+  private readonly MEDIA_UPLOAD_SLOT_TTL_MS = 30 * 60 * 1000;
 
   constructor(
     private readonly workflowQueue: WorkflowQueue,
@@ -280,7 +288,8 @@ export class PostService {
       connectedAccount.accessToken!,
     );
 
-    if ((post.media ?? []).some((m) => m.status === 'UPLOADING')) {
+    this.purgeExpiredPendingMedia(post);
+    if (this.hasMediaUploadInProgress(post)) {
       throw new ConflictException(
         'Media uploads are still in progress. Try again shortly.',
       );
@@ -473,7 +482,8 @@ export class PostService {
         }
       }
 
-      if ((post.media ?? []).some((m) => m.status === 'UPLOADING')) {
+      this.purgeExpiredPendingMedia(post);
+      if (this.hasMediaUploadInProgress(post)) {
         throw new ConflictException(
           'A media upload is already in progress for this post',
         );
@@ -530,6 +540,216 @@ export class PostService {
       return newMediaItems;
     } finally {
       await Promise.allSettled(files.map((f) => unlink(f.path)));
+    }
+  }
+
+  async initiateMediaUpload(
+    user: User,
+    postId: string,
+    dto: InitiateMediaUploadDto,
+  ) {
+    const post = await this.getOwnedEditablePost(user, postId);
+
+    const imageFiles = dto.files.filter((f) => f.mimeType.startsWith('image/'));
+    const videoFiles = dto.files.filter((f) => f.mimeType.startsWith('video/'));
+
+    if (imageFiles.length + videoFiles.length !== dto.files.length) {
+      const unsupported = dto.files.find(
+        (f) =>
+          !f.mimeType.startsWith('image/') && !f.mimeType.startsWith('video/'),
+      );
+      throw new BadRequestException(
+        `Unsupported file type: ${unsupported?.mimeType}`,
+      );
+    }
+    if (imageFiles.length > 0 && videoFiles.length > 0) {
+      throw new BadRequestException('Cannot mix images and videos in one post');
+    }
+    if (videoFiles.length > 1) {
+      throw new BadRequestException('Only one video per post is allowed');
+    }
+
+    const allowedImageMimes = new Set(['image/jpeg', 'image/png']);
+    for (const f of imageFiles) {
+      if (!allowedImageMimes.has(f.mimeType)) {
+        throw new BadRequestException(
+          `Unsupported image format: ${f.mimeType}. Use JPEG or PNG`,
+        );
+      }
+    }
+
+    this.purgeExpiredPendingMedia(post);
+    if (this.hasMediaUploadInProgress(post)) {
+      throw new ConflictException(
+        'A media upload is already in progress for this post',
+      );
+    }
+
+    await this.getOwnedUsableLinkedinConnectedAccount(
+      user._id.toString(),
+      post.connectedAccount.toString(),
+      'upload media',
+    );
+
+    const isVideo = videoFiles.length === 1;
+    const expiresAt = new Date(Date.now() + this.MEDIA_UPLOAD_SLOT_TTL_MS);
+    const ttlSeconds = Math.floor(this.MEDIA_UPLOAD_SLOT_TTL_MS / 1000);
+
+    const newMediaItems: PostMediaEntry[] = [];
+    const uploads: {
+      mediaId: string;
+      uploadUrl: string;
+      requiredHeaders: Record<string, string>;
+    }[] = [];
+
+    for (const file of dto.files) {
+      const mediaId = randomUUID();
+      const r2Key = `media-uploads/${postId}/${mediaId}`;
+      const uploadUrl = await getSignedUploadUrl(
+        r2Key,
+        file.mimeType,
+        file.sizeBytes,
+        ttlSeconds,
+      );
+
+      uploads.push({
+        mediaId,
+        uploadUrl,
+        requiredHeaders: {
+          'Content-Type': file.mimeType,
+          'Content-Length': String(file.sizeBytes),
+        },
+      });
+      newMediaItems.push({
+        id: mediaId,
+        type: isVideo ? 'VIDEO' : 'IMAGE',
+        title: file.fileName,
+        altText: isVideo ? undefined : file.fileName,
+        status: 'PENDING',
+        mimeType: file.mimeType,
+        sizeBytes: file.sizeBytes,
+        pendingExpiresAt: expiresAt,
+      });
+    }
+
+    post.media = [...(post.media ?? []), ...newMediaItems];
+    await post.save();
+
+    return { expiresAt, uploads };
+  }
+
+  async completeMediaUpload(
+    user: User,
+    postId: string,
+    dto: CompleteMediaUploadDto,
+  ) {
+    const post = await this.getOwnedEditablePost(user, postId);
+    const now = Date.now();
+
+    const mediaIds = [...new Set(dto.mediaIds)];
+    const entries: PostMediaEntry[] = [];
+    for (const mediaId of mediaIds) {
+      const entry = (post.media ?? []).find((m) => m.id === mediaId);
+      if (!entry) {
+        throw new NotFoundException(`Unknown media id: ${mediaId}`);
+      }
+      if (entry.status !== 'PENDING') {
+        throw new ConflictException(
+          `Media ${mediaId} is not awaiting upload confirmation`,
+        );
+      }
+      if (!entry.pendingExpiresAt || entry.pendingExpiresAt.getTime() <= now) {
+        throw new ConflictException(
+          'Upload slot expired. Re-initiate the upload.',
+        );
+      }
+      entries.push(entry);
+    }
+
+    const connectedAccount = await this.getOwnedUsableLinkedinConnectedAccount(
+      user._id.toString(),
+      post.connectedAccount.toString(),
+      'upload media',
+    );
+    const ownerUrn = this.resolveLinkedinAuthorUrn(connectedAccount);
+
+    const jobItems: MediaUploadJobItem[] = [];
+    for (const entry of entries) {
+      const r2Key = `media-uploads/${postId}/${entry.id}`;
+      const head = await headFile(r2Key);
+      if (!head) {
+        throw new BadRequestException(
+          `File for media ${entry.id} was not uploaded`,
+        );
+      }
+      if (
+        head.sizeBytes !== entry.sizeBytes ||
+        (head.mimeType && head.mimeType !== entry.mimeType)
+      ) {
+        throw new BadRequestException(
+          `Uploaded file for media ${entry.id} does not match the declared size or type`,
+        );
+      }
+      jobItems.push({
+        mediaId: entry.id,
+        r2Key,
+        mediaType: entry.type,
+      });
+    }
+
+    for (const entry of entries) {
+      entry.status = 'UPLOADING';
+      entry.pendingExpiresAt = undefined;
+    }
+    this.purgeExpiredPendingMedia(post);
+    post.markModified('media');
+    await post.save();
+
+    await this.mediaUploadQueue.addMediaUploadJob({
+      postId,
+      connectedAccountId: post.connectedAccount.toString(),
+      ownerUrn,
+      items: jobItems,
+    });
+
+    return entries;
+  }
+
+  private async getOwnedEditablePost(user: User, postId: string) {
+    const post = await this.postDraftModel.findById(postId);
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+    if (post.user.toString() !== user._id.toString()) {
+      throw new ForbiddenException('You are not authorized to edit this post');
+    }
+    if (post.status === PostDraftStatus.PUBLISHED) {
+      throw new BadRequestException('Post is already published');
+    }
+    return post;
+  }
+
+  private hasMediaUploadInProgress(post: PostDraft): boolean {
+    const now = Date.now();
+    return (post.media ?? []).some(
+      (m) =>
+        m.status === 'UPLOADING' ||
+        (m.status === 'PENDING' &&
+          !!m.pendingExpiresAt &&
+          m.pendingExpiresAt.getTime() > now),
+    );
+  }
+
+  private purgeExpiredPendingMedia(post: PostDraft): void {
+    const now = Date.now();
+    const media = post.media ?? [];
+    const kept = media.filter(
+      (m) =>
+        m.status !== 'PENDING' ||
+        (!!m.pendingExpiresAt && m.pendingExpiresAt.getTime() > now),
+    );
+    if (kept.length !== media.length) {
+      post.media = kept;
     }
   }
 

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -9,6 +9,10 @@ import {
 } from '@nestjs/common';
 import { WorkflowQueue } from '../workflow/workflow.queue';
 import { ScheduleQueue } from '../workflow/schedule.queue';
+import {
+  MediaUploadJobItem,
+  MediaUploadQueue,
+} from '../workflow/media-upload.queue';
 import { InputDto } from '../agent/dto';
 import { UpdatePostDto, SchedulePostDto } from './dto';
 import {
@@ -23,10 +27,12 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { ApiError, apiFetch } from 'src/common/HelperFn/apiFetch.helper';
 import { EncryptionService } from 'src/encryption/encryption.service';
-import { IContent, ILinkedInPost, IVideoInitResponse } from './post.interface';
-import { delay, formatLinkedinContent } from 'src/common/HelperFn';
+import { IContent, ILinkedInPost } from './post.interface';
+import { formatLinkedinContent } from 'src/common/HelperFn';
 import { FeatureGatingService } from '../feature-gating/feature-gating.service';
-import { open, readFile, unlink } from 'fs/promises';
+import { readFile, unlink } from 'fs/promises';
+import { randomUUID } from 'crypto';
+import { deleteFile, uploadFile } from 'src/s3';
 
 interface PostFilters {
   availableMonths: string[];
@@ -46,6 +52,7 @@ export class PostService {
   constructor(
     private readonly workflowQueue: WorkflowQueue,
     private readonly scheduleQueue: ScheduleQueue,
+    private readonly mediaUploadQueue: MediaUploadQueue,
     @InjectModel(PostDraft.name)
     private readonly postDraftModel: Model<PostDraft>,
     @InjectModel(ConnectedAccount.name)
@@ -273,9 +280,18 @@ export class PostService {
       connectedAccount.accessToken!,
     );
 
+    if ((post.media ?? []).some((m) => m.status === 'UPLOADING')) {
+      throw new ConflictException(
+        'Media uploads are still in progress. Try again shortly.',
+      );
+    }
+
     const url = `${this.LINKEDIN_API_BASE}/posts`;
-    const images = (post.media ?? []).filter((m) => m.type === 'IMAGE');
-    const videos = (post.media ?? []).filter((m) => m.type === 'VIDEO');
+    const usableMedia = (post.media ?? []).filter(
+      (m) => !m.status || m.status === 'READY',
+    );
+    const images = usableMedia.filter((m) => m.type === 'IMAGE');
+    const videos = usableMedia.filter((m) => m.type === 'VIDEO');
 
     let content: IContent | undefined;
     if (videos.length === 1) {
@@ -457,6 +473,12 @@ export class PostService {
         }
       }
 
+      if ((post.media ?? []).some((m) => m.status === 'UPLOADING')) {
+        throw new ConflictException(
+          'A media upload is already in progress for this post',
+        );
+      }
+
       const connectedAccount =
         await this.getOwnedUsableLinkedinConnectedAccount(
           user._id.toString(),
@@ -464,213 +486,51 @@ export class PostService {
           'upload media',
         );
 
-      const accessToken = await this.encryptionService.decrypt(
-        connectedAccount.accessToken!,
-      );
-
       const ownerUrn = this.resolveLinkedinAuthorUrn(connectedAccount);
-      const newMediaItems: NonNullable<typeof post.media> = [];
+      const isVideo = videoFiles.length === 1;
+      const filesToUpload = isVideo ? videoFiles : imageFiles;
 
-      if (videoFiles.length === 1) {
-        const urn = await this.uploadLinkedinVideo(
-          ownerUrn,
-          accessToken,
-          videoFiles[0],
-        );
-        newMediaItems.push({
-          id: urn,
-          type: 'VIDEO',
-          title: videoFiles[0].originalname,
-        });
-      } else {
-        for (const file of imageFiles) {
-          const urn = await this.uploadLinkedinImage(
-            ownerUrn,
-            accessToken,
-            file,
-          );
+      const newMediaItems: NonNullable<typeof post.media> = [];
+      const jobItems: MediaUploadJobItem[] = [];
+      try {
+        for (const file of filesToUpload) {
+          const mediaId = randomUUID();
+          const r2Key = `media-uploads/${postId}/${mediaId}`;
+          await uploadFile(r2Key, await readFile(file.path), file.mimetype);
+          jobItems.push({
+            mediaId,
+            r2Key,
+            mediaType: isVideo ? 'VIDEO' : 'IMAGE',
+          });
           newMediaItems.push({
-            id: urn,
-            type: 'IMAGE',
+            id: mediaId,
+            type: isVideo ? 'VIDEO' : 'IMAGE',
             title: file.originalname,
-            altText: file.originalname,
+            altText: isVideo ? undefined : file.originalname,
+            status: 'UPLOADING',
           });
         }
+      } catch (error) {
+        await Promise.allSettled(
+          jobItems.map((item) => deleteFile(item.r2Key)),
+        );
+        throw error;
       }
 
       post.media = [...(post.media ?? []), ...newMediaItems];
       await post.save();
+
+      await this.mediaUploadQueue.addMediaUploadJob({
+        postId,
+        connectedAccountId: post.connectedAccount.toString(),
+        ownerUrn,
+        items: jobItems,
+      });
+
+      return newMediaItems;
     } finally {
       await Promise.allSettled(files.map((f) => unlink(f.path)));
     }
-  }
-
-  private async uploadLinkedinImage(
-    urn: string,
-    accessToken: string,
-    file: Express.Multer.File,
-  ) {
-    interface IResponse {
-      value: {
-        uploadUrlExpiresAt: number;
-        uploadUrl: string;
-        image: string;
-      };
-    }
-    try {
-      const initializeUploadRequest = await apiFetch<IResponse>(
-        `${this.LINKEDIN_API_BASE}/images?action=initializeUpload`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Restli-Protocol-Version': '2.0.0',
-            'LinkedIn-Version': '202601',
-            Authorization: `Bearer ${accessToken}`,
-          },
-          body: JSON.stringify({
-            initializeUploadRequest: {
-              owner: urn,
-            },
-          }),
-        },
-      );
-
-      await apiFetch(initializeUploadRequest.data.value.uploadUrl, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/octet-stream',
-          'LinkedIn-Version': '202601',
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: await readFile(file.path),
-      });
-
-      return initializeUploadRequest.data.value.image;
-    } catch (error) {
-      if (
-        error instanceof ApiError &&
-        error.statusCode === 400 &&
-        typeof error.data?.message === 'string' &&
-        error.data.message.includes('Organization permissions must be used')
-      ) {
-        throw new BadRequestException(
-          'Your LinkedIn account needs to be reconnected to enable company page posting. Please disconnect and reconnect your LinkedIn account.',
-        );
-      }
-      throw error;
-    }
-  }
-
-  private async uploadLinkedinVideo(
-    ownerUrn: string,
-    accessToken: string,
-    file: Express.Multer.File,
-  ): Promise<string> {
-    const CHUNK_SIZE = 4_194_304;
-    const linkedinHeaders = {
-      'Content-Type': 'application/json',
-      'X-Restli-Protocol-Version': '2.0.0',
-      'LinkedIn-Version': '202601',
-      Authorization: `Bearer ${accessToken}`,
-    };
-
-    const initRes = await apiFetch<IVideoInitResponse>(
-      `${this.LINKEDIN_API_BASE}/videos?action=initializeUpload`,
-      {
-        method: 'POST',
-        headers: linkedinHeaders,
-        body: JSON.stringify({
-          initializeUploadRequest: {
-            owner: ownerUrn,
-            fileSizeBytes: file.size,
-            uploadCaptions: false,
-            uploadThumbnail: false,
-          },
-        }),
-      },
-    );
-
-    const {
-      video: videoUrn,
-      uploadToken,
-      uploadInstructions,
-    } = initRes.data.value;
-
-    const eTags: string[] = [];
-    const fileHandle = await open(file.path, 'r');
-    try {
-      for (const instruction of uploadInstructions) {
-        const chunkLength = instruction.lastByte - instruction.firstByte + 1;
-        const chunk = Buffer.alloc(chunkLength);
-        await fileHandle.read(chunk, 0, chunkLength, instruction.firstByte);
-        const { response } = await apiFetch<void>(instruction.uploadUrl, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/octet-stream' },
-          body: chunk,
-        });
-        const etag =
-          response.headers.get('etag') ?? response.headers.get('ETag');
-        if (!etag) {
-          throw new InternalServerErrorException(
-            'LinkedIn video chunk upload did not return an ETag',
-          );
-        }
-        eTags.push(etag.replaceAll('"', ''));
-      }
-    } finally {
-      await fileHandle.close();
-    }
-
-    await apiFetch(`${this.LINKEDIN_API_BASE}/videos?action=finalizeUpload`, {
-      method: 'POST',
-      headers: linkedinHeaders,
-      body: JSON.stringify({
-        finalizeUploadRequest: {
-          video: videoUrn,
-          uploadToken,
-          uploadedPartIds: eTags,
-        },
-      }),
-    });
-
-    await this.waitForVideoAvailable(videoUrn, accessToken);
-    return videoUrn;
-  }
-
-  private async waitForVideoAvailable(
-    videoUrn: string,
-    accessToken: string,
-    timeoutMs = 60_000,
-  ): Promise<void> {
-    const encodedUrn = encodeURIComponent(videoUrn);
-    const deadline = Date.now() + timeoutMs;
-
-    while (Date.now() < deadline) {
-      await delay(3000);
-      const { data } = await apiFetch<{ status: string }>(
-        `${this.LINKEDIN_API_BASE}/videos/${encodedUrn}`,
-        {
-          method: 'GET',
-          headers: {
-            'X-Restli-Protocol-Version': '2.0.0',
-            'LinkedIn-Version': '202601',
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-      );
-
-      if (data.status === 'AVAILABLE') return;
-      if (data.status === 'PROCESSING_FAILED') {
-        throw new InternalServerErrorException(
-          'LinkedIn video processing failed',
-        );
-      }
-    }
-
-    throw new InternalServerErrorException(
-      'Timed out waiting for LinkedIn video to become available',
-    );
   }
 
   async getLinkedinImage(user: User, urn: string) {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -26,9 +26,7 @@ import { EncryptionService } from 'src/encryption/encryption.service';
 import { IContent, ILinkedInPost, IVideoInitResponse } from './post.interface';
 import { delay, formatLinkedinContent } from 'src/common/HelperFn';
 import { FeatureGatingService } from '../feature-gating/feature-gating.service';
-import { createReadStream } from 'fs';
-import { unlink } from 'fs/promises';
-import { Readable } from 'stream';
+import { open, readFile, unlink } from 'fs/promises';
 
 interface PostFilters {
   availableMonths: string[];
@@ -545,8 +543,7 @@ export class PostService {
           'LinkedIn-Version': '202601',
           Authorization: `Bearer ${accessToken}`,
         },
-        body: Readable.toWeb(createReadStream(file.path)) as any,
-        ...({ duplex: 'half' } as any),
+        body: await readFile(file.path),
       });
 
       return initializeUploadRequest.data.value.image;
@@ -601,26 +598,28 @@ export class PostService {
     } = initRes.data.value;
 
     const eTags: string[] = [];
-    for (const instruction of uploadInstructions) {
-      const chunk = Readable.toWeb(
-        createReadStream(file.path, {
-          start: instruction.firstByte,
-          end: instruction.lastByte,
-        }),
-      );
-      const { response } = await apiFetch<void>(instruction.uploadUrl, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/octet-stream' },
-        body: chunk as any,
-        ...({ duplex: 'half' } as any),
-      });
-      const etag = response.headers.get('etag') ?? response.headers.get('ETag');
-      if (!etag) {
-        throw new InternalServerErrorException(
-          'LinkedIn video chunk upload did not return an ETag',
-        );
+    const fileHandle = await open(file.path, 'r');
+    try {
+      for (const instruction of uploadInstructions) {
+        const chunkLength = instruction.lastByte - instruction.firstByte + 1;
+        const chunk = Buffer.alloc(chunkLength);
+        await fileHandle.read(chunk, 0, chunkLength, instruction.firstByte);
+        const { response } = await apiFetch<void>(instruction.uploadUrl, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/octet-stream' },
+          body: chunk,
+        });
+        const etag =
+          response.headers.get('etag') ?? response.headers.get('ETag');
+        if (!etag) {
+          throw new InternalServerErrorException(
+            'LinkedIn video chunk upload did not return an ETag',
+          );
+        }
+        eTags.push(etag.replaceAll('"', ''));
       }
-      eTags.push(etag);
+    } finally {
+      await fileHandle.close();
     }
 
     await apiFetch(`${this.LINKEDIN_API_BASE}/videos?action=finalizeUpload`, {

--- a/src/s3/s3.client.spec.ts
+++ b/src/s3/s3.client.spec.ts
@@ -28,6 +28,7 @@ import {
 import { getSignedUrl as awsGetSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
   uploadFile,
+  getFile,
   deleteFile,
   getSignedUrl,
   __resetClient,
@@ -115,6 +116,39 @@ describe('S3 client', () => {
       await expect(
         uploadFile('key', Buffer.from(''), 'text/plain'),
       ).rejects.toThrow('upload failed');
+    });
+  });
+
+  describe('getFile', () => {
+    it('should send GetObjectCommand and return the object body as a Buffer', async () => {
+      const key = 'media-uploads/post1/media-1';
+      mockSend.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: jest
+            .fn()
+            .mockResolvedValue(new Uint8Array([1, 2, 3])),
+        },
+      });
+
+      const result = await getFile(key);
+
+      expect(GetObjectCommand).toHaveBeenCalledWith({
+        Bucket: BUCKET,
+        Key: key,
+      });
+      expect(result).toEqual(Buffer.from([1, 2, 3]));
+    });
+
+    it('should throw when the object has no body', async () => {
+      mockSend.mockResolvedValueOnce({ Body: undefined });
+      await expect(getFile('some/key')).rejects.toThrow(
+        'R2 object "some/key" has no body',
+      );
+    });
+
+    it('should propagate errors from the S3 send call', async () => {
+      mockSend.mockRejectedValueOnce(new Error('get failed'));
+      await expect(getFile('some/key')).rejects.toThrow('get failed');
     });
   });
 

--- a/src/s3/s3.client.spec.ts
+++ b/src/s3/s3.client.spec.ts
@@ -6,6 +6,7 @@ jest.mock(
     PutObjectCommand: jest.fn(),
     DeleteObjectCommand: jest.fn(),
     GetObjectCommand: jest.fn(),
+    HeadObjectCommand: jest.fn(),
   }),
   { virtual: true },
 );
@@ -24,6 +25,7 @@ import {
   PutObjectCommand,
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl as awsGetSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
@@ -31,6 +33,8 @@ import {
   getFile,
   deleteFile,
   getSignedUrl,
+  getSignedUploadUrl,
+  headFile,
   __resetClient,
 } from './s3.client';
 
@@ -237,6 +241,95 @@ describe('S3 client', () => {
       await expect(getSignedUrl('some/key')).rejects.toThrow(
         'R2 storage is not configured. Missing env vars: R2_SECRET_ACCESS_KEY',
       );
+    });
+  });
+
+  describe('getSignedUploadUrl', () => {
+    it('should presign a PutObjectCommand with signed content type and length', async () => {
+      (awsGetSignedUrl as jest.Mock).mockResolvedValueOnce(
+        'https://signed-put-url',
+      );
+      const key = 'media-uploads/post1/media-1';
+
+      await getSignedUploadUrl(key, 'image/jpeg', 1024);
+
+      expect(PutObjectCommand).toHaveBeenCalledWith({
+        Bucket: BUCKET,
+        Key: key,
+        ContentType: 'image/jpeg',
+        ContentLength: 1024,
+      });
+      expect(awsGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Object),
+        { expiresIn: 1800 },
+      );
+    });
+
+    it('should default expiresIn to 1800 seconds', async () => {
+      (awsGetSignedUrl as jest.Mock).mockResolvedValueOnce('https://url');
+      await getSignedUploadUrl('key', 'image/png', 10);
+      expect(awsGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        { expiresIn: 1800 },
+      );
+    });
+
+    it('should use a custom expiresIn when provided', async () => {
+      (awsGetSignedUrl as jest.Mock).mockResolvedValueOnce('https://url');
+      await getSignedUploadUrl('key', 'image/png', 10, 600);
+      expect(awsGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        { expiresIn: 600 },
+      );
+    });
+
+    it('should return the signed URL string', async () => {
+      const expected = 'https://presigned.example.com/put?sig=abc';
+      (awsGetSignedUrl as jest.Mock).mockResolvedValueOnce(expected);
+      await expect(getSignedUploadUrl('key', 'image/png', 10)).resolves.toBe(
+        expected,
+      );
+    });
+
+    it('should throw with a clear message when env vars are missing', async () => {
+      delete process.env.R2_BUCKET_NAME;
+      await expect(getSignedUploadUrl('key', 'image/png', 10)).rejects.toThrow(
+        'R2 storage is not configured. Missing env vars: R2_BUCKET_NAME',
+      );
+    });
+  });
+
+  describe('headFile', () => {
+    it('should send HeadObjectCommand and return size and mime type when the object exists', async () => {
+      const key = 'media-uploads/post1/media-1';
+      mockSend.mockResolvedValueOnce({
+        ContentLength: 2048,
+        ContentType: 'image/jpeg',
+      });
+
+      const result = await headFile(key);
+
+      expect(HeadObjectCommand).toHaveBeenCalledWith({
+        Bucket: BUCKET,
+        Key: key,
+      });
+      expect(result).toEqual({ sizeBytes: 2048, mimeType: 'image/jpeg' });
+    });
+
+    it('should return null when the object does not exist', async () => {
+      const notFound = new Error('not found');
+      notFound.name = 'NotFound';
+      mockSend.mockRejectedValueOnce(notFound);
+
+      await expect(headFile('missing/key')).resolves.toBeNull();
+    });
+
+    it('should propagate non-NotFound errors from the S3 send call', async () => {
+      mockSend.mockRejectedValueOnce(new Error('access denied'));
+      await expect(headFile('some/key')).rejects.toThrow('access denied');
     });
   });
 

--- a/src/s3/s3.client.ts
+++ b/src/s3/s3.client.ts
@@ -1,6 +1,7 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
@@ -90,4 +91,45 @@ export async function getSignedUrl(
   const { client, bucket } = getClient();
   const command = new GetObjectCommand({ Bucket: bucket, Key: key });
   return awsGetSignedUrl(client, command, { expiresIn });
+}
+
+export async function getSignedUploadUrl(
+  key: string,
+  mimeType: string,
+  sizeBytes: number,
+  expiresIn = 1800,
+): Promise<string> {
+  const { client, bucket } = getClient();
+  // ContentType/ContentLength become signed headers, so R2 rejects a PUT
+  // whose actual type or size differ from what was declared here.
+  const command = new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    ContentType: mimeType,
+    ContentLength: sizeBytes,
+  });
+  return awsGetSignedUrl(client, command, { expiresIn });
+}
+
+export async function headFile(
+  key: string,
+): Promise<{ sizeBytes: number; mimeType?: string } | null> {
+  const { client, bucket } = getClient();
+  try {
+    const response = await client.send(
+      new HeadObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    return {
+      sizeBytes: response.ContentLength ?? 0,
+      mimeType: response.ContentType,
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.name === 'NotFound' || error.name === 'NoSuchKey')
+    ) {
+      return null;
+    }
+    throw error;
+  }
 }

--- a/src/s3/s3.client.ts
+++ b/src/s3/s3.client.ts
@@ -65,6 +65,19 @@ export async function uploadFile(
   return `https://${bucket}.${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${key}`;
 }
 
+export async function getFile(key: string): Promise<Buffer> {
+  const { client, bucket } = getClient();
+  const response = await client.send(
+    new GetObjectCommand({ Bucket: bucket, Key: key }),
+  );
+
+  if (!response.Body) {
+    throw new Error(`R2 object "${key}" has no body`);
+  }
+
+  return Buffer.from(await response.Body.transformToByteArray());
+}
+
 export async function deleteFile(key: string): Promise<void> {
   const { client, bucket } = getClient();
   await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));

--- a/src/workflow/media-upload.queue.spec.ts
+++ b/src/workflow/media-upload.queue.spec.ts
@@ -1,0 +1,41 @@
+import { MediaUploadQueue } from './media-upload.queue';
+import { MEDIA_UPLOAD_JOB_NAME } from './workflow.constants';
+
+describe('MediaUploadQueue', () => {
+  describe('addMediaUploadJob', () => {
+    it('should enqueue the job with retry options and a colon-free jobId when called', async () => {
+      const service = new MediaUploadQueue({} as any);
+      const add = jest.fn().mockResolvedValue(undefined);
+      (service as any).queue = { add };
+
+      const data = {
+        postId: 'post123',
+        connectedAccountId: 'account123',
+        ownerUrn: 'urn:li:person:abc',
+        items: [
+          {
+            mediaId: 'media-1',
+            r2Key: 'media-uploads/post123/media-1',
+            mediaType: 'IMAGE' as const,
+          },
+        ],
+      };
+
+      await service.addMediaUploadJob(data);
+
+      expect(add).toHaveBeenCalledWith(
+        MEDIA_UPLOAD_JOB_NAME,
+        data,
+        expect.objectContaining({
+          jobId: 'media-upload-media-1',
+          attempts: 3,
+          removeOnComplete: true,
+          removeOnFail: false,
+        }),
+      );
+
+      const options = add.mock.calls[0][2];
+      expect(options.jobId.includes(':')).toBe(false);
+    });
+  });
+});

--- a/src/workflow/media-upload.queue.ts
+++ b/src/workflow/media-upload.queue.ts
@@ -1,0 +1,52 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Queue } from 'bullmq';
+import { ConfigService } from '@nestjs/config';
+import {
+  MEDIA_UPLOAD_JOB_NAME,
+  MEDIA_UPLOAD_QUEUE_NAME,
+} from './workflow.constants';
+
+export interface MediaUploadJobItem {
+  mediaId: string;
+  r2Key: string;
+  mediaType: 'IMAGE' | 'VIDEO';
+}
+
+export interface MediaUploadJobData {
+  postId: string;
+  connectedAccountId: string;
+  ownerUrn: string;
+  items: MediaUploadJobItem[];
+}
+
+@Injectable()
+export class MediaUploadQueue implements OnModuleInit, OnModuleDestroy {
+  public queue: Queue;
+
+  constructor(private config: ConfigService) {}
+
+  onModuleInit() {
+    this.queue = new Queue(MEDIA_UPLOAD_QUEUE_NAME, {
+      connection: {
+        url: this.config.get<string>('REDIS_URL')!,
+      },
+    });
+  }
+
+  async onModuleDestroy() {
+    await this.queue.close();
+  }
+
+  async addMediaUploadJob(data: MediaUploadJobData) {
+    await this.queue.add(MEDIA_UPLOAD_JOB_NAME, data, {
+      jobId: `media-upload-${data.items[0].mediaId}`,
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 10_000,
+      },
+      removeOnComplete: true,
+      removeOnFail: false,
+    });
+  }
+}

--- a/src/workflow/workers/media-upload.worker.handler.spec.ts
+++ b/src/workflow/workers/media-upload.worker.handler.spec.ts
@@ -1,0 +1,77 @@
+import { Logger } from '@nestjs/common';
+import {
+  handleMediaUploadJobExhausted,
+  processMediaUploadJob,
+} from './media-upload.worker.handler';
+
+describe('media-upload worker handler', () => {
+  const makeFixtures = () => {
+    const logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+    } as unknown as Logger;
+    const linkedinMediaService = {
+      processMediaUpload: jest.fn().mockResolvedValue(undefined),
+      handleMediaUploadFailure: jest.fn().mockResolvedValue(undefined),
+    };
+    const job = {
+      id: 'job-1',
+      data: {
+        postId: 'post123',
+        connectedAccountId: 'account123',
+        ownerUrn: 'urn:li:person:abc',
+        items: [
+          {
+            mediaId: 'media-1',
+            r2Key: 'media-uploads/post123/media-1',
+            mediaType: 'IMAGE',
+          },
+        ],
+      },
+    };
+    return { logger, linkedinMediaService, job };
+  };
+
+  describe('processMediaUploadJob', () => {
+    it('should delegate to LinkedinMediaService.processMediaUpload when a job arrives', async () => {
+      const { logger, linkedinMediaService, job } = makeFixtures();
+
+      await processMediaUploadJob(
+        job as any,
+        logger,
+        linkedinMediaService as any,
+      );
+
+      expect(linkedinMediaService.processMediaUpload).toHaveBeenCalledWith(
+        job.data,
+      );
+    });
+
+    it('should propagate errors when processing fails', async () => {
+      const { logger, linkedinMediaService, job } = makeFixtures();
+      linkedinMediaService.processMediaUpload.mockRejectedValue(
+        new Error('upload failed'),
+      );
+
+      await expect(
+        processMediaUploadJob(job as any, logger, linkedinMediaService as any),
+      ).rejects.toThrow('upload failed');
+    });
+  });
+
+  describe('handleMediaUploadJobExhausted', () => {
+    it('should delegate to LinkedinMediaService.handleMediaUploadFailure when retries are exhausted', async () => {
+      const { logger, linkedinMediaService, job } = makeFixtures();
+
+      await handleMediaUploadJobExhausted(
+        job as any,
+        logger,
+        linkedinMediaService as any,
+      );
+
+      expect(
+        linkedinMediaService.handleMediaUploadFailure,
+      ).toHaveBeenCalledWith(job.data);
+    });
+  });
+});

--- a/src/workflow/workers/media-upload.worker.handler.ts
+++ b/src/workflow/workers/media-upload.worker.handler.ts
@@ -1,0 +1,26 @@
+import { Job } from 'bullmq';
+import { Logger } from '@nestjs/common';
+import { LinkedinMediaService } from '../../post/linkedin-media.service';
+import { MediaUploadJobData } from '../media-upload.queue';
+
+export async function processMediaUploadJob(
+  job: Job<MediaUploadJobData>,
+  logger: Logger,
+  linkedinMediaService: LinkedinMediaService,
+): Promise<void> {
+  logger.log(
+    `Processing media upload job ${job.id} for post ${job.data.postId} (${job.data.items.length} item(s))`,
+  );
+  await linkedinMediaService.processMediaUpload(job.data);
+}
+
+export async function handleMediaUploadJobExhausted(
+  job: Job<MediaUploadJobData>,
+  logger: Logger,
+  linkedinMediaService: LinkedinMediaService,
+): Promise<void> {
+  logger.error(
+    `Media upload job ${job.id} for post ${job.data.postId} exhausted all retries; marking media as FAILED`,
+  );
+  await linkedinMediaService.handleMediaUploadFailure(job.data);
+}

--- a/src/workflow/workers/workflow.worker.ts
+++ b/src/workflow/workers/workflow.worker.ts
@@ -2,6 +2,7 @@ import { Job, Worker } from 'bullmq';
 import {
   EMAIL_QUEUE_NAME,
   LINKEDIN_AVATAR_REFRESH_QUEUE_NAME,
+  MEDIA_UPLOAD_QUEUE_NAME,
   QUEUE_NAME,
   SCHEDULE_QUEUE_NAME,
 } from '../workflow.constants';
@@ -20,6 +21,12 @@ import { AuthService } from '../../auth/auth.service';
 import { MailService } from '../../mail';
 import { EmailQueue } from '../email.queue';
 import { processEmailJob } from './email.worker.handler';
+import { LinkedinMediaService } from '../../post/linkedin-media.service';
+import { MediaUploadJobData } from '../media-upload.queue';
+import {
+  handleMediaUploadJobExhausted,
+  processMediaUploadJob,
+} from './media-upload.worker.handler';
 
 async function bootstrapWorker() {
   const logger = new Logger(
@@ -34,6 +41,7 @@ async function bootstrapWorker() {
   const authService = app.get(AuthService);
   const mailService = app.get(MailService);
   const emailQueue = app.get(EmailQueue);
+  const linkedinMediaService = app.get(LinkedinMediaService);
   const userModel = app.get<Model<User>>(getModelToken(User.name));
 
   logger.log('NestJs context ready');
@@ -109,11 +117,15 @@ async function bootstrapWorker() {
       try {
         const connectedAccountId = job.data?.connectedAccountId;
         if (!connectedAccountId) {
-          logger.warn(`Skipping avatar refresh job ${job.id}; missing account id`);
+          logger.warn(
+            `Skipping avatar refresh job ${job.id}; missing account id`,
+          );
           return;
         }
 
-        logger.log(`Processing LinkedIn avatar refresh for ${connectedAccountId}`);
+        logger.log(
+          `Processing LinkedIn avatar refresh for ${connectedAccountId}`,
+        );
         await authService.refreshLinkedinAvatarForAccount(connectedAccountId);
       } catch (error) {
         logger.error(error);
@@ -147,5 +159,37 @@ async function bootstrapWorker() {
       },
     },
   );
+
+  const mediaUploadWorker = new Worker(
+    MEDIA_UPLOAD_QUEUE_NAME,
+    async (job: Job<MediaUploadJobData>) => {
+      try {
+        await processMediaUploadJob(job, logger, linkedinMediaService);
+      } catch (error) {
+        logger.error(error);
+        throw error;
+      }
+    },
+    {
+      connection: {
+        url: process.env.REDIS_URL!,
+        maxRetriesPerRequest: null,
+        enableReadyCheck: false,
+      },
+    },
+  );
+
+  mediaUploadWorker.on('failed', (job, error) => {
+    if (!job) return;
+    if (job.attemptsMade >= (job.opts.attempts ?? 1)) {
+      handleMediaUploadJobExhausted(job, logger, linkedinMediaService).catch(
+        (err) => logger.error(err),
+      );
+    } else {
+      logger.warn(
+        `Media upload job ${job.id} failed (attempt ${job.attemptsMade}/${job.opts.attempts ?? 1}): ${error.message}`,
+      );
+    }
+  });
 }
 bootstrapWorker();

--- a/src/workflow/workflow.constants.ts
+++ b/src/workflow/workflow.constants.ts
@@ -16,6 +16,8 @@ export const SCHEDULE_QUEUE_NAME = 'post-schedule';
 export const LINKEDIN_AVATAR_REFRESH_QUEUE_NAME = 'linkedin-avatar-refresh';
 export const LINKEDIN_AVATAR_REFRESH_JOB_NAME = 'refresh-linkedin-avatar';
 export const EMAIL_QUEUE_NAME = 'email';
+export const MEDIA_UPLOAD_QUEUE_NAME = 'media-upload';
+export const MEDIA_UPLOAD_JOB_NAME = 'upload-post-media';
 export const WELCOME_EMAIL_JOB_NAME = 'welcome-email';
 export const SCHEDULED_POST_PUBLISHED_EMAIL_JOB_NAME =
   'scheduled-post-published-email';

--- a/src/workflow/workflow.module.ts
+++ b/src/workflow/workflow.module.ts
@@ -4,6 +4,7 @@ import { WorkflowQueue } from './workflow.queue';
 import { ScheduleQueue } from './schedule.queue';
 import { LinkedinAvatarRefreshQueue } from './linkedin-avatar-refresh.queue';
 import { EmailQueue } from './email.queue';
+import { MediaUploadQueue } from './media-upload.queue';
 
 @Module({
   controllers: [WorkflowController],
@@ -12,12 +13,14 @@ import { EmailQueue } from './email.queue';
     ScheduleQueue,
     LinkedinAvatarRefreshQueue,
     EmailQueue,
+    MediaUploadQueue,
   ],
   exports: [
     WorkflowQueue,
     ScheduleQueue,
     LinkedinAvatarRefreshQueue,
     EmailQueue,
+    MediaUploadQueue,
   ],
 })
 export class WorkflowModule {}


### PR DESCRIPTION
## Summary

Moves LinkedIn media upload off the synchronous request path to a background, direct-to-R2 flow. Instead of streaming file bytes through the API server via `multipart/form-data`, the client now requests presigned R2 upload slots, PUTs files straight to Cloudflare R2, confirms, and a BullMQ worker performs the LinkedIn upload asynchronously.

## What changed

- **Presigned direct-to-R2 upload flow** (`s3.client.ts`, `linkedin-media.service.ts`):
  - `POST /posts/:id/media/uploads` — declares files, returns presigned PUT URLs with signed `Content-Type`/`Content-Length` and temporary `mediaId`s (30-min slot expiry).
  - `POST /posts/:id/media/uploads/complete` — verifies files landed in R2, flips entries to `UPLOADING`, enqueues the background job (`202`).
- **Background media upload** (`media-upload.queue.ts`, `media-upload.worker.handler.ts`): worker transfers R2 bytes to LinkedIn, swaps the temp UUID for the real LinkedIn URN, and marks entries `READY`/`FAILED` with retries.
- **Media status lifecycle** on `PostDraft` (`post-draft.schema.ts`): `PENDING` → `UPLOADING` → `READY`/`FAILED`, with `mimeType`/`sizeBytes`/`pendingExpiresAt` bookkeeping and auto-purge of expired `PENDING` slots. Publishing is gated on in-flight uploads (`409`) and silently excludes `FAILED` entries.
- **Deprecated** the old `PUT /posts/:id/media` multipart endpoint (still works during migration; shares the in-progress lock).
- **Docs**: `docs/async-media-upload-handoff.md` (client-side handoff) and `docs/presigned-media-upload-spec.md`.

## Testing

- Unit tests added for `s3.client`, `linkedin-media.service`, `media-upload.queue`, the worker handler, and expanded `post.service` coverage.

## Notes

- Requires R2 env vars (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`).
- Requires **CORS on the R2 bucket** for the app origins, or the direct browser PUTs fail preflight.
- Requires the **worker process** to be running, or media stays `UPLOADING` indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
