### PR TITLE
docs: the artifact workflow spec (#100–#110)

### DIFF
--- a/docs/agent-loop-and-research-agent-design.md
+++ b/docs/agent-loop-and-research-agent-design.md
@@ -1,0 +1,329 @@
+# Agent Loop & Research Agent — Design
+
+> Status: design spec for wayfinder map #99, ticket #104 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled in a grilling session
+> on 2026-07-09.
+> Supersedes the ad-hoc LLM calls in `src/agent/agent.service.ts` and recovers the
+> intent of the deleted `src/mark/mark-agent.service.ts` tool loop — rebuilt on the
+> `src/llm` abstraction instead of the Vercel AI SDK.
+
+Feeds the final spec assembly (#110). This ticket owns the **`AgentRunner`** that
+#103 hands to steps as `ctx.agent` ("research + generation via the tool-calling
+agent loop"). Interlocking tickets are referenced inline at each boundary.
+
+## Framing (charter-derived givens)
+
+- The build flow is **async and non-interactive** (#102/#103: `POST /artifacts` →
+  `202 {artifactId, runId}` → progress via SSE). There is **no live user channel**
+  mid-run — the agent cannot ask the user questions.
+- The agent runs on the **`src/llm` OpenRouter stack**, not the Vercel AI SDK. The old
+  `ai` / `@ai-sdk/gateway` deps were deliberately removed when `src/mark` was stripped;
+  only `@openrouter/sdk` (^0.5.1), `@tavily/core` (^0.7.3) and `zod` (^4) remain.
+- `src/mark` is dissolved (charter #9); its `MARK_*` multi-provider abstraction is
+  retired. The surviving `src/mark/search.ts` Tavily helper is the seed for the one
+  research tool.
+- **Prior art:** the deleted `mark-agent.service.ts` ran a `ToolLoopAgent` with a
+  `tools` registry, `stepCountIs(8)` cap, and a Tavily `web_search` tool. This design
+  generalizes that loop onto our own abstraction so it is provider-swappable.
+
+---
+
+## 1. Two layers: LLM abstraction vs. the loop
+
+The agent is built in **two layers**, so swapping providers never touches the loop.
+
+**Layer 1 — the LLM abstraction (`src/llm`), provider-swappable.** The strategy
+interface grows from today's single `generateCompletion → string` into the
+**single-turn, provider-agnostic primitives** the loop needs:
+
+```ts
+interface LLMStrategy {
+  complete(messages: LLMMessage[], opts?: CompletionOptions): Promise<CompletionResult>;
+  completeWithTools(
+    messages: LLMMessage[],
+    tools: ToolDefinition[],
+    opts?: CompletionOptions,
+  ): Promise<ToolTurnResult>;                       // ONE turn
+  stream?(messages: LLMMessage[], opts?: CompletionOptions): AsyncIterable<string>; // reserved, §10
+}
+
+interface CompletionResult { text: string; usage: Usage }
+interface ToolTurnResult   { text?: string; toolCalls: ToolCall[]; usage: Usage }
+
+interface ToolDefinition { name: string; description: string; parameters: ZodType }
+interface ToolCall       { id: string; name: string; input: unknown }
+interface Usage          { promptTokens: number; completionTokens: number; totalTokens: number; cost: number }
+```
+
+- New shared types (`ToolDefinition`, `ToolCall`, `Usage`) and the message variants
+  (assistant-with-tool-calls, `role: 'tool'` result) are **owned here**.
+- The **OpenRouter strategy** implements these using `@openrouter/sdk` primitives — its
+  `tool()` Zod helper for schema conversion, `chat.send` with `tools` for the single
+  turn, and the SDK's `usage.cost` / `costDetails` for real per-call dollar cost.
+
+**Layer 2 — the `AgentRunner` loop, provider-agnostic.** It owns the multi-turn loop
+(tool registry, message accumulation, iteration cap, usage aggregation, stop
+condition) by calling `completeWithTools` in a `while` loop. Because the loop sits
+**above** the abstraction, changing providers is a strategy swap; the loop is
+untouched.
+
+**Rejected — adopt the OpenRouter SDK's full `callModel` orchestrator.** It ships an
+automatic multi-turn tool loop, but burying the loop inside the vendor SDK defeats the
+provider-swappability the layering exists for. We lean on the SDK's *lower-level*
+per-turn helpers (schema conversion, tool-call parsing, usage) and own the loop.
+
+**Rejected — re-add the Vercel AI SDK `ToolLoopAgent`.** Its deps were removed on
+purpose; it is a second live LLM vendor path alongside `src/llm`, duplicating the
+OpenRouter strategy.
+
+**Rejected — hand-plumb raw OpenAI-style `tools`/`tool_calls` JSON.** More bespoke
+message-accumulation and wire code than needed; the SDK's per-turn helpers already do
+the JSON.
+
+## 2. The generic loop contract
+
+`AgentRunner` exposes one generic primitive that both concrete agents build on:
+
+```ts
+interface Tool<I = unknown, O = unknown> {
+  name: string;
+  description: string;
+  parameters: ZodType<I>;                 // → provider tool-def via Layer 1
+  execute: (input: I) => Promise<O>;
+}
+
+interface AgentRunConfig {
+  system: string;                         // instructions
+  messages: LLMMessage[];                 // seed turn(s)
+  tools: Tool[];                          // registry for THIS run
+  maxSteps: number;                       // iteration cap
+  model?: string;
+}
+
+interface AgentStep { toolCalls: ToolCall[]; toolResults: unknown[]; usage: Usage }
+interface AgentRunResult { text: string; steps: AgentStep[]; usage: Usage }
+
+interface AgentHooks {
+  onUsage?: (u: Usage) => void;           // after each LLM turn (§4)
+  onToolCall?: (t: { name: string }) => void;
+}
+
+run(config: AgentRunConfig, hooks?: AgentHooks): Promise<AgentRunResult>;
+```
+
+**The loop:** append seed messages → `completeWithTools` → if `toolCalls` is empty,
+return `text`; else execute the called tools (**in parallel within a turn**,
+`Promise.all`, matching the old Mark behavior), append their outputs as `role:'tool'`
+messages, increment the step counter, repeat.
+
+**Cap behavior — graceful finalization.** When `maxSteps` is reached but the model
+still wants tools, make **one final completion with the tools removed** ("budget spent,
+answer now"). This guarantees a usable `text` instead of a dangling tool call and
+bounds worst-case spend at `maxSteps + 1` LLM calls.
+
+**Rejected — hard stop / throw on cap.** Turns "the model was being thorough" into a
+failed run, which #103 would retry into the same cap — wasted spend.
+
+**Rejected — return the last assistant text as-is.** May be empty or half-formed if the
+final turn was a pure tool call.
+
+## 3. Public surface — `AgentRunner`
+
+#103 §10 expects `ctx.agent` to provide **research and generation**. Research is
+agentic (calls out to the web); generation is not.
+
+```ts
+interface AgentRunner {
+  research(input: ResearchInput): Promise<ResearchResult>;   // agentic — §5
+  generate(input: GenerateInput): Promise<ArtifactContent>;  // single structured completion — §6
+}
+```
+
+- `research` runs the loop (§2) with the `searchWeb` tool.
+- `generate` handles **both** initial and refine (branch on `refine`):
+
+```ts
+interface GenerateInput {
+  type: ArtifactType;                     // #102 — POST | POLL | DOCUMENT
+  prompt: string;
+  stylePreset?: StylePreset;
+  research?: ResearchResult;              // cached findings (#103 research slot)
+  refine?: { priorContent: ArtifactContent; feedback: string };
+}
+```
+
+- The concrete instance is resolved once in the worker bootstrap and passed as
+  `ctx.agent` (the existing `app.get(...)` pattern in `workflow.worker.ts`).
+
+## 4. Generation is a single structured completion, not a loop
+
+`generate` has all its inputs already (prompt + cached research + type); it just emits
+**typed `ArtifactContent`** — commentary, a poll object, or document slides —
+validated by `ResponseParserService.parseWithSchema` against #102's Zod discriminated
+union. It uses Layer 1's `complete` (no tools). This mirrors today's
+`createLinkedInPost` / `createDraft` plain completions.
+
+- **Prompt selection per type / per revision is `AgentRunner`'s internal concern**
+  (#104 owns the prompts). Refine feeds `priorContent + feedback` into a revision
+  prompt; initial feeds `prompt + research`.
+
+**Rejected — generation as an agent loop** (self-validate / self-critique tools).
+Unbounded spend and nondeterminism for no launch benefit; #102 already gates `READY`
+on a valid render. Parked as future work.
+
+## 5. The research agent
+
+`research()` runs the generic loop with a single tool and full autonomy.
+
+- **Tool — one, `searchWeb` (Tavily).** Built from the surviving `src/mark/search.ts`
+  helper, wrapped as a `Tool`: `{ query: string }` → `{ results: {title,url,content,
+  score}[] }`, `searchDepth: 'advanced'`, `maxResults: 5`. On failure it returns
+  `{ error }` (never throws — §8). The registry stays open so YouTube-transcript /
+  Reddit sources can be added later, but launch ships the single web-search tool the
+  charter names.
+- **Fully autonomous — no `ask_clarification`.** Nowhere to deliver a question in the
+  async model. The agent **self-directs its own search queries** across turns (parallel
+  searches within a turn allowed). This **replaces** today's `generateSearchKeywords` +
+  `searchWithFallbacks` pre-steps — there is no separate keyword-generation stage.
+- **Iteration cap `maxSteps = 5`**, config-driven (`RESEARCH_MAX_STEPS`): a few search
+  rounds, then synthesize. The §2 graceful finalization guarantees a written findings
+  result even at the cap.
+
+```ts
+interface ResearchInput { prompt: string; type: ArtifactType; stylePreset?: StylePreset }
+```
+
+**Rejected — port YouTube + Reddit + web as three tools now.** Triples the tool
+surface, cost, and prompt-tuning for launch; the heavy legacy YouTube pipeline
+(search→transcript→compress) dies with the old engine (#100 resolution).
+
+**Rejected — keep a clarification path.** No channel to surface the question in the
+fire-and-forget flow.
+
+## 6. Research output shape
+
+`research()` reduces the raw `AgentRunResult` into the "findings + sources" object the
+issue names — what GENERATE reads and #103 caches on `WorkflowRun.researchContext`.
+
+```ts
+interface ResearchSource { title: string; url: string }
+interface ResearchResult {
+  findings: string;                       // the loop's final synthesized brief (= AgentRunResult.text)
+  sources: ResearchSource[];              // deduped from every searchWeb result across steps
+}
+```
+
+- Derivation inside `research()`: `findings = result.text` (the agent's own synthesis
+  after searching); `sources = dedupeByUrl(steps.flatMap(searchWeb results →
+  {title,url}))`.
+- **Raw search bodies stay in `steps` (logged) and are not forwarded** — GENERATE gets
+  the distilled `findings`, not a dump of five 5-result payloads, keeping the generation
+  prompt tight. `sources` travels forward so a post can optionally cite/attribute.
+- Zod-validated (repo convention for structured data). Stored verbatim on
+  `researchContext`, so **refine reuses it with zero re-search** (the #103 §11 cache;
+  no web-search surcharge on refine).
+
+**Rejected — forward raw results** (`sources` with `content`/`score`). Bloats the
+generation prompt and the run record with text the `findings` already distilled.
+
+## 7. Usage & cost accounting (→ #105)
+
+`AgentRunner` must **not** hold the meter (that couples the loop to #105). The seam is
+a **per-turn hook the step bridges to `ctx.meter`**:
+
+- The loop invokes `hooks.onUsage(usage)` after **each** `completeWithTools` / `complete`
+  turn (real `usage.cost` from the SDK) and `hooks.onToolCall({name})` when a tool
+  fires.
+- The RESEARCH / GENERATE step wires those to `ctx.meter.record(...)`:
+  - each LLM turn → `record({ kind: 'llm', amount: usage.cost, detail: { model, totalTokens } })`
+  - each web-search call → `record({ kind: 'web_search', amount: 1 })` — the *signal*
+    #105 turns into a surcharge.
+- `AgentRunner` also returns aggregate `usage` on `AgentRunResult` for the run record /
+  logging.
+
+Live per-turn emission lets #107's SSE show a running token/credit count during a long
+research run. **`AgentRunner` emits raw signals (cost per turn, tool fired); #105 owns
+converting them to credit amounts and surcharge rates** — clean boundary.
+
+**Rejected — return aggregate usage only, record once after `run()`.** No live ticks
+(a 6-step research run reports nothing until it finishes) and tool-surcharge signals get
+lost.
+
+## 8. Error taxonomy
+
+Three failure modes, each mapped onto #103's retry model (`WorkflowError{retryable}` →
+BullMQ `attempts:3`; terminal → `UnrecoverableError`):
+
+| Failure | Handling | Engine effect |
+|---|---|---|
+| **Tool execution error** (Tavily down / timeout / throws) | caught, returned to the model as tool-result `{ error }`; loop continues (agent adapts, bounded by `maxSteps`) | none — absorbed in-loop |
+| **LLM transport error** (429 / 5xx / network) | `src/llm` classifies and throws typed `LLMError{ retryable }` (429/5xx/network = retryable; 4xx/auth = terminal); `AgentRunner` propagates | step maps to `WorkflowError{retryable}` → whole run retried, or terminal |
+| **Bad structured output** (generation fails #102 Zod) | **one inline repair retry** in `generate()` (re-prompt with the validation error); still invalid → throw `retryable` | #103 `attempts` re-runs (research cached, so cheap) |
+
+- The `src/llm` layer owns retryable classification because it knows provider error
+  semantics.
+- Nothing here charges the user (#103 §9: commit-on-success only; failed/retried runs
+  cost the user nothing).
+
+## 9. Provider scope & model selection
+
+- **OpenRouter-only for v1**, on the single `src/llm` abstraction. Only the OpenRouter
+  strategy implements the new `complete` / `completeWithTools` / `usage` surface. The
+  `LLMProvider` enum keeps its `OPENAI` / `CLAUDE` arms unimplemented (as today); the §1
+  layering makes adding a real Claude/OpenAI strategy later a strategy addition, not a
+  loop change.
+- **`MARK_*` provider-switching is retired.** OpenRouter already fronts 300+ models, so
+  "switching providers" in practice means switching the OpenRouter model string.
+- **Per-role model config** via `ConfigService`: `RESEARCH_MODEL` (fast, for tool-loop
+  turns) and `GENERATION_MODEL` (stronger, for final content) — no hardcoded model
+  strings (retires the scattered `gemini-3-flash` / `gpt-5.4` / `gpt-5-mini` literals,
+  per CLAUDE.md's config rule).
+
+**Rejected — reinstate a multi-provider abstraction now** (port Mark's gateway/anthropic
+paths). Two+ live SDKs, more config and test surface, for a launch where OpenRouter
+covers every model we'd reach for.
+
+## 10. Streaming scope
+
+- **Token streaming is deferred.** v1 `AgentRunner` uses only non-streaming `complete` /
+  `completeWithTools`. `stream()` stays an **optional, unimplemented method on the
+  strategy interface** — the seam is reserved, nothing calls it.
+- Live progress comes entirely from #103/#107 events (step started/completed, live
+  `usage.tick` from §7's hook) — enough for a "researching… generating…" UI with a
+  running token/credit count, without token-level plumbing.
+
+**Rejected — implement token streaming now.** Forces backpressure/buffering in the
+loop, a token-delta event type into #107's contract, and breaks the
+validate-after-completion model (you cannot Zod-validate a half-streamed object).
+
+## 11. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| `ctx.agent` wiring, `WorkflowRun` record, retry/`WorkflowError` semantics, `ctx.meter` interface | #103 |
+| `ArtifactContent` Zod discriminated union, `ArtifactWriter`, version status | #102 |
+| Credit denomination, `cost`/tool signals → credit conversion, surcharge rates, optional mid-run cutoff | #105 |
+| SSE endpoint, client event schema, `usage.tick` framing, `Last-Event-ID` replay | #107 |
+| `Slide` internal shape / carousel templates (what DOCUMENT generation emits per slide) | #108 |
+| Post binding, connected-account, publish | #106 |
+| Additional research sources (YouTube-transcript, Reddit tools); token streaming; multi-provider strategies | future |
+
+## 12. Migration note
+
+Per the #100 resolution this is a clean write-over (relaunch, no users):
+
+- **`src/llm`**: extend `LLMStrategy` with `complete` / `completeWithTools` / (reserved)
+  `stream`; add the shared `ToolDefinition` / `ToolCall` / `Usage` types and tool/tool-
+  result message variants; implement them in the OpenRouter strategy over
+  `@openrouter/sdk`'s `tool()` + `chat.send`; add typed `LLMError{retryable}`.
+- **New `AgentRunner`** (in `src/agent`) owning the generic loop (§2) and the
+  `research` / `generate` surface (§3), plus the research/generation/refine prompts.
+- **`searchWeb` tool** wrapping `src/mark/search.ts` (Tavily); `src/mark` otherwise
+  dissolved.
+- **Delete** the ad-hoc pipeline methods in `agent.service.ts`
+  (`generateUserIntent`, `generateSearchKeywords`, `searchWithFallbacks`,
+  `getYouTubeTranscripts`, `extractInsight`, `createDraft`, `createLinkedInPost`,
+  `updateDraft`) — folded into `research()` + `generate()` — and their `PostDraft`
+  coupling.
+- Config: add `RESEARCH_MODEL`, `GENERATION_MODEL`, `RESEARCH_MAX_STEPS`, `TAVILY_API_KEY`;
+  retire `MARK_*`.

--- a/docs/artifact-schema-and-library-api-design.md
+++ b/docs/artifact-schema-and-library-api-design.md
@@ -1,0 +1,217 @@
+# Artifact Schema, Versioning & Library API — Design
+
+> Status: design spec for wayfinder map #99, ticket #102 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled in a grilling session
+> on 2026-07-09.
+> Supersedes the current `src/database/schemas/artifact.schema.ts` (which has a
+> `type` enum/type mismatch: `enum: ['html','text','structured']` on a field typed
+> `ArtifactType`).
+
+Feeds the final spec assembly (#110). Interlocking tickets are referenced inline
+at each boundary.
+
+## Framing (charter-derived givens)
+
+- An **`Artifact` is a standalone, user-owned library entity** with its own
+  collection and stable `_id` (charter #1). A `Post` (#106) *references* artifacts;
+  this ticket designs the library in isolation from posting.
+- Content types map to LinkedIn's model (per the #101 API research): a post is
+  **commentary (text) + at most one mutually-exclusive content object** (poll *or*
+  document). Poll+media / document+media are **not possible** — so an artifact is
+  single-type.
+
+---
+
+## 1. Versioning spine — stable family + embedded versions
+
+The **`Artifact` document is a stable "family."** Refine-after-completion appends a
+new version; versions are an **ordered, embedded `versions[]` array** inside the
+family.
+
+- Each version is a **full payload snapshot** (not a diff) plus generation metadata.
+- **Addressing:** `artifactId` resolves to `currentVersion` by default; a specific
+  version is `artifactId` + version number (`?version=N`).
+- Rendered PDFs live in R2 (only the URL + structured slides sit in the doc), so the
+  family stays comfortably under Mongo's 16 MB limit even after many refines.
+
+**Rejected:** version-as-its-own-document with a `rootId` (Git-object style) — buys
+unbounded history + per-version querying we don't need, at the cost of a
+"latest-per-root" aggregation on every list/get.
+
+## 2. Status lifecycle
+
+Status lives **on the version** (each generation has its own lifecycle):
+
+```
+GENERATING → READY
+GENERATING → FAILED
+```
+
+- A version reaches `READY` only when its content is complete — for **documents**,
+  that means the Browserless-rendered `pdfUrl` is populated. No separate `RENDERING`
+  state; fine-grained progress is the SSE stream's job (#107), so the *persisted*
+  status stays coarse.
+- **No family-level status enum.** An artifact's library state derives from
+  `currentVersion.status`, avoiding drift between two enums.
+- **Soft-delete** via a family-level `deletedAt`, not a status value (deletion is
+  orthogonal to generation).
+- **Publish state is deliberately absent** — whether an artifact has been posted is a
+  `Post` concern (#106); referencing an artifact from a post doesn't mutate it.
+
+## 3. Schema
+
+```ts
+enum ArtifactType   { POST = 'POST', POLL = 'POLL', DOCUMENT = 'DOCUMENT' }  // fixed per family
+enum VersionStatus  { GENERATING = 'GENERATING', READY = 'READY', FAILED = 'FAILED' }
+
+Artifact {                          // top-level, user-owned library unit
+  _id
+  user:           ObjectId<User>
+  type:           ArtifactType
+  title?:         string            // editable display label for the library
+  source:         { prompt: string; withResearch: boolean; stylePreset?: StylePreset }
+  currentVersion: number            // → versions[].version
+  versions:       ArtifactVersion[] // ordered, append-only (head is mutable)
+  deletedAt?:     Date              // soft delete
+  createdAt, updatedAt              // Mongoose timestamps
+}
+
+ArtifactVersion {                   // embedded subdocument
+  version:        number            // 1-based
+  status:         VersionStatus
+  content:        ArtifactContent   // stored loosely (Object); Zod-validated at the app boundary
+  refineFeedback?: string           // feedback that spawned this version (v1: none)
+  editedAt?:      Date              // set when the head is manually PATCHed
+  failureReason?: string            // set when FAILED
+  createdAt:      Date
+}
+```
+
+- `type` is **family-level** — you refine a poll into a better poll, never into a
+  document.
+- Content is stored as a loosely-typed object in Mongoose and validated by **Zod**
+  per type at the app boundary (matching the repo split: Zod for structured/LLM
+  data, `class-validator` for HTTP DTOs). This retires the enum/type mismatch —
+  `type` standardizes on `ArtifactType`; content correctness is Zod's job.
+
+## 4. Per-type content (Zod discriminated union on `type`)
+
+```ts
+// POST — text-only (the degenerate case; commentary is the whole thing)
+{ commentary: string }
+
+// POLL — commentary + poll (constraints from the #101 API research)
+{ commentary?: string;
+  poll: { question: string;            // ≤ 140 chars
+          options: string[];           // 2–4 options, each ≤ 30 chars
+          durationDays: 1 | 3 | 7 | 14 } }
+
+// DOCUMENT — commentary + structured slides + rendered PDF
+{ commentary?: string;
+  document: { slides: Slide[];         // Slide internals defined by #108
+              pdfUrl?: string;         // R2 URL, populated on render → gates READY
+              pageCount?: number } }
+```
+
+- `Slide` is intentionally opaque here — **the carousel-template ticket (#108)**
+  owns its shape (a slide is expected to be `{ templateId, fields }`, i.e. structured
+  content that fills a curated HTML/CSS template, *not* raw HTML). #102 stores
+  `slides` as an ordered array and lets #108's Zod schema validate the internals.
+- The relationship is source→derived: `slides` is the editable source of truth;
+  `pdfUrl` is the disposable Browserless render output (re-rendered on every refine
+  or slide edit).
+
+## 5. Refine vs. manual edit
+
+**A version = one AI generation.** Manual edits do not create versions.
+
+- **Initial generation** = version 1.
+- **AI refine** (`POST /artifacts/:id/refine {feedback}`) → async run → **appends** a
+  new version that becomes `currentVersion` (`GENERATING → READY`). Prior versions
+  are retained, immutable. `refineFeedback` records the human-readable reason.
+- **Manual edit** (`PATCH /artifacts/:id`) → **mutates the current version's content
+  in place** (no new version), allowed only when the head is `READY`; stamps
+  `editedAt`.
+- **Revert is deferred** (future work). If added later: `POST
+  /artifacts/:id/versions/:v/restore` that *copies* version `v` to a new head,
+  keeping older versions immutable.
+
+**Rejected:** every manual save as a new version — perfect audit trail, but explodes
+history and muddies what "version" means.
+
+## 6. Creation — async generation kickoff
+
+`POST /artifacts` is not hand-authoring; it kicks off a generation run.
+
+- Creates the `Artifact` immediately (`currentVersion=1`, version 1 `GENERATING`) and
+  **enqueues a generation run on the new engine** (#103); responds `202
+  {artifactId, runId}`. The client watches progress via SSE (#107) and/or polls
+  `GET /artifacts/:id`.
+- **Input:** `{ type, prompt, withResearch, stylePreset? }`.
+  - `withResearch` is the research/no-research toggle from the #100 resolution — this
+    is exactly where `quickPostLinkedin`/`insightPostLinkedin` collapse into one flow
+    (research-off ≈ quick post, research-on ≈ insight post).
+- **No `connectedAccount` at creation** — an artifact is account-agnostic until the
+  user chooses to post it (charter #1). Account binding happens in the `Post` flow
+  (#106). This is a deliberate change from today's `PostDraft`.
+
+**Rejected:** synchronous create — research + LLM + PDF render take tens of seconds;
+would hold the HTTP connection and bypass the SSE design.
+
+## 7. Generation context persisted
+
+Keep the *request*, drop the research guts (avoid the `PostDraft` bloat where
+`userIntent`/`compressionResult`/`youtubeResearch` were heavy and `select()`-excluded).
+
+- **Family-level `source: { prompt, withResearch, stylePreset? }`** — the original
+  request; gives refine runs base context and the UI a "generated from…" line.
+- **Version-level `refineFeedback?`** — the feedback that spawned each version.
+- **Research/intermediate context is NOT stored on the artifact** — it's a **run
+  concern**, living on the engine's run record (#103) / research agent (#104). If a
+  refine needs cached research, that belongs on the run record, not the library doc.
+
+## 8. HTTP surface
+
+All routes under `api/v1`, behind `ClerkAuthGuard`, owner-scoped (`Forbidden` if the
+artifact isn't the caller's — same pattern as `PostService`).
+
+| Method | Route | Body / Query | Result |
+|---|---|---|---|
+| POST | `/artifacts` | `{type, prompt, withResearch, stylePreset?}` | `202 {artifactId, runId}` |
+| POST | `/artifacts/:id/refine` | `{feedback}` | `202 {artifactId, version, runId}` |
+| PATCH | `/artifacts/:id` | partial content edit (head, `READY` only) | `200` |
+| GET | `/artifacts` | `?type&status&month&page` | list of **summaries** + `filters {availableMonths, types}` |
+| GET | `/artifacts/:id` | `?version=N` / `?includeVersions=true` | current version (or a specific version / + version-metadata history) |
+| DELETE | `/artifacts/:id` | — | `200` soft delete |
+
+- **List returns lightweight summaries only** — `{id, type, title, status, updatedAt,
+  preview}` (`status` from `currentVersion.status`; `preview` = commentary/first-slide
+  snippet, plus `pdfUrl` for documents). Never carries version arrays. Excludes
+  soft-deleted, sorted `updatedAt` desc, paginated. The `month` filter reuses the
+  existing `getPosts` `%Y-%m` aggregation; the `filters` block mirrors today's posts
+  endpoint minus `connectedAccountIds` (artifacts are account-agnostic).
+- **Get** returns the current version's full content by default; `?version=N` for a
+  specific version; `?includeVersions=true` adds **version metadata only**
+  (`{version, status, createdAt, editedAt, refineFeedback}`) for a history sidebar.
+- **Delete** is soft (`deletedAt`); R2 PDF cleanup is a later background sweep, not
+  inline.
+- **R2 PDF key convention:** `artifacts/${artifactId}/${version}/document.pdf`
+  (version-scoped so refines don't clobber prior renders).
+
+## 9. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| `Slide` internal shape / carousel templates | #108 |
+| Generation engine internals + the run record (holds research context) | #103 |
+| Research agent (`withResearch`) | #104 |
+| Post binding, connected-account, publish | #106 |
+| SSE progress-event contract | #107 |
+| Credit gating on create/refine | #105 |
+| Revert; background R2 cleanup sweep | future |
+
+## 10. Migration note
+
+Per the #100 resolution this is a clean write-over (relaunch, no users): the current
+`Artifact`/`postArtifact`/`pollArtifact` types and `src/mark/artifact.service.ts`
+are rebuilt to this design; no data migration. `src/mark` is dissolved (charter #9).

--- a/docs/artifact-workflow-prd.md
+++ b/docs/artifact-workflow-prd.md
@@ -1,0 +1,1635 @@
+# LinkedIn Artifact Workflow — PRD
+
+> Status: **build-ready specification.** Assembled for wayfinder map #99, ticket #110.
+> Compiled 2026-07-10 from the closed design tickets #100–#109 and their reports in `docs/`.
+>
+> This document is the **destination** of map #99. It supersedes the individual design
+> reports wherever they conflict: §2 records every cross-ticket seam this ticket ratified,
+> and the sibling docs are henceforth read *through* §2. Everything below is a given for
+> the build effort; the implementation tickets in §12 are the units of work.
+
+## Contents
+
+1. [What we are building](#1-what-we-are-building)
+2. [Ratified resolutions — read this before the design docs](#2-ratified-resolutions)
+3. [Corrections to stale claims in the design docs](#3-corrections-to-stale-claims)
+4. [Domain model](#4-domain-model)
+5. [The workflow engine](#5-the-workflow-engine)
+6. [Step pipelines](#6-step-pipelines)
+7. [The agent loop](#7-the-agent-loop)
+8. [The carousel template system](#8-the-carousel-template-system)
+9. [Credits](#9-credits)
+10. [Post and publish](#10-post-and-publish)
+11. [SSE progress streaming](#11-sse-progress-streaming)
+12. [`src/mark` dissolution map](#12-srcmark-dissolution-map)
+13. [Configuration](#13-configuration)
+14. [Risks carried into the build](#14-risks-carried-into-the-build)
+15. [Implementation tickets](#15-implementation-tickets)
+
+---
+
+## 1. What we are building
+
+An **artifact library** for LinkedIn content. A user describes what they want; a
+deterministic step pipeline running on a new workflow engine generates a typed
+**Artifact** — a text post, a poll, or a document (PDF carousel) — streaming progress to
+the browser over SSE. Artifacts live in the library as versioned, account-agnostic
+drafts. Refining one appends a new version. When the user is ready, they bind an artifact
+version to a connected LinkedIn account and publish or schedule it as a **Post**.
+
+Generation is metered in **credits** backed by real provider cost. Research is an
+optional per-run toggle served by a from-scratch agent loop with a single web-search
+tool.
+
+### Charter decisions (settled while charting map #99 — givens, not open questions)
+
+1. **Artifacts are the library.** Content lives as an `Artifact` until the user chooses to
+   post it.
+2. **A new `Post` schema replaces `PostDraft`.** A post references *multiple* artifacts
+   (leaving room for a future image artifact). This is a **complete write-over**: a
+   relaunch with no existing users, so `postdrafts` is dropped and rebuilt clean. No
+   backfill, no `_id` preservation, no coexistence window, no versioned API endpoints.
+3. **One new workflow engine, one build flow.** The old engine is absorbed, not preserved:
+   `quickPostLinkedin` and `insightPostLinkedin` fold into a single artifact-build flow as
+   a research-on/research-off toggle chosen before the build starts. The old engine is
+   deleted.
+4. **Workflows execute in the BullMQ worker.** Step events land in Redis keyed by run id;
+   the HTTP server relays them over SSE.
+5. **Iteration is refine-after-completion.** Feedback triggers a refine run producing a new
+   artifact version. No mid-run pause/resume.
+6. **The agent loop is new and generic,** built on `src/llm` extended with tool-calling.
+   The research agent (Tavily `searchWeb`) is the first and only agent at launch.
+7. **Carousel slides are curated HTML/CSS templates** filled with AI-generated structured
+   content, rendered through the existing Browserless→PDF path.
+8. **Usage gating is token-backed credits** per tier per period. Non-LLM actions (web
+   search, PDF render) carry fixed credit surcharges.
+9. **`src/mark` is absorbed and dissolved.** Its surviving utilities migrate into the new
+   modules; the module is deleted. `artifact.schema.ts` is redesigned.
+
+### Explicitly out of scope
+
+Rebuilding the autonomous Mark agent. Image-generation artifacts (the multi-artifact
+`Post` shape leaves room; the artifact type itself is later work). Mid-run checkpoint
+pause/resume. Token streaming. Credit top-ups, overage billing, rollover, mid-run credit
+cutoff. Artifact version revert. Background R2 cleanup sweep.
+
+---
+
+## 2. Ratified resolutions
+
+The design tickets were grilled in parallel and left seven seams open or contradictory.
+**#110 closes all seven.** Where a sibling doc disagrees with this section, this section
+wins.
+
+### R1 — `pdfUrl` is renamed `pdfKey` everywhere
+
+**Conflict.** #102 §4 stores `document.pdfUrl?`; #103 §2–3 writes `render: { pdfUrl }`;
+#106 §5 publishes from "the artifact version's R2 `pdfUrl`"; #107 §3 gates READY on it.
+#108 §7 discovered the R2 bucket is **private** — `uploadFile` returns an
+`…r2.cloudflarestorage.com` URL nothing can serve to a client — and renamed the field.
+
+**Ratified: `pdfKey`.** The artifact version stores the R2 **object key**, not a URL.
+Clients receive a short-lived signed URL minted via the existing `getSignedUrl(key)` at
+response-serialization time. Publish fetches bytes server-side via `getFile(key)`, exactly
+as `linkedin-media.service.ts` already does. Propagate the rename to #102 §4, #103 §2–3,
+#106 §5, #107 §3. Semantics are unchanged: `pdfKey` still gates `READY`.
+
+### R2 — a post-repair Zod failure at `GENERATE` is terminal
+
+**Conflict.** #103 §7 classes "Zod-invalid LLM output after a step's own internal retries"
+as terminal. #104 §8 says "still invalid → throw `retryable`." #108 §3 flagged the seam;
+#109 §8 resolved it and asked #110 to ratify.
+
+**Ratified: terminal.** `GENERATE` gets two failure arms:
+
+| Failure at `GENERATE` | Classification |
+|---|---|
+| LLM transport error (429 / 5xx / network) | `retryable` — rides the `attempts: 3` budget |
+| Zod-invalid output surviving the one inline repair retry | **terminal** — `UnrecoverableError` |
+
+The reasoning that decided it: `generate()` already performs one **inline repair retry**
+re-prompting with the exact Zod error — a warm resample with the failure context in the
+prompt. A BullMQ whole-job retry restarts cold from step 1 with that context gone, so it is
+a *worse*-informed resample than the one that just failed. #104 §8's counter-argument
+("cheap, because research is cached") is **false for INITIAL runs**: a retried INITIAL
+research run re-executes `RESEARCH` (the builder keeps the step for `kind === INITIAL`;
+only REFINE reads cached research), so the retry buys a full fresh Tavily pass plus a cold
+generation. And the user is not stuck — `FAILED` versions stay visible in the library
+(#102 §2), so a human-in-the-loop refine with adjusted feedback is strictly more useful
+than a blind retry.
+
+**Amend #104 §8's migration note accordingly.**
+
+### R3 — `StepContext` gains a `renderer` role
+
+**Gap.** #103 §10's `StepContext` exposes `agent / artifacts / meter / emit / run / logger`
+— no renderer. But #108 §6 and #109 §2 both have `RENDER_PDF` call
+`CarouselRendererService`. #109 §9 handed the placement to #110.
+
+**Ratified: a narrow `renderer` role interface,** consistent with the engine's
+"depend on interfaces, not concrete services" principle:
+
+```ts
+interface CarouselRenderer {
+  render(input: { artifactId: string; version: number; templateId: CarouselTheme; slides: Slide[] })
+    : Promise<{ pdfKey: string; pageCount: number }>;
+}
+
+interface StepContext {
+  logger:    Logger;
+  agent:     AgentRunner;       // #104
+  artifacts: ArtifactWriter;    // #102
+  meter:     CreditMeter;       // #105
+  renderer:  CarouselRenderer;  // #108 — added by R3
+  emit:      (e: { type: RunEventType; data: unknown }) => void;  // step.progress only
+  run:       RunRecordHandle;
+}
+```
+
+`CarouselRendererService` implements it and is resolved once in the worker bootstrap
+alongside the other roles. `RENDER_PDF` then mocks as trivially as every other step under
+the repo's manual-construction test style.
+
+### R4 — `StylePreset` (voice) and `CarouselTheme` (look) are different things
+
+**Collision, caught during assembly — no sibling doc saw it.** `StylePreset` **already
+exists** in the repo (`src/agent/style-presets.config.ts`) as a **writing-voice** enum —
+`professional | storytelling | educational | bold | contrarian | founder` — driving
+`STYLE_PRESET_INSTRUCTIONS` in the generation prompts and already persisted on
+`PostDraft.stylePreset`. #108 §1 redefined the same name as a **carousel visual theme**
+(`bold | minimal | editorial | gradient`), and #102 §6 / #109 §2 thread `stylePreset?`
+through the create input to be stamped onto `document.templateId`. Only `bold` appears in
+both value sets, meaning one literal would carry two unrelated meanings.
+
+**Ratified: split the two concepts.**
+
+- **`StylePreset` keeps its existing meaning and its six values** — the *voice* of the
+  prose. It applies to **every** artifact type: a POST, a POLL's question, and a
+  DOCUMENT's slide copy all have a voice.
+- **`CarouselTheme` is new** — `'bold' | 'minimal' | 'editorial' | 'gradient'` — the
+  *look* of a deck. It is meaningful **only for DOCUMENT** artifacts and is what
+  `document.templateId` stores.
+
+Consequences:
+
+```ts
+// create input (#102 §6), amended
+{ type: ArtifactType; prompt: string; withResearch: boolean;
+  stylePreset?: StylePreset;   // voice   — any type
+  theme?: CarouselTheme }      // look    — DOCUMENT only
+
+// Artifact.source (#102 §3), amended
+source: { prompt: string; withResearch: boolean; stylePreset?: StylePreset; theme?: CarouselTheme }
+
+// DOCUMENT content (#102 §4 + #108 §1), amended
+{ commentary?: string;
+  document: { templateId: CarouselTheme; slides: Slide[]; pdfKey?: string; pageCount?: number } }
+```
+
+The #108 §4 selection rule now reads on `theme`, not `stylePreset`: **user-supplied
+`theme` is stamped authoritatively** by `GENERATE` (the model cannot override it); if
+omitted, the model picks a `CarouselTheme` and Zod validates it is a real theme. Voice is
+handled the way it is today — `resolveStylePresetInstruction(stylePreset)` injected into
+the prompt — for all three types. Everywhere #108 says "`StylePreset` = theme id," read
+`CarouselTheme`. `RunState.input` and `ResearchInput`/`GenerateInput` carry both fields.
+
+Rejected — *repurpose `StylePreset` as the theme.* Every artifact type would carry a field
+meaningful only for carousels, and the six voice-shaping prompt instructions would be lost
+for no gain.
+
+### R5 — the `UsageKind` for a render is `pdf_render`
+
+**Conflict.** #103 §9 and #109 §2 write `ctx.meter.record({ kind: 'render', amount: 1 })`.
+#105 §3 defines `type UsageKind = 'llm' | 'web_search' | 'pdf_render'`.
+
+**Ratified: `pdf_render`.** #105 owns the `UsageKind` enum; the engine and the
+`RENDER_PDF` step conform. The surcharge constant is `CREDIT_SURCHARGE_PDF_RENDER`.
+
+### R6 — Redis Streams only; the pub/sub channel is dropped
+
+**Conflict.** #103 §6 has the emitter "both publish [to a pub/sub channel] and append [to a
+durable log]." #107 §4 adopts the Redis Stream as the single source and drops the pub/sub
+relay entirely, because `XREAD BLOCK` unifies replay, live tail, and heartbeat cadence in
+one mechanism with no subscribe-race.
+
+**Ratified: `XADD` only.** The engine's sole emission side-effect is
+`XADD workflow:run:{runId} MAXLEN ~ 1000`. No `PUBLISH`. The HTTP relay reads with
+`XREAD BLOCK`. On the terminal event the engine sets
+`EXPIRE workflow:run:{runId} 3600`.
+
+### R7 — `RENDER_PDF` emits no `step.progress`
+
+**Conflict.** #107 §3 floats a `pageRendered` progress signal from the render step. #108 §6
+and #109 §2 both say there is nothing honest to emit: the render is a single atomic
+`htmlToPdf` call with no observable intermediate state.
+
+**Ratified: none.** The core's `step.started` / `step.completed` bracket the render. The
+`step.progress` event stays in the vocabulary for `RESEARCH`'s `sourcesFound` only.
+`step.progress` remains optional, step-defined, and best-effort — never a required
+checkpoint for clients.
+
+---
+
+## 3. Corrections to stale claims
+
+Facts asserted by the design docs that no longer hold against the current tree. Verified
+against `HEAD` on 2026-07-10.
+
+| Claim | Where | Reality |
+|---|---|---|
+| "the `MarkRun` doc" is prior art; "the `MarkRun` collection is deleted with the rest of `src/mark`" | #105 §5, §11 | **No `MarkRun` collection exists.** Nothing to delete. The prior art for a per-period consumption meter is `FeatureGatingService.assertMarkTokenQuota` / `incrementMarkTokenUsage` + the `mark_tokens` `FeatureKey`, and that is all. |
+| "mirroring how `MarkUsageService` sat above the gating service today" | #105 §4 | **No `MarkUsageService` exists.** The layering it describes (a conversion service above `FeatureGatingService`) is sound, but it is new construction, not a mirror. |
+| "retire all `MARK_*` config" | #104 §9, §12; #105 §5, §11 | **No `MARK_*` keys remain in `.env.example`.** The retirement is already done. What *does* remain is `FEATURE_KEYS.MARK_TOKENS` and the `'mark_tokens'` arm of the `Feature` union — those are R-renamed to `credits` (§9). |
+| "add `TAVILY_API_KEY`" | #104 §12 | Already present in `.env.example:34`. No-op. |
+| "the `compression` filter already excludes the streaming `/mark/chat` route … add the SSE route to the same exclusion" | #107 §7 | The exclusion at `main.ts:20` is **dead** — no `/mark/chat` route or Mark controller exists. **Replace** that line with the SSE exclusion rather than adding a second one. |
+| `src/mark/utils/index.ts` exports the html/pdf utils | implied by #108 §11 | It exports only `html.utils` and `post.util`. `html_to_pdf.util.ts` and `poll.util.ts` are unexported and have **no callers anywhere**. |
+| "`src/mark/artifact.service.ts` … rebuilt to this design" | #102 §10 | Correct, but note `ArtifactService` is the *only* provider `MarkModule` supplies, and `src/database/schemas/artifact.schema.ts` imports `postArtifact`/`pollArtifact` from `src/mark/types/`. That import is the last hard edge binding `src/mark` into the app. |
+
+Two further pre-existing defects the build must clear:
+
+- **`artifact.schema.ts` has an enum/type mismatch**: `@Prop({ enum: ['html','text','structured'] })` on a field typed `ArtifactType` (`'post'|'poll'|'document'`). The schema is rebuilt wholesale (§4), so this dies with it.
+- **`ArtifactType` case changes**: today `'post' | 'poll' | 'document'` (lowercase); the new enum is `POST | POLL | DOCUMENT` (uppercase values). No data to migrate.
+
+---
+
+## 4. Domain model
+
+### `Artifact` — the library unit
+
+A stable, user-owned **family** with an ordered, embedded, append-only `versions[]` array
+and a `currentVersion` pointer. `type` is fixed per family — you refine a poll into a
+better poll, never into a document.
+
+```ts
+enum ArtifactType  { POST = 'POST', POLL = 'POLL', DOCUMENT = 'DOCUMENT' }
+enum VersionStatus { GENERATING = 'GENERATING', READY = 'READY', FAILED = 'FAILED' }
+
+Artifact {
+  _id
+  user:           ObjectId<User>
+  type:           ArtifactType
+  title?:         string
+  source:         { prompt: string; withResearch: boolean;
+                    stylePreset?: StylePreset;    // voice  — R4
+                    theme?: CarouselTheme }       // look   — R4, DOCUMENT only
+  currentVersion: number
+  versions:       ArtifactVersion[]
+  deletedAt?:     Date            // soft delete
+  createdAt, updatedAt
+}
+
+ArtifactVersion {                 // embedded subdocument
+  version:         number         // 1-based
+  status:          VersionStatus
+  content:         ArtifactContent   // stored loose (Object); Zod-validated at the app boundary
+  refineFeedback?: string
+  editedAt?:       Date           // set when the READY head is manually PATCHed
+  failureReason?:  string
+  createdAt:       Date
+}
+```
+
+**Status lives on the version**, never on the family — an artifact's library state derives
+from `currentVersion.status`, so two enums cannot drift. Deletion is orthogonal:
+soft-delete via a family-level `deletedAt`. **Publish state is deliberately absent** —
+whether an artifact has been posted is a `Post` concern; referencing an artifact from a
+post does not mutate it.
+
+A version reaches `READY` only when its content is complete. For DOCUMENT that means
+`pdfKey` is populated. There is no `RENDERING` state; fine-grained progress is the SSE
+stream's job, so the *persisted* status stays coarse.
+
+### `ArtifactContent` — a Zod discriminated union on `type`
+
+```ts
+// POST — text is the whole artifact
+{ commentary: string }                                    // ≤ 3000 LinkedIn-counted chars
+
+// POLL — commentary + inline poll (constraints from #101)
+{ commentary?: string;
+  poll: { question: string;          // ≤ 140 chars
+          options: string[];         // 2–4, each ≤ 30 chars, mutually unique
+          durationDays: 1 | 3 | 7 | 14 } }
+
+// DOCUMENT — commentary + structured slides + rendered PDF
+{ commentary?: string;
+  document: { templateId: CarouselTheme;   // R4
+              slides: Slide[];             // 2–15, shape owned by §8
+              pdfKey?: string;             // R2 key — R1; gates READY
+              pageCount?: number } }
+```
+
+Content is stored as a loosely-typed object in Mongoose and validated by **Zod** at the app
+boundary, matching the repo split (Zod for structured/LLM data, `class-validator` for HTTP
+DTOs).
+
+Two constraints the design docs left implicit, both recovered from `src/mark/utils` before
+those files are deleted (§12) and both now **part of the Zod union**:
+
+- **`commentary` caps at 3000 characters**, counted the way LinkedIn counts them — by
+  UTF-16 code unit, so an astral-plane emoji costs 2. `linkedInCharCount` from
+  `post.util.ts` is the reference implementation and survives the dissolution for exactly
+  this reason. Applies to all three types.
+- **Poll options must be mutually unique** (case-insensitive, trimmed). `poll.util.ts`
+  enforces this today; #101 does not state it and #102's schema omitted it. LinkedIn's
+  behavior on duplicate options is untested, and a poll with two identical options is a
+  product defect regardless.
+
+### `Post` — a publish record, not a draft
+
+In the `PostDraft` world the draft *was* the content. In the artifact world **the artifact
+is the draft** — it lives `READY` in the library. So a `Post` is created **only when the
+user acts to publish or schedule**. There is no `DRAFT` post stage, which collapses the
+status enum to three states and removes a whole redundant lifecycle.
+
+```ts
+enum PostStatus { SCHEDULED = 'SCHEDULED', PUBLISHED = 'PUBLISHED', FAILED = 'FAILED' }
+
+Post {
+  _id                                            // = BullMQ jobId = data.postId
+  user:             ObjectId<User>
+  connectedAccount: ObjectId<ConnectedAccount>   // bound HERE, not on the artifact
+  artifacts: [{ artifact: ObjectId<Artifact>, version: number }]   // PINNED; v1 length 1
+  status:           PostStatus
+  scheduledAt?:     Date
+  publishedAt?:     Date
+  channelPostId?:   string                       // LinkedIn URN from x-restli-id
+  failureReason?:   string
+  createdAt, updatedAt
+}
+```
+
+`artifacts` pins `{ artifact, version }` rather than a bare id, because an artifact is
+mutable — refine appends a version, `PATCH` edits the head in place. A post scheduled for
+next Tuesday publishes the version approved today, even if the artifact is refined three
+times before then. If the pinned version becomes unresolvable at fire time, the worker
+fails the post gracefully (`FAILED`, reason `"source artifact unavailable"`) rather than
+publishing stale or empty content.
+
+The schema's `artifacts` array is real (charter #2) but **publish-composition enforces
+LinkedIn's one-content-object rule** (#101 §4). For v1 a post binds exactly one artifact.
+
+### `WorkflowRun` — the durable run record
+
+```ts
+enum RunKind   { INITIAL = 'INITIAL', REFINE = 'REFINE' }
+enum RunStatus { RUNNING = 'RUNNING', COMPLETED = 'COMPLETED', FAILED = 'FAILED' }
+
+WorkflowRun {
+  _id:              ObjectId       // = runId = BullMQ jobId = Redis stream key suffix
+  user:             ObjectId<User>
+  artifact:         ObjectId<Artifact>
+  targetVersion:    number
+  kind:             RunKind
+  status:           RunStatus
+  input:            BuildInput
+  currentStep?:     WorkflowStep   // updated at each boundary — SSE cold-start fallback
+  researchContext?: ResearchResult // persisted when RESEARCH completes; refine reuses it
+  creditsUsed:      number         // attempt-scoped accumulator, reset each attempt
+  failureReason?:   string
+  createdAt, updatedAt
+}
+```
+
+One durable record per generation, 1:1 with a BullMQ job, giving a clean identity chain
+**run ↔ job ↔ Redis stream**. It decouples durable state from BullMQ's eviction policy
+(jobs are removed on completion). It never copies generated content — that lives on the
+artifact version; the run holds only the `(artifact, targetVersion)` reference.
+
+---
+
+## 5. The workflow engine
+
+A **linear ordered step list** over a **typed, progressively-built run state**. No DAG —
+these flows have no real branching or fan-out; the variation axes are handled by
+*composition*, not runtime edges.
+
+### Composition
+
+```ts
+function buildWorkflow({ type, withResearch, kind }: BuildSpec): WorkflowDefinition {
+  return {
+    name: `artifact:${type}`,
+    steps: [
+      WorkflowStep.RESOLVE_INPUT,
+      ...(withResearch && kind === RunKind.INITIAL ? [WorkflowStep.RESEARCH] : []),
+      WorkflowStep.GENERATE,                                    // dispatches on type internally
+      ...(type === ArtifactType.DOCUMENT ? [WorkflowStep.RENDER_PDF] : []),
+      WorkflowStep.PERSIST_VERSION,
+    ],
+  };
+}
+```
+
+**The emitted step sequence is honest** — only steps that actually run appear. This matters
+because that sequence feeds the SSE progress stream and the progress-bar math, so `total`
+is exact and the bar has no skipped-step gaps.
+
+### Run state
+
+The step list is assembled dynamically, so TypeScript cannot infer a fully-chained
+input→output pipeline. The model is one `RunState` interface with typed, named optional
+slots; each step returns a typed partial patch the engine shallow-merges.
+
+```ts
+interface BuildInput {
+  type: ArtifactType; prompt: string; withResearch: boolean;
+  stylePreset?: StylePreset;    // R4
+  theme?: CarouselTheme;        // R4
+  userId: string; artifactId: string; version: number; kind: RunKind;
+}
+
+interface RunState {
+  input:    BuildInput;                                  // RESOLVE_INPUT
+  research?: ResearchResult;                             // RESEARCH, or seeded on REFINE
+  refine?:  { priorContent: ArtifactContent; feedback: string };  // RESOLVE_INPUT on REFINE
+  content?: ArtifactContent;                             // GENERATE
+  render?:  { pdfKey: string; pageCount: number };       // RENDER_PDF — R1
+}
+
+type StepHandler = (state: RunState, ctx: StepContext) => Promise<Partial<RunState>>;
+```
+
+Steps **read the slots they need** (guarding with a `WorkflowError` if a required upstream
+slot is missing — a programming bug, not control flow) and **write only their own slots**
+via the returned patch. The returned-patch style rather than in-place mutation gives the
+event layer a clean "here is what this step produced" hook.
+
+### Events
+
+The engine core wraps each step, so lifecycle events are guaranteed complete and match the
+honest builder sequence. **Steps emit only what the core cannot observe.**
+
+| Event | Emitted by | `data` |
+|---|---|---|
+| `run.started` | core | `{ kind, type, steps: WorkflowStep[] }` |
+| `step.started` | core (wrap) | `{ step, index, total }` |
+| `step.completed` | core (wrap) | `{ step, index, total }` |
+| `step.failed` | core (wrap) | `{ step, retryable, message }` — non-terminal, "retrying…" |
+| `step.progress` | step via `ctx.emit` | `{ step, ...signal }` — `RESEARCH` only (R7) |
+| `usage.tick` | `ctx.meter.record` | `{ kind, credits, detail? }` |
+| `run.completed` | core | `{ artifactId, version }` |
+| `run.failed` | core | `{ failureReason }` |
+
+```ts
+interface RunEvent { runId: string; seq: number; type: RunEventType; ts: number; data: unknown }
+```
+
+`seq` is a monotonic per-run integer the **core** assigns, starting at 1. Steps supply only
+`{ type, data }`; the core stamps `runId` / `seq` / `ts`. `usage.tick` is emitted by
+`meter.record` — the one call that both accounts and announces — so `ctx.emit` is reserved
+for `step.progress`.
+
+The emitter's **only** side effect is `XADD workflow:run:{runId} MAXLEN ~ 1000` (R6).
+
+### Error and retry semantics
+
+A retry re-runs the **whole** job from step 1 — there are no per-step checkpoints, because
+charter #5 fixed no mid-run resume.
+
+- **BullMQ:** `attempts: 3`, `backoff: { type: 'exponential' }`.
+- **Taxonomy:** `WorkflowError { retryable: boolean; reason: string }`. Transient
+  (`retryable: true`) rides the attempt budget. Terminal (`retryable: false`) is rethrown
+  as BullMQ's `UnrecoverableError`, which stops retries immediately.
+
+**Why whole-job retry is safe:** a run targets a *fixed* `(artifactId, version)` created as
+`GENERATING` at kickoff. Every step, including `PERSIST_VERSION`, writes to that same fixed
+version, so a retry *overwrites* rather than appending. No duplicate versions. The only
+non-idempotent side effect is usage accounting, handled by the attempt-scoped reset (§9).
+
+**Terminal-failure handler** (a job-level `failed` handler mirroring the existing
+`media-upload` `exhausted` idiom), fired only on attempts-exhausted or `UnrecoverableError`:
+
+1. Target version → `FAILED` with `failureReason`.
+2. `WorkflowRun` → `FAILED` with `failureReason`.
+3. Emit `run.failed { failureReason }`.
+4. **No credit commit** — the user is not charged for a failed run.
+
+Intermediate will-retry failures emit `step.failed` and leave the version `GENERATING`.
+
+### Refine re-entry
+
+A refine is a **new run** (`kind: REFINE`) over an existing artifact. `POST
+/artifacts/:id/refine { feedback }` appends a new `GENERATING` version and returns
+`202 { artifactId, version, runId }`, then kicks off the run that fills it.
+
+`RESOLVE_INPUT` seeds `input` from the family-level `source`, plus
+`refine = { priorContent, feedback }`, plus `research` **copied from the artifact's latest
+`COMPLETED` `WorkflowRun.researchContext`**. The builder omits `RESEARCH` for
+`kind: REFINE`, so refine re-charges no web-search surcharge and adds no latency. If the
+original run was research-off there is simply no cached research, and `GENERATE` runs on
+prompt + feedback alone.
+
+---
+
+## 6. Step pipelines
+
+Nine `(type × kind × withResearch)` combinations — the 3 × 2 × 2 product minus the three
+REFINE-with-research-on combos that cannot exist — collapse to **four distinct step-list
+shapes**:
+
+| Shape | Step list | Used by |
+|---|---|---|
+| **A** | `RESOLVE_INPUT → GENERATE → PERSIST_VERSION` | POST/POLL initial research-off; POST/POLL refine |
+| **B** | A + `RESEARCH` | POST/POLL initial research-on |
+| **C** | A + `RENDER_PDF` | DOCUMENT initial research-off; DOCUMENT refine |
+| **D** | A + `RESEARCH` + `RENDER_PDF` | DOCUMENT initial research-on |
+
+**POST and POLL share identical pipelines.** They differ only in `GENERATE`'s output shape
+and in what `PERSIST_VERSION` Zod-validates. **DOCUMENT is POST/POLL + `RENDER_PDF`.** That
+is the entire variation surface.
+
+### The five steps
+
+| Step | Kind | Metered | Conditional on |
+|---|---|---|---|
+| `RESOLVE_INPUT` | code | no | always |
+| `RESEARCH` | **AI** (agentic tool loop) | `llm` per turn + `web_search` per call | `withResearch && kind === INITIAL` |
+| `GENERATE` | **AI** (single completion) | `llm` per turn | always |
+| `RENDER_PDF` | code (deterministic) | `pdf_render` fixed surcharge (R5) | `type === DOCUMENT` |
+| `PERSIST_VERSION` | code | no | always |
+
+Exactly two AI steps. Note that the AI/code axis and the metering axis are independent — a
+code step can still be metered. The deterministic spine (`RESOLVE_INPUT`, `RENDER_PDF`,
+`PERSIST_VERSION`) is what makes whole-job retry safe.
+
+**`RESOLVE_INPUT`** — materializes the typed `RunState` from `job.data: BuildInput`. On
+REFINE it additionally seeds `refine` (prior content + feedback) and `research` (from the
+run-record cache). A missing target artifact/version is **terminal** — kickoff created
+them, so absence is a bug, and re-running cannot fix it.
+
+**`RESEARCH`** — calls `ctx.agent.research({ prompt, type, stylePreset })` → `ResearchResult
+{ findings, sources }`. Writes the `research` slot **and** persists `researchContext` on the
+`WorkflowRun` so a later refine reuses it with zero re-search. Emits optional
+`step.progress { sourcesFound }`. Tool errors are absorbed in-loop; an LLM transport error
+surfaces as `WorkflowError { retryable }` per `src/llm`'s classification.
+
+**`GENERATE`** — calls `ctx.agent.generate(...)` → `ArtifactContent`, one `complete` call
+with no tools, validated against the §4 Zod union with **one inline repair retry**.
+Dispatch on `type`. For DOCUMENT, `templateId` resolution happens **inside this step**: a
+user-supplied `theme` is stamped authoritatively (the model cannot override it); if omitted
+the model picks one and Zod validates it is a real `CarouselTheme` (R4). `slides` is the
+only thing set here — `pdfKey` and `pageCount` are `RENDER_PDF`'s job. Failure arms per R2.
+
+**`RENDER_PDF`** — calls `ctx.renderer.render(...)` (R3), which owns
+`assembleHtml → htmlToPdf → uploadFile`. Writes `render = { pdfKey, pageCount:
+slides.length }`. Emits **no** `step.progress` (R7) and one
+`ctx.meter.record({ kind: 'pdf_render', amount: 1 })` (R5). A Browserless timeout is
+**retryable**; an unknown `templateId`/`slide.type` at assembly is **terminal** (Zod already
+validated the content, so it cannot occur and re-running cannot fix it).
+
+**`PERSIST_VERSION`** — calls `ctx.artifacts.setVersionContent(artifactId, version, content,
+render?)`: writes `content`, folds `render.pdfKey` + `pageCount` into `content.document` for
+documents, and flips `GENERATING → READY`. The run's only durable content write. On
+`run.completed` the engine calls `meter.commit(runId)` — the **only** real credit debit,
+charged once for the winning attempt. A DB write error is retryable; the write targets the
+fixed `(artifactId, version)`, so a retry overwrites rather than appends.
+
+### Run-state slot lifecycle
+
+| Slot | Set by | Read by |
+|---|---|---|
+| `input` | `RESOLVE_INPUT` | every downstream step |
+| `refine` | `RESOLVE_INPUT` (REFINE only) | `GENERATE` |
+| `research` | `RESEARCH`, **or** `RESOLVE_INPUT` on REFINE (from cache) | `GENERATE` |
+| `content` | `GENERATE` | `RENDER_PDF` (document), `PERSIST_VERSION` |
+| `render` | `RENDER_PDF` (document only) | `PERSIST_VERSION` |
+
+`research` has two producers and one consumer; `GENERATE` reads it agnostic of origin.
+`content` is the hinge — the AI product every downstream code step renders or persists.
+
+### Research invocation rules
+
+One rule, uniform across all three types (POST, POLL, and DOCUMENT honor `withResearch`
+identically — a topical poll or carousel benefits from fresh findings exactly as a post
+does, and special-casing would fork the clean one-rule builder for no gain):
+
+- **Runs** iff `withResearch === true` **and** `kind === INITIAL`.
+- **Skipped on REFINE, always** — research is cache-seeded from the run record.
+- **Re-runs on a whole-job retry of an INITIAL research run.** The builder still contains
+  `RESEARCH` for `kind === INITIAL`, so a retry executes a fresh Tavily pass. This is
+  precisely why R2 lands on terminal: the "retry is cheap because research is cached"
+  premise holds only for REFINE.
+
+---
+
+## 7. The agent loop
+
+Built in **two layers**, so swapping providers never touches the loop.
+
+### Layer 1 — the LLM abstraction (`src/llm`), provider-swappable
+
+Today's single `generateCompletion → string` grows into the single-turn primitives the loop
+needs:
+
+```ts
+interface LLMStrategy {
+  complete(messages: LLMMessage[], opts?: CompletionOptions): Promise<CompletionResult>;
+  completeWithTools(messages: LLMMessage[], tools: ToolDefinition[], opts?: CompletionOptions)
+    : Promise<ToolTurnResult>;                                          // ONE turn
+  stream?(messages: LLMMessage[], opts?: CompletionOptions): AsyncIterable<string>;  // reserved
+}
+
+interface CompletionResult { text: string; usage: Usage }
+interface ToolTurnResult   { text?: string; toolCalls: ToolCall[]; usage: Usage }
+interface ToolDefinition   { name: string; description: string; parameters: ZodType }
+interface ToolCall         { id: string; name: string; input: unknown }
+interface Usage { promptTokens: number; completionTokens: number; totalTokens: number; cost: number }
+```
+
+The OpenRouter strategy implements these over `@openrouter/sdk` — its `tool()` Zod helper
+for schema conversion, `chat.send` with `tools` for the single turn, and `usage.cost` /
+`costDetails` for real per-call dollar cost. Add a typed `LLMError { retryable }`: the
+`src/llm` layer owns retryable classification because it knows provider error semantics
+(429/5xx/network → retryable; 4xx/auth → terminal).
+
+We deliberately do **not** adopt the SDK's `callModel` orchestrator, which ships an
+automatic multi-turn tool loop — burying the loop inside the vendor SDK defeats the
+provider-swappability the layering exists for. We lean on its lower-level per-turn helpers
+and own the loop.
+
+### Layer 2 — `AgentRunner`, provider-agnostic
+
+```ts
+interface Tool<I = unknown, O = unknown> {
+  name: string; description: string;
+  parameters: ZodType<I>;
+  execute: (input: I) => Promise<O>;
+}
+
+interface AgentRunConfig { system: string; messages: LLMMessage[]; tools: Tool[]; maxSteps: number; model?: string }
+interface AgentStep      { toolCalls: ToolCall[]; toolResults: unknown[]; usage: Usage }
+interface AgentRunResult { text: string; steps: AgentStep[]; usage: Usage }
+interface AgentHooks     { onUsage?: (u: Usage) => void; onToolCall?: (t: { name: string }) => void }
+
+run(config: AgentRunConfig, hooks?: AgentHooks): Promise<AgentRunResult>;
+```
+
+**The loop:** append seed messages → `completeWithTools` → if `toolCalls` is empty, return
+`text`; else execute the called tools **in parallel within a turn** (`Promise.all`), append
+their outputs as `role: 'tool'` messages, increment the step counter, repeat.
+
+**Cap behavior — graceful finalization.** When `maxSteps` is reached but the model still
+wants tools, make **one final completion with the tools removed** ("budget spent, answer
+now"). This guarantees usable `text` instead of a dangling tool call and bounds worst-case
+spend at `maxSteps + 1` LLM calls. A hard throw on cap would turn "the model was being
+thorough" into a failed run that the engine would then retry into the same cap.
+
+### Public surface
+
+```ts
+interface AgentRunner {
+  research(input: ResearchInput): Promise<ResearchResult>;   // agentic
+  generate(input: GenerateInput): Promise<ArtifactContent>;  // single structured completion
+}
+
+interface ResearchInput { prompt: string; type: ArtifactType; stylePreset?: StylePreset }
+interface GenerateInput {
+  type: ArtifactType; prompt: string;
+  stylePreset?: StylePreset;   // voice — R4
+  theme?: CarouselTheme;       // look  — R4, DOCUMENT only
+  research?: ResearchResult;
+  refine?: { priorContent: ArtifactContent; feedback: string };
+}
+```
+
+**Generation is not a loop.** `generate()` has all its inputs already; it emits typed
+`ArtifactContent` via Layer 1's `complete` (no tools), validated by
+`ResponseParserService.parseWithSchema` against the §4 union, with one inline repair retry
+re-prompting with the validation error. Prompt selection per type and per revision is
+`AgentRunner`'s internal concern.
+
+### The research agent
+
+- **One tool, `searchWeb` (Tavily).** `{ query: string }` → `{ results: {title,url,content,score}[] }`,
+  `searchDepth: 'advanced'`, `maxResults: 5`. On failure it returns `{ error }` and never
+  throws — the loop absorbs it and the model adapts.
+- **Fully autonomous.** No `ask_clarification` — there is nowhere to deliver a question in
+  the async fire-and-forget model. The agent **self-directs its own search queries** across
+  turns. This replaces today's `generateSearchKeywords` + `searchWithFallbacks` pre-steps;
+  there is no separate keyword-generation stage.
+- **`maxSteps = 5`**, config-driven via `RESEARCH_MAX_STEPS`.
+
+```ts
+interface ResearchSource { title: string; url: string }
+interface ResearchResult { findings: string; sources: ResearchSource[] }
+```
+
+`findings = result.text` (the agent's own synthesis after searching);
+`sources = dedupeByUrl(...)` across every `searchWeb` result. **Raw search bodies are not
+forwarded** — `GENERATE` gets the distilled findings, not a dump of five 5-result payloads,
+keeping the generation prompt tight. Stored verbatim on `researchContext`, so refine reuses
+it with zero re-search.
+
+### Usage accounting
+
+`AgentRunner` must **not** hold the meter. The seam is a per-turn hook the step bridges to
+`ctx.meter`:
+
+- The loop invokes `hooks.onUsage(usage)` after **each** LLM turn and
+  `hooks.onToolCall({ name })` when a tool fires.
+- The step wires those to `ctx.meter.record(...)`: each LLM turn →
+  `{ kind: 'llm', amount: usage.cost, detail: { model, totalTokens } }`; each web search →
+  `{ kind: 'web_search', amount: 1 }`.
+
+`AgentRunner` emits raw signals; §9 owns converting them to credits. Live per-turn emission
+is what lets the SSE stream show a climbing credit count during a long research run.
+
+### Scope
+
+**OpenRouter-only for v1.** The `LLMProvider` enum keeps its unimplemented `OPENAI` /
+`CLAUDE` arms; the layering makes adding a real strategy later an addition, not a loop
+change. Per-role model config via `ConfigService`: `RESEARCH_MODEL` (fast, tool-loop turns)
+and `GENERATION_MODEL` (stronger, final content) — retiring the scattered hardcoded model
+literals. **Token streaming is deferred**; `stream()` stays an optional, unimplemented
+method on the strategy interface. Live progress comes entirely from step events plus
+`usage.tick`, which is enough for a "researching… generating…" UI with a running credit
+count, without token-level plumbing.
+
+---
+
+## 8. The carousel template system
+
+A carousel is a LinkedIn **document post**: a multi-page PDF, one page per slide, on the
+1080×1350 portrait canvas. (LinkedIn's `content.carousel` is a *different*, sponsored-only
+ad format and is unavailable to us for organic posting.)
+
+### Template model — theme (deck) × slide type (role)
+
+```ts
+type CarouselTheme = 'bold' | 'minimal' | 'editorial' | 'gradient';   // R4
+type SlideType     = 'cover' | 'content' | 'list' | 'quote' | 'cta';
+
+Slide = { type: SlideType; fields: <type-specific, Zod-validated> };
+```
+
+**Theme is document-level, not per-slide** — a carousel's whole point is a consistent brand
+look across pages. **`type` is per-slide** — real carousels are not homogeneous; a cover
+(hook), body slides, and a CTA are visually distinct roles. **Field schemas attach to the
+slide type, not the theme**: every theme renders the same five typed shapes and differs only
+in how they look. That is what lets one Zod contract serve the artifact content union, the
+agent's generation contract, and all four themes simultaneously.
+
+### Field schema
+
+```ts
+const cap = (n: number) => z.string().trim().min(1).max(n);
+
+export const slideFieldSchemas = {
+  cover:   z.object({ eyebrow: cap(24).optional(), title: cap(70), subtitle: cap(120).optional() }),
+  content: z.object({ heading: cap(60), body: cap(280) }),
+  list:    z.object({ heading: cap(60), items: z.array(cap(80)).min(2).max(6) }),
+  quote:   z.object({ quote: cap(200), attribution: cap(48).optional() }),
+  cta:     z.object({ headline: cap(70), action: cap(40), handle: cap(40).optional() }),
+} as const;
+
+export const slideSchema  = z.discriminatedUnion('type', [ /* one arm per SlideType */ ]);
+export const slidesSchema = z.array(slideSchema).min(2).max(15);
+```
+
+**Caps are the fit contract, sized to the tightest theme.** A fixed 1080×1350 slide has no
+scroll, so overflow is the enemy. Character count is only a *proxy* for rendered width, so
+the caps are enforced three ways, defence in depth: the agent prompt states them so the
+model aims within them; Zod rejects over-cap output at the generation boundary; and the
+`.slide` frame's `overflow: hidden` + `overflow-wrap: anywhere` is the last-resort clamp, so
+a slip degrades to clipped text rather than a broken layout or a spilled page.
+
+**The fixture deck is the fit proof.** Each theme ships a 15-slide `fixture.json` exercising
+every slide type at maximum field lengths (6-item list, full-cap strings, an emoji, a long
+unbroken token). A registry spec asserts it assembles cleanly; rendering the fixtures to PDF
+is the manual QA gate per theme before launch. Caps are only trustworthy because the
+fixtures prove them.
+
+Launch is **text-only** — no user-supplied slide images. `slideSchema` is a discriminated
+union precisely so a future `image` arm touches no existing one.
+
+### Pagination — the one-slide-one-page invariant
+
+The whole deck is **one HTML document rendered in one `htmlToPdf` call**. Puppeteer
+paginates it; the CSS must make that pagination exact:
+
+```css
+.slide {
+  box-sizing: border-box;   /* theme padding never inflates the box */
+  width: 1080px; height: 1350px;
+  overflow: hidden;         /* nothing ever spills onto the next page */
+  overflow-wrap: anywhere;  /* one long token can't blow the box sideways */
+  break-after: page;
+  break-inside: avoid;
+}
+.slide:last-child { break-after: auto; }   /* load-bearing: no blank trailing page */
+```
+
+The `:last-child` override is not cosmetic — a break after the final slide emits an empty
+page LinkedIn would show as a blank last card. `htmlToPdf` already passes
+`width: '1080px', height: '1350px'`, zero margins, `printBackground: true`, and a matching
+viewport, so the page box matches the slide box exactly and `pageCount = slides.length` is
+true by construction.
+
+### Self-contained HTML
+
+Browserless renders the POSTed HTML with no reliable access to our asset host, so the
+assembled document must resolve **zero network requests**. All CSS inlined in one `<style>`;
+system font stacks by default (a brand font would be a subset WOFF2 `data:` URI); decoration
+is CSS or inline SVG. With nothing to fetch, the util's `waitUntil: 'networkidle0'` resolves
+immediately.
+
+**Emoji caveat:** whether emoji render depends on the Browserless image shipping a color
+emoji font (Noto Color Emoji is standard but unverified). The fixture deck includes an emoji
+sample. If it renders as tofu, the generation prompt bans emoji rather than embedding a
+multi-megabyte font.
+
+### Security — LLM fields never become markup
+
+Every slide field is LLM-generated, i.e. untrusted text flowing into HTML.
+
+- **Double-stache `{{field}}` only**, and **only in element text content** — never in
+  attributes, URLs, `<style>`, or comments, where HTML-escaping is not a sufficient defence.
+  Lists use `{{#each items}}`.
+- **Triple-stache `{{{…}}}` is banned and machine-enforced**: the registry's boot-time
+  compile fails on any template source containing `{{{`, turning the rule from a review
+  checkpoint into an invariant that cannot erode as templates are added. No custom helpers
+  emitting `SafeString`s either.
+- Rendering is sandboxed anyway — Browserless paints a PDF from an inert document with no
+  cookies, no same-origin secrets, no navigation. Escaping is defence in depth, not the only
+  wall.
+
+### Rendering pipeline
+
+At **module init**, the registry loads and `Handlebars.compile`s every `(theme, slideType)`
+template once and **fails fast** if any file is missing, fails to compile, or contains
+`{{{`. Per render, `CarouselRendererService`:
+
+1. `assembleHtml(templateId, slides)` — pure, no I/O: apply each precompiled template to
+   `slide.fields`, wrap in `<section class="slide slide--{{type}}">`, concatenate in order
+   inside one document whose `<head>` inlines `base.css` + the theme's `theme.css`.
+2. `htmlToPdf(html)` → `Buffer`.
+3. `uploadFile('artifacts/${artifactId}/${version}/document.pdf', buffer, 'application/pdf')`.
+4. Return `{ pdfKey, pageCount: slides.length }`.
+
+Assembly is pure string-in/string-out, so it unit-tests without Browserless.
+
+### Storage — store the key, sign on read (R1)
+
+The R2 key is `artifacts/${artifactId}/${version}/document.pdf` — **version-scoped**, so a
+refine renders to a fresh key and never clobbers a prior version's PDF, and a whole-job
+retry PUTs the same key (idempotent, no orphans). The bucket is private, so the version
+stores the **key**; client reads exchange it for a signed URL at response time and publish
+fetches the buffer via `getFile(key)`. The rendered PDF *is* the document's preview — no
+separate thumbnail asset for launch.
+
+### Layout
+
+```
+assets/carousel/
+  base.css
+  templates/{bold,minimal,editorial,gradient}/
+    cover.hbs content.hbs list.hbs quote.hbs cta.hbs theme.css fixture.json
+
+src/carousel/
+  index.ts  carousel.module.ts
+  carousel-renderer.service.ts   carousel-renderer.service.spec.ts
+  templates.ts     # registry + boot-time compile/validation
+  schemas.ts       # slideFieldSchemas / slideSchema / slidesSchema — single source of truth
+  utils/index.ts  utils/html-to-pdf.util.ts   # moved from src/mark, kebab-cased
+```
+
+`schemas.ts` is consumed by both the artifact content union (§4) and the agent's `generate()`
+validation. The registry deliberately does **not** carry schemas — keying them by theme would
+invite per-theme divergence of a contract that must stay uniform. Adding a theme later is a
+new folder plus one registry entry; no schema or engine change.
+
+---
+
+## 9. Credits
+
+### Denomination — a cost-backed unit
+
+```
+1 credit = $0.001 of raw provider cost   →   CREDITS_PER_USD = 1000
+credits  = ceil(amount_usd * CREDITS_PER_USD * CREDIT_MARKUP)
+```
+
+`CREDITS_PER_USD` and `CREDIT_MARKUP` (default `1.0`) are **global** env, never per-tier.
+Per-tier config carries only the allowance.
+
+Because `amount_usd` is OpenRouter's authoritative per-call `usage.cost` — which already
+prices each model's input and output tokens at that model's real rate — the credit price of
+a call is **automatically correct per model and self-updating** when OpenRouter changes
+prices. A raw token count would be price-blind: 1000 tokens of a frontier model and 1000 of
+a cheap one cost the operator wildly different amounts yet would debit the same budget, and
+it would need a hand-maintained per-model table that drifts every time provider prices move.
+`usage.cost` already encodes all of that. Margin lives in two tunable levers —
+`CREDIT_MARKUP` and the Paddle price of an allowance — so pricing can move without a code
+change.
+
+**Fallback (only when cost is missing).** If a provider returns `usage.cost` as
+`0`/`undefined`, fall back to `ceil(totalTokens / 1000 * FALLBACK_CREDITS_PER_1K_TOKENS)`
+and **log a warning**. For OpenRouter v1 `cost` is always present, so this should never
+fire; it exists so a future provider without cost reporting cannot slip through free.
+Tokens are carried on `detail.totalTokens` for display and audit, never for pricing.
+
+### Surcharges
+
+Web search and PDF render cost real money but emit no `usage.cost`. Each carries a flat
+credit surcharge, priced in the same unit so it is commensurable with LLM credits:
+
+| `UsageKind` | Fired by | Env constant | Illustrative |
+|---|---|---|---|
+| `llm` | every LLM turn | — (cost-derived) | — |
+| `web_search` | research agent, per Tavily call | `CREDIT_SURCHARGE_WEB_SEARCH` | `8` |
+| `pdf_render` | `RENDER_PDF`, per render (R5) | `CREDIT_SURCHARGE_PDF_RENDER` | `5` |
+
+`record`'s `amount` is **polymorphic by `kind`** — USD for `llm`, a unit count for
+surcharges (`credits = amount * CREDIT_SURCHARGE_<KIND>`). This asymmetry is inherited from
+the committed `record({ kind, amount })` shape; it is pinned in one conversion table rather
+than reshaping the upstream signal. A surcharge as a *percentage* of the run's LLM credits
+was rejected: a web search's cost is fixed and independent of how expensive the generation
+model is.
+
+### `CreditMeterService`
+
+```ts
+interface CreditMeter {                                    // engine-composed, §5
+  assertBalance(userId: string): Promise<void>;
+  record(usage: { kind: UsageKind; amount: number; detail?: unknown }): void;
+  commit(runId: string): Promise<void>;
+}
+
+@Injectable()
+class CreditMeterService {                                 // stateless half
+  toCredits(usage: { kind: UsageKind; amount: number }): number;  // pure, sync
+  assertBalance(userId: string): Promise<void>;
+  debit(userId: string, credits: number): Promise<void>;
+}
+```
+
+**Split of ownership.** The engine owns the *stateful, per-run* half: the attempt-scoped
+`creditsUsed` accumulator on `WorkflowRun`, the per-attempt reset, and `usage.tick`
+emission. `CreditMeterService` owns the *stateless* half. `record` calls `toCredits(...)`,
+adds to the accumulator, and emits `usage.tick` with the credit delta plus running total.
+`commit(runId)` reads the winning attempt's `creditsUsed` and calls `debit(...)` — the only
+real write to the period aggregate. `toCredits` is pure and synchronous (config in, integer
+out), which keeps `record` non-async and makes it trivially unit-testable.
+
+`CreditMeterService` **depends on** `FeatureGatingService` for tier/period/`Usage`
+primitives and adds conversion on top. Putting the accumulator in `CreditMeterService` was
+rejected: it is per-run state the engine already owns and resets, and duplicating it invites
+double-count.
+
+### Schema changes
+
+**`FeatureKey` — rename, don't add.** `mark_tokens` → `credits`; it is already a variable
+per-period consumption meter, so this re-denominates and re-scopes it rather than inventing
+a sibling. `ai_drafts` is **removed**.
+
+```ts
+export const FEATURE_KEYS = {
+  CREDITS: 'credits',                        // was mark_tokens
+  CONNECTED_ACCOUNTS: 'connected_accounts',  // capacity counter — unchanged
+  SCHEDULED_POSTS: 'scheduled_posts',        // capacity counter — unchanged
+} as const;
+
+type Feature = 'credits' | 'connected_accounts' | 'scheduled_posts';   // Tier.limits
+```
+
+`limits.credits` is the per-period allowance: positive integer, `-1` = unlimited
+(short-circuits the guard), `0` = **AI disabled on this plan**. `Usage` is unchanged —
+consumption keyed `(user_id, 'credits', periodStart)`, same unique index, same `$inc` upsert
++ E11000-retry write path. **Period resolution is reused verbatim** (subscription
+`currentPeriodStart`, or UTC-month start). Credits reset each period; **no rollover** in v1.
+
+**No new ledger collection.** The per-run breakdown lives on `WorkflowRun.creditsUsed` plus
+the recorded ticks; the period total lives on `Usage`. That covers dashboard, SSE, and audit
+without a third store.
+
+### Enforcement — three touch points
+
+1. **HTTP pre-check.** `POST /artifacts` and `/refine` call `assertBalance(userId)` before
+   enqueueing, so an out-of-credits user gets an immediate `FeatureGateForbiddenException`
+   (403, code `FEATURE_LIMIT_EXCEEDED`, feature `credits`) instead of a queued run that
+   fails. Same exception shape the frontend already handles.
+2. **Worker pre-run guard.** The engine calls `ctx.meter.assertBalance(userId)` before the
+   step loop. Insufficient → **terminal** `WorkflowError` → run/version `FAILED`, reason
+   `"insufficient credits"`. Guards the race where balance drained between enqueue and
+   pickup.
+3. **Post-run debit.** On `run.completed`, `commit(runId)` debits the winning attempt.
+   Failed and retried attempts debit **nothing** — the operator absorbs transient-failure
+   spend. Settlement is **best-effort** (try/catch + log): never fail a user's *completed*
+   run over an accounting write.
+
+**Balance semantics — headroom check, not fit check.** `assertBalance` passes iff
+`used < limit` (or `limit === -1`). It does not verify the whole run will fit, because
+commit-on-success has no pre-run estimate to fit against. A user with 5 credits left may
+start a run that settles at 60 and overshoot; the **next** run's guard blocks. Bounded
+overshoot is accepted and intentional — the agent's `maxSteps` cap bounds a single run's
+worst case. **No mid-run cutoff in v1**; the live `creditsUsed` accumulator leaves room for
+one without new plumbing.
+
+**Refine runs** reuse cached research → no `web_search` surcharge, only the generation LLM
+call (plus `pdf_render` for DOCUMENT). Metered and gated identically; just cheaper.
+
+### Fate of the existing counters
+
+| Current feature | Fate | Why |
+|---|---|---|
+| `mark_tokens` | → **`credits`** (renamed, re-denominated) | already the per-period consumption meter |
+| `ai_drafts` | **retired** | every generation run debits credits; a separate draft counter is redundant double-gating |
+| `scheduled_posts` | **unchanged counter** | scheduling is a plan *capacity* limit, not compute |
+| `connected_accounts` | **unchanged counter** | account capacity, not consumption |
+
+There is no coexistence window for `ai_drafts`: the clean write-over deletes the draft path
+that gated it, so the counter has no remaining caller. `getDashboardUsage` returns `credits`
+(used/limit/remaining, `-1` for unlimited) alongside the two counters; the `ai_drafts` and
+`mark_tokens` keys are dropped.
+
+### Paddle / tier config
+
+Each plan's Paddle price maps to a tier carrying `limits.credits`, seeded from *target model
+cost per average run × expected runs per month × `CREDIT_MARKUP`*. Illustrative ladder: free
+`0` (no AI) or a small trial grant, Starter `2000`, Pro `10000`, top tier `-1`.
+
+**Sizing anchor** (illustrative, at `CREDITS_PER_USD = 1000`, markup `1.0`): an insight post
+≈ research (~$0.02) + generation (~$0.01) + one web search (`8`) ≈ **~38 credits**; a quick
+post (no research) ≈ **~12 credits**; a carousel adds a `pdf_render` (`5`). So "2,000
+credits" ≈ 50 insight posts or ~160 quick posts.
+
+**Upgrades take effect immediately** — the allowance is read live from the resolved tier at
+guard time while the `Usage` aggregate persists, so a mid-period upgrade instantly raises
+headroom without touching usage rows. Downgrade lowers the ceiling the same way; a user
+already over the new ceiling is blocked until the next period, with no clawback. Reset
+cadence is the existing usage period, reused verbatim.
+
+---
+
+## 10. Post and publish
+
+### Creating a post
+
+```
+POST /posts   { artifactId, version?, connectedAccount, scheduledAt? }
+```
+
+1. **Resolve and authorize** — load the artifact owner-scoped (403 if not the caller's);
+   resolve `version` (defaults to `currentVersion`); resolve the account via the existing
+   `getOwnedUsableLinkedinConnectedAccount(userId, accountId, action)`.
+2. **Validate publishability** — the pinned version must be `READY` (cannot post
+   `GENERATING` or `FAILED`); the composition must be valid for LinkedIn (trivially so for
+   a single artifact — this is the seam where a future text+image pair is checked against
+   the mutual-exclusivity rule); org accounts keep the existing `assertCompanyPagesAccess`
+   gate.
+3. **Branch on `scheduledAt`** — absent → run `publishPost` inline and persist `PUBLISHED`
+   (+ `channelPostId`, `publishedAt`) or `FAILED` (+ `failureReason`). Present → assert the
+   `scheduled_posts` counter on first-time schedule, persist `SCHEDULED`, enqueue the job,
+   increment the counter.
+
+### Publish composition
+
+`publishPost(postId)` is **one routine**, invoked inline for immediate publish and by the
+`post-schedule` worker at fire time.
+
+**Reused verbatim** from today's `publishOnLinkedIn`: the `POST {LINKEDIN_API_BASE}/posts`
+call with the `LinkedIn-Version: 202601` / `X-Restli-Protocol-Version: 2.0.0` / `Bearer`
+header trio (202601 is confirmed valid for posts, polls, *and* documents);
+`resolveLinkedinAuthorUrn`; the `visibility` / `distribution` / `lifecycleState` /
+`isReshareDisabledByAuthor` envelope; `commentary` via `formatLinkedinContent`;
+`x-restli-id` capture into `channelPostId`; connected-account decryption and the
+`"Organization permissions must be used"` → reconnect error mapping. `ScheduleQueue` and the
+`post-schedule` queue are unchanged, now keyed on `Post._id`.
+
+**Rebuilt** — content composition reads the pinned artifact version, not `post.content` /
+`post.media[]`:
+
+| Artifact `type` | `commentary` | `content` object | Asset upload at publish |
+|---|---|---|---|
+| **POST** | the text | *(none)* | none |
+| **POLL** | optional | `content.poll = { question, options[], settings: { duration, voteSelectionType: 'SINGLE_VOTE', isVoterVisibleToAuthor: true } }` | **none** — inline JSON |
+| **DOCUMENT** | optional | `content.media = { id: <documentUrn>, title }` | **yes** — R2 `pdfKey` → LinkedIn |
+
+- **`IContent` gains a `poll` arm.** The document rides in the existing `media.id` with a
+  `urn:li:document:*` id — no new `IContent` field.
+- **Duration mapping:** `durationDays: 1|3|7|14` → `ONE_DAY|THREE_DAYS|SEVEN_DAYS|FOURTEEN_DAYS`.
+  `voteSelectionType` fixed `SINGLE_VOTE` (`MULTIPLE_VOTE` is documented as future);
+  `isVoterVisibleToAuthor` fixed `true` (`false` returns 400).
+- **Document upload** happens at publish time from the already-rendered PDF. New
+  `uploadDocument` on `LinkedinMediaService`, modeled on `uploadImage`, **not**
+  `uploadVideo`: `POST /rest/documents?action=initializeUpload` → **single PUT** of the
+  bytes → the returned `value.document` URN. No chunking, no per-chunk ETags, no
+  `finalizeUpload` step (documents explicitly do not support `SYNCHRONOUS_UPLOAD` either).
+  Defensively poll `GET /rest/documents/{urn}` to `AVAILABLE` before attaching, mirroring
+  `waitForVideoAvailable` — the docs show upload immediately followed by post creation and
+  never state a mandatory wait, so this is unconfirmed and we wait to be safe. Enforce
+  ≤100 MB / ≤300 pages before upload.
+
+**Immediate-publish latency:** a DOCUMENT immediate-publish does init→PUT→poll inline, so
+the HTTP call blocks on the LinkedIn upload. Acceptable for a one-shot PUT; if it proves
+slow, route immediate publish through the schedule queue with `delay: 0` — same
+`publishPost`, and the seam is already there.
+
+### Retired for v1, preserved as the future-image seed
+
+The **post-level embedded-media user-upload path** — `addLinkedinMedia`, the presigned
+`initiate`/`complete` direct-to-R2 flow, and the `media-upload` queue that patched
+`PostDraft.media.$` — goes dormant. Artifact content is produced by *generation* (documents
+pre-rendered to R2), so a post never uploads user media in v1.
+`LinkedinMediaService`'s **LinkedIn-upload half** (`uploadImage`, new `uploadDocument`,
+`waitFor*Available`, R2 `getFile`) is reused by `publishPost`; its **user-upload half**
+stays for the future image artifact type.
+
+### Cancel / reschedule / retry
+
+- **`DELETE /posts/:id`** — cancels a `SCHEDULED` post: `getJob(postId)` → `remove()`, then
+  delete the record. Does **not** touch the source artifact.
+- **`POST /posts/:id/schedule { scheduledAt }`** — reschedule a `SCHEDULED`/`FAILED` post
+  (remove old job, add new). First-ever schedule counts against `scheduled_posts`; a
+  reschedule of an already-counted post does **not** re-charge.
+- **`POST /posts/:id/publish`** — publish immediately; enables one-click retry of a `FAILED`
+  post.
+
+### Compat-audit residue
+
+The data-migration hazards (in-flight jobs, stranded media, orphaned R2 objects,
+aggregations, backfill) are **moot** under the clean write-over: drop `postdrafts`, flush
+Redis and R2 at cutover. The *engineering* residue is real and must be done:
+
+- **`@InjectModel('PostDraft')` string token** in `auth.service.ts:76` → `Post`. Register
+  `{ name: Post.name, schema: PostSchema }` in `database.module`. This fails loud at boot if
+  missed.
+- **Legacy `type` field** (a workflow-name string, `quickPostLinkedin`/`insightPostLinkedin`):
+  dropped, no successor on `Post` — the artifact carries `type`. `getPosts`/metrics no longer
+  aggregate on it.
+- **Usage triggers:** `scheduled_posts` stays a capacity counter, asserted and incremented on
+  first-time schedule, **monotonic** (delete/cancel/disconnect do not refund — an explicit
+  carry-over of today's behavior). Immediate publish is not counted. `ai_drafts` is retired.
+- **Account-disconnect safety:** repoint `auth.service`'s query from `postdrafts
+  status:'SCHEDULED'` to `posts status:'SCHEDULED'` for the disconnected account; for each,
+  `getJob(post._id).remove()` and set the post `FAILED`, reason `"connected account
+  disconnected"`. There is no `DRAFT` to reset to, and the source artifact is untouched in
+  the library, so the user re-posts it after reconnecting. **Add a regression test for
+  disconnect → schedule-job cancel** — the audit called this out explicitly.
+
+### HTTP surface
+
+| Method | Route | Body / Query | Result |
+|---|---|---|---|
+| POST | `/posts` | `{artifactId, version?, connectedAccount, scheduledAt?}` | `201 Post` |
+| POST | `/posts/:id/publish` | — | publish now / retry a FAILED post |
+| POST | `/posts/:id/schedule` | `{scheduledAt}` | reschedule |
+| DELETE | `/posts/:id` | — | cancel a SCHEDULED post + remove job |
+| GET | `/posts` | `?status&month&connectedAccount&page` | list + `filters` |
+| GET | `/posts/:id` | — | one post, with resolved artifact refs |
+| GET | `/posts/metrics/:connectedAccountId` | — | `{ total, monthly[] }` |
+| GET | `/posts/linkedin/image/:urn` | — | LinkedIn image proxy, reused unchanged |
+
+---
+
+## 11. SSE progress streaming
+
+**`GET /runs/:runId/events`** — one stream per generation run.
+
+Keyed by `runId`, not artifact: the kickoff responses already hand the client a `runId`,
+which is the `WorkflowRun._id` *and* the Redis stream key, so it is the natural minimal
+handle. A run belongs to exactly one artifact/version, so nothing is lost.
+
+**Auth:** `@UseGuards(ClerkAuthGuard)`. Browser `EventSource` can send **only cookies**, no
+custom headers — and the guard is already cookie-first (`__session`, with a legacy
+`access_token` JWT fallback), so it works unchanged. Load the `WorkflowRun` by `:runId`;
+**403** if `run.user !== req.user._id`, **404** if no such run. Do this *before* opening the
+stream, so auth and ownership failures are ordinary JSON HTTP errors rather than mid-stream
+events.
+
+**Handler style: raw `@Res({ passthrough: false })`, not `@Sse()`.** The endpoint needs four
+things that fight the `@Sse()` Observable abstraction: read the inbound `Last-Event-ID`
+header to seek the replay cursor; short-circuit with **HTTP 204** before any stream body;
+set anti-buffering headers per-response; and drive an imperative `XREAD BLOCK` loop whose
+cadence also produces heartbeats. `@Sse()` owns the status line and content-type before we
+can inspect `Last-Event-ID` or return 204, and hides the `res` we need.
+
+WebSocket was rejected: progress is server→client, one-way, per-run, short-lived. SSE gives
+native auto-reconnect and `Last-Event-ID` replay for free over plain HTTP and cookies.
+
+### Wire format
+
+```
+id: <redis-stream-entry-id>
+event: <RunEventType>            # e.g. step.completed
+data: <JSON of { seq, ts, ...data }>   # single line
+```
+
+`event:` is the engine's `RunEventType` **verbatim** — the internal names *are* the client's
+event names, so there is no translation layer to drift. Clients attach typed listeners
+rather than switching inside one `onmessage`.
+
+**`id:` is the Redis Stream entry ID, not `seq`.** This makes replay a trivial native
+`XREAD ... STREAMS <key> <lastEventId>` with no `seq → offset` index to maintain. `seq`
+still travels inside `data` as the app-level monotonic counter, so the client can detect
+gaps and dedupe independently of the opaque transport id.
+
+On connect, write `retry: 3000` to pin the reconnect backoff.
+
+### Transport
+
+One **Redis Stream** per run, `workflow:run:{runId}` (R6). For each open connection the
+relay loops `XREAD BLOCK <heartbeatMs> COUNT <n> STREAMS workflow:run:{runId} <cursor>`.
+This **single mechanism** gives replay, live tail, and heartbeat cadence at once: entries
+returned → write them as SSE events; a block timeout with no entries → write a heartbeat and
+loop. There is **no subscribe-race** — events fired before a late subscriber attaches are
+simply still in the stream.
+
+A blocking `XREAD` monopolizes its connection, so the relay uses
+`RedisService.getClient().duplicate()` per SSE connection and **quits it on
+`req.on('close')`**. Connection count is bounded by concurrent viewers of in-flight runs,
+which is small: a user watches their own generation.
+
+### Reconnect
+
+| Situation | Behavior |
+|---|---|
+| No `Last-Event-ID` (fresh connect) | Replay the whole stream from `0`, then tail — a client that connects *after* `run.started` still renders full history |
+| With `Last-Event-ID` | Resume strictly after that entry. No duplicates, no gap |
+| Run terminal **and** client current | **HTTP 204** — per the SSE spec this tells `EventSource` to stop reconnecting, preventing a finished run from being polled forever by a stale tab |
+| Run terminal, client behind | Open, replay the tail including the terminal event, close; the *next* reconnect hits the 204 |
+| Stream expired, run doc present | Synthesize a snapshot from `WorkflowRun` (`status`, `currentStep`, `steps` reconstructed via `buildWorkflow(input)`), then close |
+| Stream expired, run doc gone | `404` |
+
+**Failures are data, not HTTP status.** Only pre-stream problems (auth, ownership, unknown
+run) are HTTP errors. Once the stream is open, everything — including `run.failed` — is an
+SSE event, so a mid-run failure never looks like a transport error to the client.
+
+### Heartbeats, close, and the buffering gotchas
+
+- Every `XREAD BLOCK` timeout with no entries writes an SSE **comment** `: hb\n\n`. Comments
+  fire no event and carry no `id`, so they never perturb `Last-Event-ID`. Cadence **15 s**,
+  comfortably under common 30–60 s proxy idle timeouts.
+- **Initial frame:** immediately on open, before any replay, write `retry: 3000` and one
+  heartbeat. The early write forces the response headers to flush past any buffering proxy,
+  so the client's `onopen` fires promptly.
+- **Close handshake:** after the terminal event, `res.end()`. The client calls `es.close()`
+  in its `run.completed`/`run.failed` handler; the 204 short-circuit is the backstop. There
+  is deliberately **no bespoke `end` event** — the two terminal events already are the
+  end-of-stream signal.
+- **Headers:** `Content-Type: text/event-stream; charset=utf-8`, `Cache-Control: no-cache,
+  no-transform`, `Connection: keep-alive`, and **`X-Accel-Buffering: no`** — disabling nginx
+  response buffering is the single most common fix for "SSE works locally, not in prod".
+- **Disable gzip for this route.** Compression buffers the stream to build its window and
+  would stall progress. Per §3, `main.ts:20`'s dead `/mark/chat` exclusion is **replaced**:
+
+  ```ts
+  filter: (req, res) => {
+    if (req.path.includes('/runs/') && req.path.endsWith('/events')) return false;
+    return compression.filter(req, res);
+  }
+  ```
+
+### Retention
+
+`XADD ... MAXLEN ~ 1000` bounds live size (a run emits well under 1000 events, so the cap is
+a safety valve, not normal retention). On the terminal event, `EXPIRE workflow:run:{runId}
+3600` reclaims the log after an hour — long enough for a client reconnecting shortly after
+completion to replay the full run. No separate cleanup job; Redis self-manages. The
+`WorkflowRun` Mongo doc persists independently.
+
+### Client contract
+
+```ts
+type ProgressEvent =
+  | { event: 'run.started';    data: { seq; ts; kind: 'INITIAL'|'REFINE'; type: 'POST'|'POLL'|'DOCUMENT'; steps: WorkflowStep[] } }
+  | { event: 'step.started';   data: { seq; ts; step: WorkflowStep; index: number; total: number } }
+  | { event: 'step.completed'; data: { seq; ts; step: WorkflowStep; index: number; total: number } }
+  | { event: 'step.progress';  data: { seq; ts; step: WorkflowStep; [k: string]: unknown } }
+  | { event: 'usage.tick';     data: { seq; ts; kind: UsageKind; credits: number; detail?: unknown } }
+  | { event: 'step.failed';    data: { seq; ts; step: WorkflowStep; retryable: true; message: string } }
+  | { event: 'run.completed';  data: { seq; ts; artifactId: string; version: number } }
+  | { event: 'run.failed';     data: { seq; ts; failureReason: string } };
+```
+
+**"Artifact ready" is `run.completed`** — there is deliberately no separate `artifact.ready`
+event. A run completing *is* the target version reaching `READY`, so `run.completed
+{ artifactId, version }` is the single unambiguous "go look at it now" signal, on which the
+client refetches `GET /artifacts/:id?version=<version>`.
+
+**Progress-bar math** is `index/total` from the step events, where `total = steps.length`
+from `run.started`. Because the builder emits an honest step list, `total` is exact.
+
+**Exactly one terminal event fires per run.** `step.failed` (`retryable: true`) is *not*
+terminal — it announces a transient blip while BullMQ retries the whole job, and the client
+should show "retrying…", not "failed".
+
+### Artifact library HTTP surface
+
+All under `api/v1`, behind `ClerkAuthGuard`, owner-scoped.
+
+| Method | Route | Body / Query | Result |
+|---|---|---|---|
+| POST | `/artifacts` | `{type, prompt, withResearch, stylePreset?, theme?}` | `202 {artifactId, runId}` |
+| POST | `/artifacts/:id/refine` | `{feedback}` | `202 {artifactId, version, runId}` |
+| PATCH | `/artifacts/:id` | partial content edit (head, `READY` only) | `200` |
+| GET | `/artifacts` | `?type&status&month&page` | summaries + `filters {availableMonths, types}` |
+| GET | `/artifacts/:id` | `?version=N` / `?includeVersions=true` | current version, or a specific one, or + version metadata |
+| DELETE | `/artifacts/:id` | — | `200` soft delete |
+
+**List returns lightweight summaries only** — `{id, type, title, status, updatedAt,
+preview}`, never version arrays; `preview` is a commentary/first-slide snippet plus a signed
+PDF URL for documents. Excludes soft-deleted, sorted `updatedAt` desc, paginated. The
+`month` filter reuses the existing `%Y-%m` aggregation.
+
+**Create is not hand-authoring** — it creates the `Artifact` (`currentVersion=1`, version 1
+`GENERATING`), enqueues the run, and responds `202`. Synchronous create was rejected:
+research + LLM + PDF render take tens of seconds and would hold the connection and bypass the
+SSE design. **No `connectedAccount` at creation** — an artifact is account-agnostic until
+posted.
+
+**A version is one AI generation.** Manual edits do not create versions: `PATCH` mutates the
+current version's content in place (allowed only when the head is `READY`) and stamps
+`editedAt`. AI refine appends. Revert is deferred.
+
+---
+
+## 12. `src/mark` dissolution map
+
+`src/mark` is 15 files / ~1156 lines and is **entirely dead code** today except for two
+edges: `app.module.ts` imports `MarkModule` (lines 30, 56), and
+`src/database/schemas/artifact.schema.ts` imports `postArtifact`/`pollArtifact` from
+`src/mark/types/artifact.types.ts`. `searchWeb`, `html_to_pdf.util`, and `poll.util` have
+**no callers anywhere** (the latter two are not even exported from `utils/index.ts`).
+
+| File | Fate | Destination / note |
+|---|---|---|
+| `mark.module.ts` | **delete** | also remove `app.module.ts:30` and `:56` |
+| `index.ts` | **delete** | |
+| `artifact.service.ts` | **delete** | superseded by the new `ArtifactService` (§4, §11) |
+| `artifact.service.spec.ts` | **delete** | |
+| `types/artifact.types.ts` | **delete** | `postArtifact`/`pollArtifact`/`markArtifact` replaced by the §4 Zod union. Deleting this unblocks the last hard edge in `artifact.schema.ts` |
+| `search.ts` | **move** | → `src/agent/tools/search-web.tool.ts`, wrapped as a `Tool` (§7). Keep the `{ error }`-on-failure contract — the loop depends on it never throwing |
+| `utils/html_to_pdf.util.ts` | **move** | → `src/carousel/utils/html-to-pdf.util.ts` (kebab-case per repo convention). Defaults untouched — 1080×1350, zero margins, `printBackground` |
+| `utils/html_to_pdf.util.spec.ts` | **move** | alongside |
+| `utils/post.util.ts` | **salvage, then delete** | Extract `linkedInCharCount` → `src/artifact/utils/linkedin-char-count.util.ts`; it is the reference implementation for the §4 3000-char `commentary` cap (LinkedIn counts by UTF-16 code unit). The `validateLinkedInPost` validator/preview half has no caller — see the open question below |
+| `utils/post.util.spec.ts` | **salvage, then delete** | keep the `linkedInCharCount` cases |
+| `utils/poll.util.ts` | **absorb, then delete** | Its constraints (≤140 question, 2–4 options, ≤30 chars each, **options mutually unique**) become the §4 Zod poll schema. The uniqueness rule is the one thing #101/#102 missed — carry it forward |
+| `utils/poll.util.spec.ts` | **absorb, then delete** | port cases into the artifact schema spec |
+| `utils/html.utils.ts` | **delete** | `validateHtml`/`correctHtml`/`strictParseHtml` (parse5). Under §8 the AI never authors HTML — it fills fields — so these have no consumer |
+| `utils/html.utils.spec.ts` | **delete** | |
+| `utils/index.ts` | **delete** | |
+
+**Dependency cleanup:** `parse5` (`^8.0.1`, a direct dependency) is used **only** by
+`html.utils.ts`. Once that file is deleted, drop `parse5` from `package.json`.
+
+**Open question for the operator** (does not block the build): does the frontend want
+`validateLinkedInPost`'s hook-preview and hashtag/emoji warnings surfaced on the artifact
+editor? If yes, it should be re-homed as a small `src/artifact/utils/linkedin-post-lint.util.ts`
+and exposed on the artifact GET response. If no, delete it with the rest. Defaulting to
+**delete** — nothing calls it today.
+
+### What else dies with the write-over
+
+| Target | Reason |
+|---|---|
+| `src/database/schemas/post-draft.schema.ts` (+ `PostDraftStatus`) | replaced by `Post` (§4) |
+| `src/database/schemas/artifact.schema.ts` | rebuilt to §4; retires the `enum: ['html','text','structured']` / `ArtifactType` mismatch |
+| `src/workflow/engine/*`, `workflow.registory.ts`, `workflow.types.ts` | rebuilt to §5 |
+| `src/workflow/workflows/{quickPostLinkedin,insightPostLinkedin}.workflow.ts` | folded into the `withResearch` toggle |
+| `src/workflow/steps/{createLinkedinDraft,extractIntent,getQueries}.step.ts` | replaced by the five §6 steps |
+| `agent.service.ts`: `generateUserIntent`, `generateSearchKeywords`, `searchWithFallbacks`, `getYouTubeTranscripts`, `extractInsight`, `createDraft`, `createLinkedInPost`, `updateDraft` | folded into `research()` + `generate()` |
+| `post.service.ts`: `createDraft`, `updateContent`, `addLinkedinMedia`, `initiate`/`completeMediaUpload`, embedded-`media` logic + DTOs | §10; `publishOnLinkedIn`→`publishPost`, `schedulePost`, `deletePost`, `getPosts`, `getPost`, `getPostMetrics` are kept and re-pointed |
+| `FEATURE_KEYS.AI_DRAFTS`, `assertAiDraftQuota`, `incrementAiDraftUsage` | §9 |
+| `main.ts:20` `/mark/chat` compression exclusion | dead route; replaced by the SSE exclusion (§11) |
+| `GOOGLE_API_KEY` (YouTube Data API) | the heavy YouTube search→transcript→compress pipeline dies with the old engine. Confirm no other caller before removing the env key |
+
+---
+
+## 13. Configuration
+
+New global env, added to `.env.example` (no hardcoded values — repo rule):
+
+| Key | Purpose | Default |
+|---|---|---|
+| `CREDITS_PER_USD` | credit peg | `1000` |
+| `CREDIT_MARKUP` | margin multiplier | `1.0` |
+| `FALLBACK_CREDITS_PER_1K_TOKENS` | safety net when `usage.cost` is missing | — |
+| `CREDIT_SURCHARGE_WEB_SEARCH` | flat surcharge per Tavily call | `8` |
+| `CREDIT_SURCHARGE_PDF_RENDER` | flat surcharge per Browserless render | `5` |
+| `RESEARCH_MODEL` | fast model for tool-loop turns | — |
+| `GENERATION_MODEL` | stronger model for final content | — |
+| `RESEARCH_MAX_STEPS` | agent iteration cap | `5` |
+
+Already present, no action: `TAVILY_API_KEY`, `OPENROUTER_API_KEY`, `BROWSERLESS_URL`,
+`BROWSERLESS_TOKEN`. Already absent, no action: all `MARK_*`.
+
+---
+
+## 14. Risks carried into the build
+
+**LinkedIn API, unconfirmed from primary sources.** Three items want a one-shot sandbox
+confirmation before the DOCUMENT and POLL paths are trusted in production:
+
+1. **Community Management API product grant.** Polls and documents live under LinkedIn's
+   Marketing / Community Management surface and are gated at the *app-product* level, not per
+   endpoint. The app already posts images and videos through `/rest/posts` with
+   `w_member_social` / `w_organization_social`, so access appears granted — but it is not
+   verifiable from public docs. **Confirm the connected app's product grant explicitly
+   includes Community Management before shipping polls/documents.**
+2. **Must a document reach `AVAILABLE` before attaching to a post?** The docs show upload
+   immediately followed by post creation and never state a mandatory wait; the video flow
+   *does* require it. We poll defensively (§10), which is correct either way, but the poll
+   adds latency to immediate publish. Verify and drop the wait if unnecessary.
+3. **Mutual exclusivity of `content` sub-fields is an inference,** not a verbatim rule.
+   Consistent across every documented example and the union-style schema, but LinkedIn never
+   prints "you cannot combine these." Our publish composition enforces it regardless, so the
+   risk is only that we are *more* restrictive than necessary.
+
+Additionally: **`MULTIPLE_VOTE` polls are documented as future** — do not build UI depending
+on multi-select. **Polls are organic and non-sponsored only** ("API partners can only create
+non-sponsored poll posts") — confirmed, no workaround. **Organic `content.carousel` is
+unavailable** — confirmed; the swipeable format must be a document post.
+
+**Emoji rendering in Browserless** (§8) — unverified whether the image ships a color emoji
+font. The fixture deck surfaces it; if it renders as tofu, the generation prompt bans emoji.
+
+**Character caps are a proxy for rendered width** (§8). The three-layer defence (prompt, Zod,
+`overflow: hidden`) means a miscalibration degrades to clipped text, never a broken layout —
+but the per-theme fixture render is the only real proof, and it is a manual QA gate.
+
+---
+
+## 15. Implementation tickets
+
+Ordered as **tracer-bullet vertical slices**: slice 0 is a walking skeleton that goes all the
+way through, and each later slice widens it. Every slice is independently shippable and
+leaves the tree green. `Blocked by` declares hard ordering.
+
+### Slice 0 — walking skeleton: a research-off POST artifact, end to end
+
+> **T1 — LLM layer: single-turn primitives + typed errors.**
+> Extend `LLMStrategy` with `complete` / `completeWithTools` / reserved `stream`. Add
+> `ToolDefinition`, `ToolCall`, `Usage`, and the assistant-with-tool-calls and `role:'tool'`
+> message variants. Implement in the OpenRouter strategy over `@openrouter/sdk`'s `tool()` +
+> `chat.send`, surfacing `usage.cost`. Add typed `LLMError { retryable }` (429/5xx/network →
+> retryable; 4xx/auth → terminal). *Blocked by: none.*
+
+> **T2 — `Artifact` schema + the POST arm of the content union.**
+> New `Artifact`/`ArtifactVersion` schema (§4) with `ArtifactType`, `VersionStatus`,
+> `CarouselTheme` (R4). Zod union with the POST arm only, including the 3000-char
+> `commentary` cap via `linkedInCharCount` salvaged from `post.util.ts` (§12). Implement the
+> `ArtifactWriter` role (`setVersionContent`, `readCurrent`). Rebuild
+> `src/database/schemas/artifact.schema.ts`, deleting the enum/type mismatch and the
+> `src/mark/types` import. *Blocked by: none.*
+
+> **T3 — `CreditMeterService` + the `credits` feature key.**
+> Rename `FEATURE_KEYS.MARK_TOKENS` → `CREDITS` and the `Feature` union arm; drop
+> `AI_DRAFTS`, `assertAiDraftQuota`, `incrementAiDraftUsage`. `assertMarkTokenQuota` →
+> `assertBalance` (headroom check); `incrementMarkTokenUsage` → `debit`. New
+> `CreditMeterService` with pure `toCredits` (llm/cost path + token fallback + warn). Update
+> `getDashboardUsage` to the `credits` shape. Config: `CREDITS_PER_USD`, `CREDIT_MARKUP`,
+> `FALLBACK_CREDITS_PER_1K_TOKENS`. Tests per CLAUDE.md: `credit-meter.service.spec.ts` and
+> an updated `feature-gating.service.spec.ts` (headroom guard, `-1`/`0` edges). *Blocked by:
+> none.*
+
+> **T4 — Workflow engine core + `WorkflowRun`.**
+> New `WorkflowRun` schema. `WorkflowStep` enum redefined to the five §6 steps.
+> `buildWorkflow`, typed `RunState`, patch-merging `runWorkflow` loop, `StepContext` with all
+> six roles **including `renderer`** (R3). `RunEvent` envelope, core-assigned `seq`, emitter
+> that **only** `XADD`s (R6) with `MAXLEN ~ 1000` and `EXPIRE` on terminal. `WorkflowError`
+> taxonomy, `attempts: 3` + exponential backoff, `UnrecoverableError` for terminal, and the
+> terminal-failure handler (version → `FAILED`, run → `FAILED`, emit `run.failed`, **no
+> commit**). Attempt-scoped `creditsUsed` reset. Delete `src/workflow/engine/*`,
+> `workflow.registory.ts`, and both legacy workflow definitions. *Blocked by: T2, T3.*
+
+> **T5 — `AgentRunner.generate()` for POST + the two code steps.**
+> `AgentRunner` surface; `generate()` as a single `complete` call validated against T2's Zod
+> union with **one inline repair retry**, and a Zod failure surviving it thrown as
+> **terminal** (R2). Per-type prompt for POST, with `resolveStylePresetInstruction` injecting
+> voice (R4). Step handlers `RESOLVE_INPUT`, `GENERATE`, `PERSIST_VERSION`. Wire the worker's
+> `workflow` queue to build `StepContext` from the role interfaces. Config: `GENERATION_MODEL`.
+> *Blocked by: T1, T2, T4.*
+
+> **T6 — `POST /artifacts` + `GET /runs/:runId/events`.**
+> Create endpoint: `assertBalance` pre-check → create artifact + v1 `GENERATING` → enqueue →
+> `202 {artifactId, runId}`. SSE controller with raw `@Res`, `ClerkAuthGuard`, owner scoping
+> (403/404 before the stream opens), `XREAD BLOCK` relay on a duplicated ioredis connection,
+> `Last-Event-ID` replay, 204 terminal short-circuit, 15 s heartbeats, `X-Accel-Buffering:
+> no`, `retry: 3000`, teardown on `req.on('close')`. **Replace** the dead `/mark/chat`
+> compression exclusion in `main.ts:20` with the SSE one (§3). *Blocked by: T4, T5.*
+
+**Slice 0 exit criteria:** `POST /artifacts {type:'POST', withResearch:false}` returns 202;
+the worker generates; the browser sees `run.started → step.started/completed ×3 →
+usage.tick → run.completed`; the version is `READY`; credits are debited once.
+
+### Slice 1 — research
+
+> **T7 — the generic agent loop + the `searchWeb` tool + `RESEARCH`.**
+> `Tool` interface, `AgentRunConfig`, the `while` loop over `completeWithTools` with parallel
+> in-turn tool execution, `maxSteps` cap with **graceful finalization** (one final
+> tools-removed completion). `AgentHooks` (`onUsage`, `onToolCall`). Move
+> `src/mark/search.ts` → `src/agent/tools/search-web.tool.ts`, wrapped as a `Tool` preserving
+> its never-throw `{ error }` contract. `research()` reducing `AgentRunResult` →
+> `{ findings, sources }` with URL dedupe and **no raw bodies forwarded**. `RESEARCH` step:
+> persists `researchContext` on the run, emits `step.progress { sourcesFound }`, bridges
+> `onUsage`/`onToolCall` → `ctx.meter.record`. `web_search` surcharge in `toCredits`. Config:
+> `RESEARCH_MODEL`, `RESEARCH_MAX_STEPS`, `CREDIT_SURCHARGE_WEB_SEARCH`. *Blocked by: T5.*
+
+### Slice 2 — polls
+
+> **T8 — POLL artifacts.**
+> POLL arm of the Zod content union: question ≤140, 2–4 options ≤30 chars each, **mutually
+> unique** (absorbed from `poll.util.ts`, §12), `durationDays ∈ {1,3,7,14}`. POLL branch in
+> `generate()` + its prompt. No new steps — POLL is structurally identical to POST.
+> *Blocked by: T7.*
+
+### Slice 3 — carousels
+
+> **T9 — carousel schemas, templates, and assets.**
+> New `src/carousel/` module. `schemas.ts` (`slideFieldSchemas`, `slideSchema`,
+> `slidesSchema` 2–15). `templates.ts` typed registry with **boot-time compile that fails
+> fast** on a missing file, a compile error, or any `{{{`. `base.css` with the `.slide` frame
+> and the load-bearing `:last-child { break-after: auto }`. Four themes × five slide types =
+> 20 `.hbs` + 4 `theme.css` + 4 `fixture.json` (15 slides, max-length fields, an emoji, a long
+> unbroken token). Registry spec iterating every fixture through `assembleHtml`. *Blocked by:
+> none.*
+
+> **T10 — `CarouselRendererService` + `RENDER_PDF`.**
+> Move `html_to_pdf.util.ts` → `src/carousel/utils/html-to-pdf.util.ts` (kebab-case), defaults
+> untouched. `assembleHtml` (pure) → `htmlToPdf` → `uploadFile` to
+> `artifacts/${artifactId}/${version}/document.pdf`. Implement the `CarouselRenderer` role
+> (R3). `RENDER_PDF` step writing `render = { pdfKey, pageCount }` (R1), emitting **no**
+> `step.progress` (R7) and one `pdf_render` surcharge (R5). Browserless failure → retryable;
+> unknown `templateId`/`slide.type` → terminal. Config: `CREDIT_SURCHARGE_PDF_RENDER`.
+> *Blocked by: T4, T9.*
+
+> **T11 — DOCUMENT artifacts end to end.**
+> DOCUMENT arm of the Zod union (`templateId: CarouselTheme`, `slides`, `pdfKey?`,
+> `pageCount?`). DOCUMENT branch in `generate()`, with `theme` **stamped authoritatively when
+> user-supplied** and model-picked-then-Zod-validated when omitted (R4). Builder inserts
+> `RENDER_PDF` for `type === DOCUMENT`. `PERSIST_VERSION` folds `pdfKey`/`pageCount` into
+> `content.document`. **Manual QA gate:** render all four fixture decks to PDF and eyeball
+> pagination, overflow, and emoji. *Blocked by: T8, T10.*
+
+### Slice 4 — refine
+
+> **T12 — REFINE runs.**
+> `POST /artifacts/:id/refine {feedback}` → append a `GENERATING` version →
+> `202 {artifactId, version, runId}`. `RunKind.REFINE`; builder omits `RESEARCH`.
+> `RESOLVE_INPUT` seeds `refine = { priorContent, feedback }` and copies `research` from the
+> artifact's latest `COMPLETED` `WorkflowRun.researchContext`. Revision prompt in `generate()`.
+> DOCUMENT refine re-runs `RENDER_PDF` to the new version's key, carrying the theme forward.
+> *Blocked by: T11.*
+
+### Slice 5 — the library
+
+> **T13 — artifact library API.**
+> `GET /artifacts` (summaries only, `%Y-%m` month filter, `filters {availableMonths, types}`,
+> excludes soft-deleted, paginated); `GET /artifacts/:id` (`?version=N`,
+> `?includeVersions=true` → version metadata only); `PATCH /artifacts/:id` (mutates the READY
+> head in place, stamps `editedAt`, no new version); `DELETE /artifacts/:id` (soft).
+> **Signed-URL exchange** (`getSignedUrl(pdfKey)`) on every response carrying a document
+> preview (R1). Owner-scoped throughout. *Blocked by: T11.*
+
+### Slice 6 — publishing
+
+> **T14 — `Post` schema + `publishPost` for POST artifacts.**
+> New `Post`/`PostStatus` schema (§4), registered in `database.module`. `publishPost(postId)`
+> resolving the pinned `{artifact, version}` → `ArtifactContent` → `IContent`, reusing the
+> existing header trio, `resolveLinkedinAuthorUrn`, envelope, and `x-restli-id` capture.
+> `POST /posts` with the immediate-publish branch and READY-version validation. **H2:** fix
+> `@InjectModel('PostDraft')` in `auth.service.ts:76`. *Blocked by: T13.*
+
+> **T15 — publish POLL and DOCUMENT.**
+> `IContent` gains a `poll` arm; `durationDays` → LinkedIn duration enum;
+> `voteSelectionType: 'SINGLE_VOTE'`, `isVoterVisibleToAuthor: true`. New
+> `LinkedinMediaService.uploadDocument` — init → **single PUT** → `value.document` URN, **no
+> chunking, no ETags, no finalize** — plus `waitForDocumentAvailable`. Enforce ≤100 MB /
+> ≤300 pages. DOCUMENT publish sources bytes via `getFile(pdfKey)`. `MediaType` gains
+> `DOCUMENT`. Spec per CLAUDE.md: `linkedin-media.service.spec.ts` for the single-PUT path.
+> **Sandbox-verify the three §14 LinkedIn unknowns before merging.** *Blocked by: T14.*
+
+> **T16 — scheduling, cancel, and disconnect safety.**
+> `POST /posts/:id/schedule`, `POST /posts/:id/publish` (retry a FAILED post), `DELETE
+> /posts/:id`. `scheduled_posts` asserted + incremented on first-time schedule only,
+> monotonic. **H8:** repoint `auth.service`'s disconnect query to `posts status:'SCHEDULED'`,
+> cancel jobs, set `FAILED` with `"connected account disconnected"`, leave the artifact
+> untouched. **Add the disconnect → schedule-job-cancel regression test** the audit demanded.
+> `GET /posts`, `GET /posts/:id` (resolving artifact refs), `GET /posts/metrics/:id`
+> re-pointed. *Blocked by: T15.*
+
+### Slice 7 — demolition and seed
+
+> **T17 — dissolve `src/mark` and the legacy engine.**
+> Execute the §12 table: delete `mark.module.ts` (and `app.module.ts:30,56`), `index.ts`,
+> `artifact.service.ts`(+spec), `types/artifact.types.ts`, `html.utils.ts`(+spec),
+> `utils/index.ts`, and the salvaged-from `post.util.ts` / `poll.util.ts`. Drop `parse5` from
+> `package.json`. Delete `post-draft.schema.ts` + `PostDraftStatus`, the legacy step files,
+> the dead `agent.service.ts` pipeline methods, and the `PostDraft`-coupled `post.service.ts`
+> methods and DTOs. Confirm `GOOGLE_API_KEY` has no remaining caller before removing it.
+> *Blocked by: T12, T13, T16.*
+
+> **T18 — tier seed, `.env.example`, and the dashboard.**
+> Seed `limits.credits` per tier (free `0` or a trial grant, Starter `2000`, Pro `10000`, top
+> `-1`), sized against the §9 anchor. Add all eight §13 keys to `.env.example`. Verify
+> `getDashboardUsage` returns `{credits, connected_accounts, scheduled_posts}` and that
+> `limit === 0` is distinguishable from "out of credits". *Blocked by: T3, T17.*
+
+### Not covered by these tickets
+
+Client-side handoff documentation (how the frontend consumes SSE, the library API, and the
+refine flow) — the contract is fixed in §11, but the frontend migration is a separate effort.
+Rollout sequencing is trivial under the clean write-over: drop `postdrafts`, flush Redis and
+R2, deploy. There is no coexistence window and no feature flag.

--- a/docs/artifact-workflow-step-pipelines-design.md
+++ b/docs/artifact-workflow-step-pipelines-design.md
@@ -1,0 +1,440 @@
+# Artifact Workflow Step Pipelines — Design
+
+> Status: design spec for wayfinder map #99, ticket #109 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled on 2026-07-09.
+> **Synthesis ticket.** It does not invent a new engine — #103 (engine/step model),
+> #104 (agent loop), #108 (carousel render), #102 (artifact schema), and #101
+> (LinkedIn API) already settled the parts. #109 stitches them into the **concrete
+> per-workflow pipelines**: for each artifact `type` (POST / POLL / DOCUMENT) and
+> each run `kind` (INITIAL / REFINE) — the ordered deterministic steps, which are AI
+> vs. pure code, where the research agent runs (and when it's skipped), the
+> refine-run variants, and each step's inputs/outputs through the run state.
+>
+> Blockers #101, #103, #104, #108 are all closed.
+
+Feeds the final spec assembly (#110). Interlocking tickets are referenced inline at
+each boundary.
+
+## Framing (charter-derived givens)
+
+- **One engine, one build flow** (#103). A single artifact-build pipeline serves every
+  generation; it varies along three axes only: `type` (POST | POLL | DOCUMENT, #102),
+  `withResearch` (the quick/insight collapse from #100), and `kind`
+  (INITIAL | REFINE). There is no per-type or per-mode *separate* workflow — the
+  variation is **composition**, not branching (#103 §1–2).
+- **The engine fills a pre-created version, never creates artifacts** (#103, #102 §6).
+  `POST /artifacts` (and `/refine`) create the `Artifact` + a `GENERATING` version
+  first, respond `202 {artifactId, runId}`, then enqueue the run whose pipeline this
+  doc defines.
+- **Executes in the BullMQ worker** (charter #4); steps emit events the SSE stream
+  (#107) relays. This doc fixes *what runs in what order and what each step reads/
+  writes*; #103 owns the run record, retry taxonomy, and emission envelope.
+- **What #109 owns vs. references.** #109 owns the concrete pipelines, the AI-vs-code
+  classification, the per-step RunState I/O contract, the research skip rules, the
+  refine variants, **and** the resolution of the one live cross-ticket conflict at
+  `GENERATE` (§8). It references — does not redefine — the engine loop (#103), the
+  agent surface (#104), the render step internals (#108), the content schemas (#102),
+  and the LinkedIn constraints (#101).
+
+The canonical flow (#103 §2), bracketed steps conditional:
+
+```
+RESOLVE_INPUT → [RESEARCH] → GENERATE → [RENDER_PDF] → PERSIST_VERSION
+```
+
+---
+
+## 1. The builder produces an honest, per-combination step list
+
+The concrete step list is assembled by the #103 §2 builder, reproduced here as the
+spine every pipeline in §3 instantiates:
+
+```ts
+function buildWorkflow({ type, withResearch, kind }: BuildSpec): WorkflowDefinition {
+  return {
+    name: `artifact:${type}`,
+    steps: [
+      WorkflowStep.RESOLVE_INPUT,
+      ...(withResearch && kind === RunKind.INITIAL ? [WorkflowStep.RESEARCH] : []),
+      WorkflowStep.GENERATE,
+      ...(type === ArtifactType.DOCUMENT ? [WorkflowStep.RENDER_PDF] : []),
+      WorkflowStep.PERSIST_VERSION,
+    ],
+  };
+}
+```
+
+- **The emitted sequence is honest** — only steps that actually run appear, because
+  the sequence feeds the SSE progress stream and the progress-percentage math (#103
+  §2, #107).
+- **`RESEARCH` is gated on `withResearch && kind === INITIAL`** — the research axis is
+  **uniform across all three types** (POST, POLL, DOCUMENT all honor `withResearch`
+  identically; no per-type special-casing — see §4). REFINE never runs `RESEARCH`; it
+  reuses cached findings (§5).
+- **`RENDER_PDF` is gated on `type === DOCUMENT`** — the only type-dependent step. It
+  runs on **both** INITIAL and REFINE document runs (a refine re-renders to the new
+  version's key — §5, #108 §7).
+- **`GENERATE` dispatches on `type` internally** — one step, three output shapes (§2).
+
+So there are **nine `(type × kind × withResearch)` combinations** — the 3 × 2 × 2 = 12
+axis product minus the 3 REFINE-with-research-on combos that cannot exist (REFINE never
+takes the research axis; research is always cache-seeded, never re-run). Those nine
+combinations collapse to just **four distinct step-list shapes** (the count that feeds
+the progress stream — many combinations share a shape):
+
+| # | type | kind | withResearch | Step list |
+|---|---|---|---|---|
+| 1 | POST | INITIAL | off | `RESOLVE_INPUT → GENERATE → PERSIST_VERSION` |
+| 2 | POST | INITIAL | on | `RESOLVE_INPUT → RESEARCH → GENERATE → PERSIST_VERSION` |
+| 3 | POST | REFINE | (n/a) | `RESOLVE_INPUT → GENERATE → PERSIST_VERSION` |
+| 4 | POLL | INITIAL | off | `RESOLVE_INPUT → GENERATE → PERSIST_VERSION` |
+| 5 | POLL | INITIAL | on | `RESOLVE_INPUT → RESEARCH → GENERATE → PERSIST_VERSION` |
+| 6 | POLL | REFINE | (n/a) | `RESOLVE_INPUT → GENERATE → PERSIST_VERSION` |
+| 7 | DOCUMENT | INITIAL | off | `RESOLVE_INPUT → GENERATE → RENDER_PDF → PERSIST_VERSION` |
+| 8 | DOCUMENT | INITIAL | on | `RESOLVE_INPUT → RESEARCH → GENERATE → RENDER_PDF → PERSIST_VERSION` |
+| 9 | DOCUMENT | REFINE | (n/a) | `RESOLVE_INPUT → GENERATE → RENDER_PDF → PERSIST_VERSION` (= #7 shape) |
+
+The four distinct shapes: **A** `RESOLVE_INPUT → GENERATE → PERSIST_VERSION` (rows 1, 3,
+4, 6); **B** = A + `RESEARCH` (rows 2, 5); **C** = A + `RENDER_PDF` (rows 7, 9);
+**D** = A + `RESEARCH` + `RENDER_PDF` (row 8).
+
+**POST and POLL share identical pipelines** — structurally the same step list; they
+differ *only* in `GENERATE`'s output shape (commentary vs. commentary+poll object) and
+in what `PERSIST_VERSION` Zod-validates. **DOCUMENT is POST/POLL + `RENDER_PDF`.** This
+is the whole variation surface.
+
+## 2. Step catalogue — the five steps
+
+Each step below is fixed once and reused across all pipelines in §3. **AI** = calls the
+LLM/agent (nondeterministic, metered); **code** = deterministic, no model call. Steps
+**read the RunState slots they need** (guarding with a `WorkflowError` if a required
+upstream slot is missing — #103 §3) and **write only their own slots** via a returned
+`Partial<RunState>` patch.
+
+### `RESOLVE_INPUT` — code
+
+- **Purpose:** materialize the typed `RunState` from the job's `BuildInput`; on a
+  refine, additionally seed the `refine` and `research` slots from durable state.
+- **Reads:** `job.data: BuildInput` (`type, prompt, withResearch, stylePreset?,
+  userId, artifactId, version, kind`). On **REFINE**: the artifact's prior
+  `currentVersion.content` (via `ctx.artifacts.readCurrent`) and the artifact's latest
+  `COMPLETED` `WorkflowRun.researchContext` (via `ctx.run` / a run lookup).
+- **Writes:** `input` (always). On REFINE also `refine = { priorContent, feedback }`
+  and `research` (copied from cache, if any) — #103 §11.
+- **Emits:** nothing beyond the core `step.started/completed`.
+- **Failure:** a missing target artifact/version is **terminal** (`retryable: false`) —
+  #102 created them at kickoff, so absence is a bug, not a blip. Re-running can't fix it.
+
+### `RESEARCH` — AI (agentic loop) — *conditional: `withResearch && kind === INITIAL`*
+
+- **Purpose:** gather + synthesize web findings that inform `GENERATE`.
+- **Reads:** `input` (`prompt, type, stylePreset`).
+- **Calls:** `ctx.agent.research({ prompt, type, stylePreset })` → `ResearchResult
+  { findings, sources }` (#104 §5–6). The agent runs the generic tool loop with the
+  single `searchWeb` (Tavily) tool, `maxSteps = RESEARCH_MAX_STEPS` (default 5), and
+  self-directs its own queries — there is no separate keyword-generation stage.
+- **Writes:** `research` slot; **and persists `researchContext` on the `WorkflowRun`**
+  (via `ctx.run`) so a later refine reuses it with zero re-search (#103 §4, §11).
+- **Emits:** optional `step.progress` (e.g. `{ sourcesFound }`) via `ctx.emit`;
+  `usage.tick` per LLM turn and per `searchWeb` call, both via `ctx.meter.record`
+  (bridged from the agent's `onUsage` / `onToolCall` hooks — #104 §7).
+- **Failure:** tool errors are absorbed in-loop (returned to the model as `{ error }`,
+  #104 §8); an LLM transport error surfaces as `WorkflowError { retryable }` per
+  `src/llm`'s classification (429/5xx/network → retryable; 4xx/auth → terminal).
+
+### `GENERATE` — AI (single structured completion) — *always*
+
+- **Purpose:** produce the typed `ArtifactContent` for the artifact's `type`.
+- **Reads:** `input` (`type, prompt, stylePreset`), `research?` (cached or fresh),
+  `refine?` (prior content + feedback).
+- **Calls:** `ctx.agent.generate({ type, prompt, stylePreset, research?, refine? })`
+  → `ArtifactContent`, a single `complete` call (no tools), validated against #102 §4's
+  Zod discriminated union with **one inline repair retry** on Zod failure (#104 §4, §8).
+  Dispatch on `type`:
+  - **POST** → `{ commentary }` (text is the whole artifact).
+  - **POLL** → `{ commentary?, poll { question ≤140, options[2–4] ≤30 each,
+    durationDays ∈ {1,3,7,14} } }` — the #101 poll constraints, enforced by the Zod
+    schema (#102 §4).
+  - **DOCUMENT** → `{ commentary?, document { templateId, slides[2–15] } }` — structured
+    slide fields per #108 §3. **`templateId` resolution happens inside this step**
+    (#108 §4): if `input.stylePreset` was supplied it is **stamped** authoritatively
+    (the model cannot override it); if omitted, the model picks a `StylePreset` and Zod
+    validates it is a real preset. `slides`, `pdfKey`, and `pageCount` are *not* set
+    here — only the slide source; the render is `RENDER_PDF`'s job.
+- **Writes:** `content` slot.
+- **Emits:** `usage.tick` per LLM turn via `ctx.meter.record` (#104 §7).
+- **Failure:** an LLM transport error → `WorkflowError { retryable }`. A **Zod-invalid
+  output that survives the inline repair retry is terminal** — see §8 (this doc resolves
+  the #103 §7 / #104 §8 conflict).
+
+### `RENDER_PDF` — code (deterministic template fill + Browserless) — *conditional:
+`type === DOCUMENT`*
+
+- **Purpose:** turn `document.slides` into a rendered LinkedIn-document PDF in R2.
+- **Reads:** `input` (`artifactId, version`), `content.document` (`templateId, slides`).
+- **Calls:** `CarouselRendererService` — #108 §6 owns the `assembleHtml → htmlToPdf → R2
+  uploadFile` chain, the boot-precompiled templates, and the R2 key convention. #109
+  fixes only what this step reads and writes into `RunState`.
+  - **Interlock note for #110 (StepContext gap):** #103 §10's `StepContext` exposes
+    `agent / artifacts / meter / emit / run / logger` but **no renderer role**, while
+    #108 §6 has this step call `CarouselRendererService`. #110 should either add a
+    narrow `renderer: CarouselRenderer` role interface to `StepContext` (consistent with
+    the engine's "depends on interfaces, not concrete services" principle, #103 §10) or
+    resolve `CarouselRendererService` once in the worker bootstrap alongside the other
+    roles. Recommended: the role-interface route, so `RENDER_PDF` mocks as trivially as
+    every other step under the repo's manual-construction test style.
+- **Writes:** `render = { pdfKey, pageCount: slides.length }` slot (#108 §6). Note the
+  `pdfKey` (not `pdfUrl`) naming — #108 §7's private-bucket correction; #110 propagates
+  the rename across #102 §4 / #103 §2–3 / #106 / #107.
+- **Emits:** **no `step.progress`** — the render is one atomic `htmlToPdf` call with no
+  honest per-page signal (#108 §6, superseding #107's speculative `pageRendered`). The
+  core's `step.started/completed` bracket it. `usage.tick` for the Browserless-render
+  surcharge via `ctx.meter.record({ kind: 'render', amount: 1 })` (#103 §9; #105 owns the
+  amount).
+- **Failure:** a Browserless timeout/failure is **retryable** (transient, #103 §7). An
+  unknown `templateId`/`slide.type` at assembly is **terminal** — Zod already validated
+  the content at `GENERATE`, so it should never occur and re-running cannot fix it
+  (#108 §6).
+
+### `PERSIST_VERSION` — code — *always*
+
+- **Purpose:** write the finished content onto the pre-created version and flip it
+  `READY` (the run's only durable content write; #103 §8 idempotency spine).
+- **Reads:** `input` (`artifactId, version`), `content`, `render?` (documents).
+- **Calls:** `ctx.artifacts.setVersionContent(artifactId, version, content, render?)`
+  (the `ArtifactWriter` role, #103 §10) — writes `content`, folds `render.pdfKey` +
+  `pageCount` into `content.document` for documents, and sets `status: GENERATING →
+  READY` (#102 §2's lifecycle).
+- **Writes:** no RunState slot (terminal step); side effect is the artifact version
+  reaching `READY`.
+- **Emits:** the core emits `step.completed` then `run.completed { artifactId, version }`,
+  on which the engine calls `meter.commit(runId)` — the **only** real credit debit,
+  charged once for the winning attempt (#103 §9).
+- **Failure:** a DB write error is **retryable**; the write targets the fixed
+  `(artifactId, version)`, so a whole-job retry overwrites rather than appends —
+  idempotent, no duplicate versions (#103 §8).
+
+## 3. Per-workflow pipelines
+
+Each pipeline is an instantiation of §1's builder; the step bodies are §2's catalogue.
+The tables below give the **concrete ordered run** with the AI/code tag and the
+per-step RunState delta, so #110 can lift them straight into implementation tickets.
+
+### 3.1 POST
+
+**INITIAL, research-off** (list #1 — the "quick post" collapse, #100):
+
+| Order | Step | AI/code | Reads | Writes |
+|---|---|---|---|---|
+| 1 | `RESOLVE_INPUT` | code | `BuildInput` | `input` |
+| 2 | `GENERATE` | **AI** | `input` | `content = { commentary }` |
+| 3 | `PERSIST_VERSION` | code | `input, content` | — (version → READY) |
+
+**INITIAL, research-on** (list #2 — the "insight post" collapse): identical, with
+`RESEARCH` (AI) inserted at order 2 — reads `input`, writes `research` + persists
+`researchContext`; `GENERATE` then also reads `research`.
+
+**REFINE** (list #3): `RESOLVE_INPUT` additionally seeds `refine` (+ cached `research`),
+`GENERATE` reads them, no `RESEARCH` step. See §5.
+
+### 3.2 POLL
+
+**Structurally identical to POST** (lists #4/#5/#6 mirror #1/#2/#3). The *only*
+differences are inside `GENERATE` and `PERSIST_VERSION`:
+
+| Order | Step | AI/code | Reads | Writes |
+|---|---|---|---|---|
+| 1 | `RESOLVE_INPUT` | code | `BuildInput` | `input` |
+| (2) | `RESEARCH` | **AI** | `input` | `research` (+ `researchContext`) — *research-on only* |
+| 2/3 | `GENERATE` | **AI** | `input, research?` | `content = { commentary?, poll {…} }` |
+| 3/4 | `PERSIST_VERSION` | code | `input, content` | — (version → READY) |
+
+- **No upload step, ever** — a poll is inline JSON with no binary asset (#101 §1, §5);
+  it never touches R2, the `media-upload` queue, or `RENDER_PDF`. The whole poll object
+  is assembled at *publish* time (#106), not in the generation pipeline.
+- **Poll constraints are a `GENERATE`-boundary concern** — the Zod poll schema (#102 §4,
+  from #101) rejects out-of-range questions/options/durations; a violation that survives
+  the inline repair retry is terminal (§8).
+- **Research is available for polls** (§4) — a topical poll can be informed by fresh
+  findings exactly like a post; the builder makes no exception.
+
+### 3.3 DOCUMENT (carousel)
+
+**INITIAL, research-off** (list #7):
+
+| Order | Step | AI/code | Reads | Writes |
+|---|---|---|---|---|
+| 1 | `RESOLVE_INPUT` | code | `BuildInput` | `input` |
+| 2 | `GENERATE` | **AI** | `input` | `content = { commentary?, document { templateId, slides } }` |
+| 3 | `RENDER_PDF` | code | `input, content.document` | `render = { pdfKey, pageCount }` |
+| 4 | `PERSIST_VERSION` | code | `input, content, render` | — (version → READY) |
+
+**INITIAL, research-on** (list #8): `RESEARCH` (AI) inserted at order 2; `GENERATE`
+reads `research`. Full five-step chain.
+
+**REFINE** (= list #7 shape): `RESOLVE_INPUT` seeds `refine` + cached `research`, no
+`RESEARCH`; `GENERATE` re-authors slides from `priorContent + feedback`; **`RENDER_PDF`
+re-runs**, rendering to the *new* version's key `artifacts/${artifactId}/${newVersion}/
+document.pdf` (version-scoped, never clobbers the prior render — #108 §7). See §5.
+
+- **`RENDER_PDF` is what gates `READY` for documents** — the version stays `GENERATING`
+  until `pdfKey` is written (#102 §2, #108 §7). POST/POLL reach `READY` at
+  `PERSIST_VERSION` with no render.
+- **The rendered PDF *is* the document's preview/thumbnail** — no separate thumbnail
+  asset for launch (#108 §7).
+
+## 4. Research invocation & skip rules
+
+One rule, applied uniformly to all three types:
+
+- **Runs** iff `withResearch === true` **and** `kind === INITIAL`. This is the sole
+  invocation point (§1 builder). Research-on ≈ the old insight post; research-off ≈ the
+  old quick post (#100).
+- **Uniform across types** (settled decision): POST, POLL, and DOCUMENT honor
+  `withResearch` identically — no per-type restriction. Rationale: the builder is
+  type-agnostic on the research axis (#103 §2), a poll/carousel benefits from topical
+  findings exactly as a post does, and special-casing would add surface for no gain.
+  - *Rejected — restrict research to POST.* Would fork the clean one-rule builder and
+    deny polls/carousels timely grounding for no principled reason.
+- **Skipped on REFINE — always** (#103 §11). A refine reuses the initial run's
+  `researchContext` (seeded into the `research` slot by `RESOLVE_INPUT`), so it
+  **re-charges no web-search surcharge** and adds no latency. If the original run was
+  research-off, there is simply no cached research and `GENERATE` runs on
+  prompt + feedback alone.
+- **Skipped on whole-job retry of an INITIAL research run — NO.** A retry re-runs the
+  whole job from step 1 (#103 §7); for an INITIAL run the builder still contains
+  `RESEARCH`, so it **re-executes** (a fresh Tavily pass). This matters for §8: the
+  "retry is cheap because research is cached" premise holds only for REFINE, not for a
+  retried INITIAL run.
+
+## 5. Refine-run variants
+
+A refine is a **new run** (`kind: REFINE`) over an existing artifact that appends a new
+`GENERATING` version (#102 §5, #103 §11). Per type:
+
+- **POST / POLL refine** (`RESOLVE_INPUT → GENERATE → PERSIST_VERSION`):
+  - `RESOLVE_INPUT` builds `input` from the family-level `source
+    {prompt, withResearch, stylePreset}` (#102 §7), plus `refine = { priorContent,
+    feedback }` (prior version content + new feedback) and `research` copied from the
+    artifact's latest `COMPLETED` `WorkflowRun.researchContext`.
+  - `GENERATE` consumes `refine` (prior content + feedback drive the revision prompt —
+    #104 §4) and any cached `research`.
+  - `PERSIST_VERSION` writes the new version `READY`.
+- **DOCUMENT refine** (`RESOLVE_INPUT → GENERATE → RENDER_PDF → PERSIST_VERSION`):
+  as above, **plus `RENDER_PDF` re-runs** on the revised slides, writing to the new
+  version's R2 key. The theme (`templateId`) carries forward from the prior version
+  unless the user changes it (#108 §4); `GENERATE`'s stamp/pick logic (§2) applies to
+  the refine's `stylePreset` the same way.
+
+Common to all: **no `RESEARCH` step** (research is cache-seeded, §4); the revision-prompt
+shape is #104's concern; #109 fixes only the slot flow and the research-skip.
+
+## 6. RunState slot lifecycle
+
+The complete I/O contract, one row per slot (#103 §3's `RunState`), showing which step
+sets it and which read it — the "inputs/outputs through the run state" #109 owns:
+
+| Slot | Type | Set by | Read by | Notes |
+|---|---|---|---|---|
+| `input` | `BuildInput` | `RESOLVE_INPUT` | every downstream step | the request + fixed target `(artifactId, version)` |
+| `refine` | `{ priorContent, feedback }` | `RESOLVE_INPUT` (REFINE only) | `GENERATE` | absent on INITIAL |
+| `research` | `ResearchResult` | `RESEARCH`, **or** `RESOLVE_INPUT` on REFINE (from cache) | `GENERATE` | absent when research-off and no cache |
+| `content` | `ArtifactContent` (Zod union) | `GENERATE` | `RENDER_PDF` (document), `PERSIST_VERSION` | the typed per-type payload |
+| `render` | `{ pdfKey, pageCount }` | `RENDER_PDF` (document only) | `PERSIST_VERSION` | absent for POST/POLL |
+
+- **Every step reads `input`** (it carries the fixed target and the request); guards fire
+  only if an *optional* upstream slot a step needs is missing (a builder/programming bug,
+  not control flow — #103 §3).
+- **`research` has two producers, one consumer** — the RESEARCH step (INITIAL) or the
+  cache-seed in RESOLVE_INPUT (REFINE). `GENERATE` reads it agnostic of origin.
+- **`content` is the hinge** — the AI product every code step downstream serializes,
+  renders, or persists.
+
+## 7. AI vs. pure-code classification (consolidated)
+
+| Step | Classification | Metered? | Nondeterministic? |
+|---|---|---|---|
+| `RESOLVE_INPUT` | **code** | no | no |
+| `RESEARCH` | **AI** (agentic tool loop) | yes — `llm` per turn + `web_search` per call | yes |
+| `GENERATE` | **AI** (single completion) | yes — `llm` per turn | yes |
+| `RENDER_PDF` | **code** (deterministic render) | yes — `render` surcharge (fixed) | no |
+| `PERSIST_VERSION` | **code** | no | no |
+
+- **Exactly two AI steps.** Everything else is deterministic. The two metered
+  *AI* steps carry token cost; `RENDER_PDF` carries a **fixed non-LLM surcharge** (a
+  code step can still be metered — the classification axis (AI/code) and the metering
+  axis are independent; #103 §9, #105).
+- **The deterministic spine** (`RESOLVE_INPUT`, `RENDER_PDF`, `PERSIST_VERSION`) is what
+  makes whole-job retry safe: re-running them reproduces identical side effects against
+  the fixed `(artifactId, version)` (#103 §8).
+
+## 8. Resolution — a post-repair Zod failure at `GENERATE` is **terminal**
+
+The siblings left one live conflict (flagged by #108 §3 for reconciliation): #103 §7
+classifies "Zod-invalid LLM output after a step's own internal retries" as **terminal**;
+#104 §8 says "still invalid → throw `retryable`." **#109 resolves it in favour of
+#103 §7: terminal (`WorkflowError { retryable: false }` → BullMQ `UnrecoverableError`).**
+The version ends `FAILED` with the validation reason; no whole-job retry.
+
+**Jurisdiction.** #103 owns the retry *mechanism* (transient → `retryable` rides
+`attempts: 3`; terminal → `UnrecoverableError`) — this doc doesn't touch that. What
+#109 fixes, as the ticket that defines the concrete pipeline behaviour, is *which arm
+this specific `GENERATE` throw takes* — a per-step classification, which is squarely a
+pipeline concern. #108 §3 parked the reconciliation for #110; #109 supplies the resolved
+position and its reasoning **for #110 to ratify** into the PRD, rather than leaving the
+seam open for #110 to rediscover.
+
+Reasoning:
+
+1. **The cheap, well-informed resample already happened.** `generate()` does one **inline
+   repair retry** re-prompting with the exact Zod error (#104 §8). That is a warm resample
+   *with the failure context in the prompt*. A BullMQ whole-job retry, by contrast, starts
+   cold from step 1 — the repair context is gone (each attempt rebuilds `RunState` fresh),
+   so it is a *worse*-informed resample than the one that already failed.
+2. **#104 §8's "cheap because research is cached" premise is false for INITIAL runs.** A
+   retried INITIAL research run **re-executes `RESEARCH`** (§4) — the builder keeps the
+   step for `kind === INITIAL`; only REFINE reads cached research. So the retry re-runs a
+   full Tavily pass plus a cold generation, not the cheap cached path the retryable
+   argument assumes.
+3. **It is exactly the case #103 §7 names to protect against** — "retrying just burns time
+   and credits" on output the model has now failed to schema-fit twice with the error in
+   hand. Terminal bounds worst-case spend.
+4. **The user is not stuck.** #102 §2 deliberately keeps `FAILED` versions visible in the
+   library; the user can refine with adjusted feedback or start a new run — a
+   human-in-the-loop resample that is strictly more useful than a blind retry.
+
+Consequence for the pipeline: `GENERATE`'s failure handling has **two arms** —
+LLM/transport error → `retryable` (rides the `attempts: 3` budget); Zod-invalid after
+one inline repair → `terminal`. The terminal-failure handler (#103 §8) sets the target
+version → `FAILED`, sets the `WorkflowRun` → `FAILED`, emits `run.failed`, and commits no
+credits. **This supersedes #104 §8's `retryable` for this specific throw**; #110 should
+ratify the resolution and adjust #104's migration note accordingly.
+
+*Rejected — retryable (side with #104 §8).* Relies on a premise (cached-research retry)
+that only holds for REFINE, spends a full research+generation on a cold resample less
+informed than the inline repair that just failed, and risks three attempts on a
+schema-fit failure the model has already demonstrated. The inline repair retry is the
+right place for a resample; the BullMQ budget is for transient infra, not content.
+
+## 9. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| Engine loop, `WorkflowStep` enum, builder, `RunState` typing, `WorkflowRun` record, emission envelope, retry taxonomy, credit-hook timing | #103 |
+| `AgentRunner` (`research` / `generate`), tool loop, per-type & revision prompts, inline repair retry, usage hooks | #104 |
+| `ArtifactContent` Zod union, `ArtifactWriter.setVersionContent`, version status, R2 key convention | #102 |
+| `Slide` shape, `CarouselRendererService` internals, template registry, `pdfUrl→pdfKey` rename | #108 |
+| LinkedIn poll/document API constraints & publish-time content assembly | #101 / #106 |
+| Post binding, connected-account, publish, scheduling | #106 |
+| SSE endpoint, client event schema, `Last-Event-ID` replay, heartbeats | #107 |
+| Credit denomination, token→credit rates, `llm`/`web_search`/`render` surcharge amounts | #105 |
+| **StepContext renderer role for `RENDER_PDF`** (gap surfaced in §2) | #110 to place (recommended: role interface) |
+
+## 10. Migration note
+
+Per the #100 clean write-over (relaunch, no users): **this is a design doc, no code of
+its own.** It fixes the pipelines the #103 engine executes; implementation lands with
+#103's `WorkflowStep` enum, the §2 step handlers under `src/workflow/steps/`, and the
+worker rewiring. Two items for #110 to carry from here: (a) the `GENERATE` Zod-failure
+resolution (§8, terminal — adjust #104's migration note), and (b) the `StepContext`
+renderer-role gap for `RENDER_PDF` (§2 / §9).

--- a/docs/carousel-template-system-design.md
+++ b/docs/carousel-template-system-design.md
@@ -58,6 +58,9 @@ each slide is rendered by a **slide-type** variant. A document has **one theme**
 and an ordered list of typed slides:
 
 ```ts
+// Terminology: "theme" in prose = a StylePreset value, stored as document.templateId.
+// Both identifiers are #102's fixed contract (§6 create input / §4 content field);
+// this doc does not mint a third name.
 type StylePreset = 'bold' | 'minimal' | 'editorial' | 'gradient';   // = theme id (§5)
 type SlideType   = 'cover' | 'content' | 'list' | 'quote' | 'cta';
 
@@ -229,10 +232,15 @@ export const slidesSchema = z.array(slideSchema).min(2).max(15);
   before launch (and would surface any pagination regression as a page-count
   mismatch or blank page). Caps are only trustworthy because the fixtures
   prove them.
-- **A Zod failure is a terminal generation error.** #104 §8 gives `generate()`
+- **A Zod failure never renders a broken deck.** #104 §8 gives `generate()`
   one inline repair retry (re-prompt with the validation error); if the output
-  is still invalid the run fails per #103 §7 rather than rendering a broken
-  deck. In practice the prompt caps make this rare.
+  is still invalid the step throws and the version ends `FAILED` — never a
+  half-valid deck. *Interlock note for #110:* the siblings disagree on the
+  classification of that throw — #103 §7 lists "Zod-invalid LLM output after a
+  step's own internal retries" as **terminal**, while #104 §8 says "still
+  invalid → throw `retryable`" (a fresh attempt re-samples cheaply, research
+  cached). #108 doesn't own that seam; #110 must reconcile it. In practice the
+  prompt caps make the case rare either way.
 - **Slide count 2–15 for launch.** LinkedIn allows ≤300 pages (#101), but a
   good carousel is short; 2–15 bounds UX, render time, and worst-case LLM
   output size. `pageCount = slides.length` — true by construction of the §2
@@ -300,7 +308,7 @@ decks), varied enough to cover common voices:
 
 ## 6. Rendering pipeline
 
-A single `CarouselRenderer` owns assembly + render; the engine's `RENDER_PDF`
+A single `CarouselRendererService` owns assembly + render; the engine's `RENDER_PDF`
 step calls it.
 
 **At module init (boot), not per render:** the registry (§8) loads and
@@ -335,6 +343,14 @@ An unknown `slide.type` or `templateId` at assembly is a **terminal** error
 (should never occur — Zod validated the content at generation), not a retry:
 re-running cannot fix invalid input.
 
+**`RENDER_PDF` emits no `step.progress` for launch.** #107's boundaries table
+assigns render-progress signals to #108, floating a per-page `pageRendered`
+example — but the render is a single atomic `htmlToPdf` call with nothing
+observable between request and buffer, so there is no honest per-page signal
+to emit. The core's `step.started`/`step.completed` (#103 §5) bracket it;
+`step.progress` for render stays empty until a streaming render path exists.
+This supersedes #107's speculative example.
+
 ## 7. PDF storage in R2 — store the key, sign on read
 
 - **Key:** `artifacts/${artifactId}/${version}/document.pdf` (#102 §8) —
@@ -351,9 +367,12 @@ re-running cannot fix invalid input.
   - **Publish** (#106) fetches the buffer server-side via `getFile(key)` to
     upload to LinkedIn — which needs the key anyway, and is exactly how
     `linkedin-media.service.ts` already handles media.
-  - *Interlock note for #110:* this renames #102 §4's `pdfUrl?` field to
-    `pdfKey?` — same slot, same READY-gating semantics, corrected to what a
-    private bucket can actually serve. (The key is also derivable from
+  - *Interlock note for #110:* this renames `pdfUrl` → `pdfKey` everywhere the
+    siblings mention it — #102 §4's `pdfUrl?` content field, #103 §2/§3
+    (`render: { pdfUrl, pageCount }` in `RunState` and "writes the R2
+    `pdfUrl`"), #106's publish source ("the artifact version's R2 `pdfUrl`"),
+    and #107's READY note. Same slot, same READY-gating semantics, corrected to
+    what a private bucket can actually serve. (The key is also derivable from
     `(artifactId, version)`; storing it keeps reads convention-free.)
 - **Overwrite-on-retry is safe.** A whole-job retry (#103 §7–8) targets the
   *same* `(artifactId, version)`, so re-rendering PUTs the same key —
@@ -361,7 +380,8 @@ re-running cannot fix invalid input.
 - **`pdfKey` gates `READY`.** Until the upload returns and `pdfKey` is
   written, the version stays `GENERATING` (#102 §2). The rendered PDF *is* the
   preview; no separate thumbnail asset for launch.
-- **Cleanup** stays a later background sweep (#102 §8/§11), not inline — a
+- **Cleanup** stays a later background sweep (#102 §8, and its §9 boundaries
+  table), not inline — a
   soft-deleted or superseded version's PDF is reclaimed by that sweep, not by
   the renderer.
 
@@ -380,19 +400,23 @@ assets/carousel/
     gradient/   …
 
 src/carousel/
+  index.ts                           # barrel (repo rule: every folder exposes one)
   carousel.module.ts
-  carousel-renderer.service.ts       # assembleHtml + render + store (§6)
+  carousel-renderer.service.ts       # CarouselRendererService — assembleHtml + render + store (§6)
   carousel-renderer.service.spec.ts  # CLAUDE.md: every service ships a spec
   templates.ts                       # registry (below) + boot-time compile/validation
   schemas.ts                         # slideFieldSchemas / slideSchema / slidesSchema (§3)
-  utils/html-to-pdf.util.ts          # moved from src/mark (§11), renamed to kebab-case
+  utils/
+    index.ts
+    html-to-pdf.util.ts              # moved from src/mark (§11), renamed to kebab-case
 ```
 
 ```ts
-// schemas are per slide type (§3) — the registry maps theme × type to markup only
+// schemas are per slide type (§3) — the registry maps theme × type to the
+// template filename only (resolved under assets/carousel/templates/<theme>/)
 export const carouselTemplates: Record<
   StylePreset,
-  Record<SlideType, { hbs: `${string}.hbs` }>
+  Record<SlideType, `${string}.hbs`>
 > = { … };
 ```
 
@@ -439,7 +463,7 @@ Every slide field is **LLM-generated**, i.e. untrusted text flowing into HTML.
 | `DOCUMENT` artifact/version schema, READY gate, R2 key convention (with the §7 `pdfKey` rename) | #102 |
 | Signed-URL exchange on GET/list responses | #102 |
 | Credit surcharge for a Browserless render | #105 |
-| `step.progress` during render, if surfaced | #107 |
+| `step.progress` transport/framing (render emits none for launch — §6) | #107 |
 | Fetching the PDF and uploading it as a LinkedIn document on publish | #106 |
 | Future: `image` slide type; per-slide PNG thumbnails; background R2 cleanup; re-render on manual slide `PATCH` mechanics | future |
 

--- a/docs/carousel-template-system-design.md
+++ b/docs/carousel-template-system-design.md
@@ -2,7 +2,11 @@
 
 > Status: design spec for wayfinder map #99, ticket #108 (grilling outcome).
 > Author: generated for Christopher Pam. Decisions settled in a grilling session
-> on 2026-07-09.
+> on 2026-07-09; **revised 2026-07-09 (v2)** — same settled decisions, with the
+> render mechanics corrected (blank trailing page, pagination invariants), the
+> schema/registry split fixed (field schemas are per slide *type*, not per
+> theme), and the PDF-storage contract grounded in how the app actually serves
+> R2 objects (private bucket → store the key, sign on read).
 > Blocked by: #102 (artifact schema), which is closed. This ticket owns the
 > `Slide` shape #102 §4 deliberately left opaque, plus how slides become a
 > LinkedIn document PDF.
@@ -12,33 +16,37 @@ at each boundary.
 
 ## Framing (charter-derived givens)
 
-- **A carousel is a LinkedIn *document* post.** #101's research established the
-  channel: a multi-page PDF uploaded as a document (≤100 MB / ≤300 pages), shown
-  as a swipeable carousel. So "carousel" = a PDF where **one page = one slide**.
+- **A carousel is a LinkedIn *document* post.** #101 §2 established the channel:
+  a multi-page PDF uploaded as a document (≤100 MB, ≤300 pages, formats
+  PPT/PPTX/DOC/DOCX/PDF), shown as a swipeable page-by-page card in the feed. So
+  "carousel" = a PDF where **one page = one slide**. The 1080×1350 canvas is the
+  4:5 portrait ratio the format is built around.
 - **#102 fixed the surrounding contract.** A `DOCUMENT` artifact version stores
-  `content.document = { slides: Slide[]; pdfUrl?; pageCount? }` (#102 §4);
-  `pdfUrl` is the R2 render output that gates `READY` (#102 §2); the R2 key is
+  `content.document = { slides: Slide[]; pdfUrl?; pageCount? }` (#102 §4); the
+  render output gates `READY` (#102 §2); the R2 key is
   `artifacts/${artifactId}/${version}/document.pdf` (#102 §8); `slides` is the
-  editable source of truth, `pdfUrl` the disposable derived render. #102 §4
-  explicitly parked the **internal `Slide` shape** here, guessing
+  editable source of truth, the rendered PDF the disposable derived output. #102
+  §4 explicitly parked the **internal `Slide` shape** here, guessing
   `{ templateId, fields }`.
 - **This slots into the engine's `RENDER_PDF` step.** #103 §2 runs `RENDER_PDF`
   for documents only; it "calls the existing Browserless→PDF path and writes the
   R2 `pdfUrl`." #108 owns what that step *renders* (templates + field schema +
-  assembly); #103 owns *when* it runs.
+  assembly); #103 owns *when* it runs and its retry semantics.
 - **The infra already exists and fits.** `htmlToPdf()`
-  (`src/mark/utils/html_to_pdf.util.ts`) already defaults to **1080×1350, zero
-  margin, `printBackground: true`** — the exact slide canvas. `uploadFile()`
-  (`src/s3/s3.client.ts`) already puts a `Buffer` to R2 and returns a URL.
-  Handlebars is already a dependency, used via a **typed template registry** +
-  `.hbs` files in `assets/` (`src/mail/*`). #108 composes these, inventing no new
-  infra.
+  (`src/mark/utils/html_to_pdf.util.ts`) defaults to **width `1080px`, height
+  `1350px`, zero margins, `printBackground: true`**, and sets the Browserless
+  viewport to the same dimensions — the exact slide canvas. `uploadFile(key,
+  buffer, mimeType)` (`src/s3/s3.client.ts`) PUTs to R2; `getSignedUrl(key)` and
+  `getFile(key)` already exist for reads. Handlebars is already a dependency,
+  used via a **typed template registry** + `.hbs` files in `assets/`
+  (`src/mail/templates.ts` + `assets/mail/templates/`). #108 composes these,
+  inventing no new infra.
 
 The pipeline this ticket defines:
 
 ```
 Slide[] (+ templateId)  →  assemble HTML (Handlebars per slide, one page each)
-                        →  htmlToPdf()  →  uploadFile() → R2  →  pdfUrl
+                        →  htmlToPdf()  →  uploadFile() → R2 key  →  signed URL on read
 ```
 
 ---
@@ -57,7 +65,7 @@ type SlideType   = 'cover' | 'content' | 'list' | 'quote' | 'cta';
 { commentary?: string;
   document: { templateId: StylePreset;   // the theme — one per deck
               slides: Slide[];           // 2–15 for launch (§3)
-              pdfUrl?: string;
+              pdfKey?: string;           // R2 key of the render (§7; #102 §4's `pdfUrl`, renamed)
               pageCount?: number } }
 
 Slide = { type: SlideType; fields: <type-specific, Zod-validated §3> };
@@ -68,49 +76,107 @@ Slide = { type: SlideType; fields: <type-specific, Zod-validated §3> };
 - **Theme is document-level, not per-slide.** A carousel's whole point is a
   consistent brand look across pages; letting each slide pick a different theme
   would produce an incoherent deck. One `templateId` per document.
-- **`type` is per-slide.** Real carousels are *not* homogeneous — a cover (hook),
-  body slides, and a CTA/outro are visually distinct roles. So the varying axis
-  *within* a deck is the slide **type**, each a variant `.hbs` under the theme.
+- **`type` is per-slide.** Real carousels are *not* homogeneous — a cover
+  (hook), body slides, and a CTA/outro are visually distinct roles. So the
+  varying axis *within* a deck is the slide **type**, each a variant `.hbs`
+  under the theme.
+- **Field schemas attach to the slide type, not the theme** (§3). Every theme
+  renders the same five typed shapes; themes differ only in how those shapes
+  look. This is what lets one Zod contract serve #102's content union, #104's
+  generation, and all four launch themes simultaneously.
 
 **Rejected — per-slide `templateId` (#102's literal guess).** Maximum freedom,
-but invites a Frankendeck of clashing styles and gives the AI a selection problem
-it shouldn't have. Theme-once + typed-slides is the constraint that keeps output
-on-brand.
+but invites a Frankendeck of clashing styles and gives the AI a selection
+problem it shouldn't have. Theme-once + typed-slides is the constraint that
+keeps output on-brand.
 
 **Rejected — one monolithic template per theme (no slide types).** Every slide
-would share one layout; you couldn't give the cover a hero treatment or the CTA a
-button. Slide types are cheap (small `.hbs` variants) and buy the visual variety
-carousels need.
+would share one layout; you couldn't give the cover a hero treatment or the CTA
+a button. Slide types are cheap (small `.hbs` variants) and buy the visual
+variety carousels need.
 
 ## 2. Template format
 
 Each slide-type variant is a **Handlebars `.hbs` fragment** that renders exactly
 one **1080×1350** slide; a theme also ships one **`theme.css`**.
 
-- **Fixed canvas, one page per slide.** Every slide renders inside
-  `<section class="slide">` sized to exactly `1080px × 1350px` with
-  `page-break-after: always`. Puppeteer (via `htmlToPdf`, whose defaults already
-  match — width `1080px`, height `1350px`, zero margin, `printBackground`)
-  paginates **one slide per PDF page**. No per-slide `htmlToPdf` calls — the whole
-  deck is one HTML document rendered once.
-- **Self-contained HTML, everything inlined.** Browserless renders remote HTML
-  with no reliable access to our asset host, so the assembled document inlines
-  **all** CSS (base reset + `theme.css`) in a single `<head>` `<style>`, and
-  embeds fonts and any decorative images as **`data:` URIs**. No external
-  `<link>`/`<img src=http…>`/`@import`. This makes the render deterministic and
-  fast (`waitUntil: networkidle0` resolves immediately with nothing to fetch).
-- **Layered CSS.** A shared **`base.css`** (reset, the `.slide` frame box, spacing
-  scale, the `page-break` rule) + a per-theme **`theme.css`** (palette,
-  type scale, backgrounds). Slide-type `.hbs` files carry only structural markup
-  and semantic class names the theme styles.
-- **Placeholders are auto-escaped `{{field}}`.** Slide fields are LLM-generated
-  (§9), so templates use **double-stache** `{{title}}` (Handlebars
-  HTML-escapes by default) and **never** triple-stache `{{{…}}}`. Loops use
-  `{{#each items}}`.
+### Pagination — the one-slide-one-page invariant
+
+The whole deck is **one HTML document rendered in one `htmlToPdf` call** (no
+per-slide render round-trips). Puppeteer paginates it into PDF pages; the CSS
+must make that pagination exact:
+
+```css
+/* base.css — the frame every theme inherits */
+html, body { margin: 0; padding: 0; }
+body       { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+
+.slide {
+  box-sizing: border-box;        /* theme padding never inflates the box */
+  width: 1080px;
+  height: 1350px;
+  overflow: hidden;              /* nothing ever spills onto the next page */
+  overflow-wrap: anywhere;       /* one long token can't blow the box sideways */
+  break-after: page;             /* one slide per PDF page */
+  break-inside: avoid;
+}
+.slide:last-child { break-after: auto; }   /* no blank trailing page */
+```
+
+- **`break-after: page` on every slide *except the last*.** A break after the
+  final slide emits an empty 1080×1350 page, which LinkedIn would show as a
+  blank last card — the `:last-child` override is load-bearing, not cosmetic.
+- **The page box matches the slide box exactly.** `htmlToPdf` passes
+  `width: '1080px', height: '1350px'`, zero margins (Chromium resolves px at 96
+  CSS px/in → an 11.25 in × 14.0625 in page), and a matching viewport. With
+  `box-sizing: border-box`, zeroed body margins, and `overflow: hidden` on the
+  slide, no rounding slack or oversized content can push a fragment onto an
+  extra page. No `@page` rules or `preferCSSPageSize` needed — the explicit
+  options are the single source of page geometry.
+- Slides are `<section class="slide slide--{{type}}">…</section>`, concatenated
+  in `slides[]` order.
+
+### Self-contained HTML — everything inlined
+
+Browserless renders the POSTed HTML string with no reliable access to our asset
+host, so the assembled document must resolve **zero network requests**:
+
+- All CSS (base + `theme.css`) is inlined in a single `<head>` `<style>`.
+- **Fonts:** themes use **system font stacks by default** (e.g. a Georgia stack
+  for `editorial`'s serif) — zero payload, zero load risk. A theme that needs a
+  brand font embeds it as a **subset WOFF2 `data:` URI** in its `theme.css`
+  (~30 KB per weight; keep the assembled HTML payload well under ~2 MB since it
+  travels in the Browserless POST body).
+- Decorative imagery is CSS (gradients, shapes) or small inline SVG / `data:`
+  URIs. No external `<link>`, `<img src="http…">`, or `@import`.
+- With nothing to fetch, `waitUntil: 'networkidle0'` (the util's setting)
+  resolves immediately — renders are deterministic and fast.
+- **Emoji:** LLM copy may contain emoji; whether they render depends on the
+  Browserless image shipping a color-emoji font (Noto Color Emoji is standard
+  but unverified). The fixture deck (§3) includes an emoji sample; if it renders
+  as tofu, the generation prompt (#104) bans emoji rather than us embedding a
+  multi-megabyte emoji font.
+
+### Layered CSS, structural markup
+
+A shared **`base.css`** (reset, the `.slide` frame above, spacing scale) + a
+per-theme **`theme.css`** (palette, type scale, backgrounds, per-type layout).
+Slide-type `.hbs` files carry only structural markup and semantic class names
+the theme styles.
+
+### Placeholders
+
+Slide fields are LLM-generated (§9), so templates use **auto-escaping
+double-stache `{{field}}` only, and only in element text content** — never in
+attributes, URLs, `<style>`, or comments, where HTML-escaping is not a
+sufficient defence. Lists use `{{#each items}}`. Triple-stache `{{{…}}}` is
+banned and enforced at boot (§6). Multi-line fields (`content.body`,
+`quote.quote`) render inside an element styled `white-space: pre-line` so
+intentional line breaks survive; all other fields are single-line.
 
 **Rejected — raw HTML authored by the AI (no template).** #102 §4 already ruled
-this out ("structured content that fills a curated template, *not* raw HTML"). It
-would be an XSS vector, produce inconsistent layouts, and make overflow
+this out ("structured content that fills a curated template, *not* raw HTML").
+It would be an XSS vector, produce inconsistent layouts, and make overflow
 unmanageable. The AI fills **fields**, never markup.
 
 **Rejected — a headless design lib / SVG / canvas renderer.** We already have a
@@ -119,187 +185,272 @@ authoring surface and the lowest-friction path to a launch set.
 
 ## 3. Structured content schema (what the AI fills)
 
-Each slide type has a **Zod field schema** — the contract the agent (#104) fills
-and the boundary at which output is validated (repo split: Zod for LLM data). The
-launch shapes, with **character caps** so text fits the fixed frame:
+Each slide **type** has one **Zod field schema** — shared by all themes — that
+is the contract the agent (#104) fills and the boundary at which output is
+validated (repo split: Zod for LLM data):
 
 ```ts
-cover:   { eyebrow?: string(≤24); title: string(≤70); subtitle?: string(≤120) }
-content: { heading: string(≤60);  body: string(≤280) }
-list:    { heading: string(≤60);  items: string(≤80)[] (2–6) }
-quote:   { quote: string(≤200);   attribution?: string(≤48) }
-cta:     { headline: string(≤70); action: string(≤40); handle?: string(≤40) }
+const cap = (n: number) => z.string().trim().min(1).max(n);
 
-Slide = z.discriminatedUnion('type', [ /* one arm per SlideType */ ]);
-document.slides: Slide[]  // z.array(Slide).min(2).max(15)
+export const slideFieldSchemas = {
+  cover:   z.object({ eyebrow: cap(24).optional(), title: cap(70), subtitle: cap(120).optional() }),
+  content: z.object({ heading: cap(60), body: cap(280) }),
+  list:    z.object({ heading: cap(60), items: z.array(cap(80)).min(2).max(6) }),
+  quote:   z.object({ quote: cap(200), attribution: cap(48).optional() }),
+  cta:     z.object({ headline: cap(70), action: cap(40), handle: cap(40).optional() }),
+} as const;
+
+export const slideSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('cover'),   fields: slideFieldSchemas.cover }),
+  z.object({ type: z.literal('content'), fields: slideFieldSchemas.content }),
+  z.object({ type: z.literal('list'),    fields: slideFieldSchemas.list }),
+  z.object({ type: z.literal('quote'),   fields: slideFieldSchemas.quote }),
+  z.object({ type: z.literal('cta'),     fields: slideFieldSchemas.cta }),
+]);
+
+// document.slides — plugs into #102 §4's DOCUMENT content schema
+export const slidesSchema = z.array(slideSchema).min(2).max(15);
 ```
 
-- **Caps are the fit contract.** A fixed 1080×1350 slide has no scroll — overflow
-  is the enemy. Caps are chosen so worst-case text fits each theme's type scale.
-  They are enforced **three ways, defence in depth:** (1) the agent prompt (#104)
-  states the caps so the model aims within them; (2) Zod rejects over-cap output
-  at the generation boundary; (3) `theme.css` sets `overflow: hidden` +
-  `text-overflow: ellipsis` as a last-resort clamp so a slip never breaks layout.
-- **A Zod failure is a terminal generation error.** Per #103 §7, Zod-invalid LLM
-  output (after the agent's own internal retries) is `retryable: false` → the run
-  fails cleanly rather than rendering a broken slide. In practice the prompt caps
-  make this rare.
-- **Slide count 2–15 for launch.** LinkedIn allows ≤300 pages (#101), but a good
-  carousel is short; 2–15 bounds both UX and render time. `pageCount = slides.length`.
+- **Caps are the fit contract — sized to the tightest theme.** A fixed
+  1080×1350 slide has no scroll; overflow is the enemy. Character count is a
+  *proxy* for rendered width (70 "W"s are wider than 70 "i"s), so the caps are
+  calibrated against the theme with the largest type scale, and enforced
+  **three ways, defence in depth:** (1) the agent prompt (#104) states the caps
+  so the model aims within them; (2) Zod rejects over-cap output at the
+  generation boundary; (3) the `.slide` frame's `overflow: hidden` +
+  `overflow-wrap: anywhere` (§2) is the last-resort clamp so a slip degrades to
+  clipped text, never a broken layout or a spilled page.
+- **The fixture deck is the fit proof.** Each theme ships a fixture: a
+  15-slide deck exercising every slide type at **maximum** field lengths
+  (6-item list, full-cap strings, an emoji, a long unbroken token). A registry
+  spec test asserts it assembles and renders cleanly through the template
+  layer; rendering the fixtures to PDF is the manual QA gate for each theme
+  before launch (and would surface any pagination regression as a page-count
+  mismatch or blank page). Caps are only trustworthy because the fixtures
+  prove them.
+- **A Zod failure is a terminal generation error.** #104 §8 gives `generate()`
+  one inline repair retry (re-prompt with the validation error); if the output
+  is still invalid the run fails per #103 §7 rather than rendering a broken
+  deck. In practice the prompt caps make this rare.
+- **Slide count 2–15 for launch.** LinkedIn allows ≤300 pages (#101), but a
+  good carousel is short; 2–15 bounds UX, render time, and worst-case LLM
+  output size. `pageCount = slides.length` — true by construction of the §2
+  pagination invariant, which the fixture decks guard.
 - **Launch is text-only.** No user-supplied slide images in v1 (keeps rendering
-  deterministic — no asset fetch/upload/sizing). Visual richness comes from theme
-  CSS (gradients, shapes, type). Image slides are noted future work (§10), and the
-  `Slide` union is a discriminated union precisely so an `image` type can be added
-  without touching existing arms.
+  deterministic — no asset fetch/upload/sizing). Visual richness comes from
+  theme CSS. `slideSchema` is a discriminated union precisely so a future
+  `image` slide type is a new arm, touching no existing one (§10).
+
+**Rejected — per-theme field schemas** (caps varying with each theme's type
+scale). Tighter per-theme fit, but the schema is shared with #102's content
+union and #104's generation contract, neither of which can vary by theme — a
+per-theme schema would fork the single source of truth. One schema, calibrated
+to the tightest theme, keeps the contract whole at the cost of slightly
+conservative caps in roomier themes.
 
 ## 4. Template selection — user-picked *or* AI-picked
 
 Two distinct decisions, split by who's better placed to make them:
 
-- **Theme (`templateId`) — user-picked, else AI-picked.** #102 §6's create input
-  already carries `stylePreset?: StylePreset`. When the user picks a theme it is
-  used verbatim. When omitted, the **agent picks** a theme from the launch set
-  based on the prompt/topic (e.g. `editorial` for a thought-piece, `bold` for a
-  punchy hook). The chosen `templateId` is persisted on `document` either way, so
-  a refine (#103 §11) keeps the same theme unless the user changes it.
+- **Theme (`templateId`) — user-picked, else AI-picked.** #102 §6's create
+  input already carries `stylePreset?: StylePreset`.
+  - **User supplied it** → it is authoritative: the `GENERATE` step **stamps**
+    `document.templateId = stylePreset` after generation; the model is not
+    asked to choose and its output cannot override the user.
+  - **Omitted** → the generation prompt (#104) asks the model to pick a
+    `templateId` from the `StylePreset` enum based on the prompt/topic (e.g.
+    `editorial` for a thought-piece, `bold` for a punchy hook); the Zod
+    boundary validates it is a real preset.
+  - Either way the chosen `templateId` is persisted on `document`, so a refine
+    (#103 §11) keeps the same theme unless the user changes it.
 - **Slide structure (count, per-slide `type`, field values) — always AI.** The
-  narrative arc — how many slides, which is a `cover` vs `list` vs `cta`, and what
-  each says — is authored by the agent as it composes the deck. The user does not
-  hand-assemble slides at generation time (they can manually `PATCH` afterward per
-  #102 §5).
+  narrative arc — how many slides, which is a `cover` vs `list` vs `cta`, and
+  what each says — is authored by the agent as it composes the deck. The user
+  does not hand-assemble slides at generation time (they can manually `PATCH`
+  afterward per #102 §5; a slide edit re-renders the PDF per #102 §4).
 
 **Rejected — user hand-builds the deck slide-by-slide up front.** That's a
-page-builder product, not the AI-generation flow #99 is about. Manual editing is
-the post-generation `PATCH` path (#102 §5), not the create path.
+page-builder product, not the AI-generation flow #99 is about. Manual editing
+is the post-generation `PATCH` path (#102 §5), not the create path.
 
 **Rejected — AI free-picks any CSS/colours.** Off-brand, unbounded, and defeats
-the point of a *curated* template set. The AI picks *within* the curated themes.
+the point of a *curated* template set. The AI picks *within* the curated
+themes.
 
 ## 5. Launch template set
 
-Four themes, each implementing all five slide types — small enough to hand-craft
-and QA, varied enough to cover common voices:
+Four themes, each implementing all five slide types — small enough to
+hand-craft and QA (4 × 5 = 20 `.hbs` fragments + 4 stylesheets + 4 fixture
+decks), varied enough to cover common voices:
 
 | `templateId` | Voice | Look |
 |---|---|---|
 | `bold` | Punchy, hook-driven | High-contrast, oversized display type, solid accent blocks |
 | `minimal` | Clean, professional | Lots of whitespace, restrained palette, thin rules |
-| `editorial` | Thought-leadership | Serif headings, magazine grid, muted paper tones |
+| `editorial` | Thought-leadership | Serif headings (system Georgia stack), magazine grid, muted paper tones |
 | `gradient` | Energetic, modern | Vivid gradient backgrounds, white type, rounded shapes |
 
 - Each theme = `assets/carousel/templates/<templateId>/` containing
-  `cover.hbs`, `content.hbs`, `list.hbs`, `quote.hbs`, `cta.hbs`, `theme.css`.
+  `cover.hbs`, `content.hbs`, `list.hbs`, `quote.hbs`, `cta.hbs`, `theme.css`,
+  `fixture.json` (§3).
 - `base.css` is shared across all themes.
-- Adding a theme later = a new folder + one registry entry (§8); no engine change.
+- Adding a theme later = a new folder + one registry entry (§8); no schema or
+  engine change (schemas are per-type, §3).
 
 ## 6. Rendering pipeline
 
 A single `CarouselRenderer` owns assembly + render; the engine's `RENDER_PDF`
-step calls it. Steps:
+step calls it.
 
-1. **Assemble HTML** — `assembleHtml(templateId, slides)`:
-   - read `base.css` + `<templateId>/theme.css`, inline both into one `<style>`;
-   - for each slide, `Handlebars.compile(<templateId>/<slide.type>.hbs)(slide.fields)`,
-     wrapped in the `.slide` section;
-   - concatenate slides in order into one `<html>` document.
-2. **Render** — `htmlToPdf(html)` (existing util; defaults already 1080×1350,
-   zero-margin, `printBackground`). Returns a `Buffer`. The util already throws a
-   descriptive error on Browserless failure, which the `RENDER_PDF` step surfaces
-   as a (retryable) `WorkflowError` (#103 §7 — Browserless timeout is transient).
+**At module init (boot), not per render:** the registry (§8) loads and
+`Handlebars.compile`s every `(theme, slide type)` template once, and **fails
+fast** if any file is missing, fails to compile, or contains `{{{` — turning
+the no-triple-stache rule (§9) from a review checkpoint into an enforced
+invariant. Templates are static assets, so boot-time compilation is safe and
+makes per-render work pure string interpolation. (The mail service compiles
+per-send — `mail.service.ts:88` — which is fine at mail volume; a deck
+interpolates up to 15 fragments per render, so precompiling is the same idiom
+moved to init.)
+
+**Per render**, the `RENDER_PDF` step:
+
+1. **Assemble** — `assembleHtml(templateId, slides): string` (pure, no I/O at
+   render time): for each slide, apply the precompiled
+   `<templateId>/<slide.type>` template to `slide.fields`, wrap in the
+   `.slide` section, concatenate in order inside one `<html>` document whose
+   `<head>` inlines `base.css` + the theme's `theme.css`.
+2. **Render** — `htmlToPdf(html)` (existing util, defaults untouched) →
+   `Buffer`. The util already throws a descriptive error on Browserless
+   failure; the step surfaces it as a **retryable** `WorkflowError` (#103 §7 —
+   Browserless timeouts are transient).
 3. **Store** — `uploadFile('artifacts/${artifactId}/${version}/document.pdf',
-   buffer, 'application/pdf')` → returns the R2 URL.
-4. **Write back** — the step writes `render = { pdfUrl, pageCount: slides.length }`
-   to `RunState` (#103 §3); `PERSIST_VERSION` writes `document.pdfUrl` /
-   `pageCount` onto the version, flipping it `READY` (#102 §2).
+   buffer, 'application/pdf')` (§7).
+4. **Write back** — the step returns
+   `render = { pdfKey, pageCount: slides.length }` into `RunState` (#103 §3);
+   `PERSIST_VERSION` writes both onto the version, flipping it `READY`
+   (#102 §2).
 
-- **Handlebars is compiled per render** (matching `mail.service.ts:88`); template
-  sources may be cached in-process since `.hbs` files are static assets.
-- **Template registry (§8)** validates `slide.type ∈ theme's variants` and gives
-  `assembleHtml` the `.hbs` path + the Zod schema; an unknown type is a terminal
-  error (should never occur — the agent only emits registered types).
+An unknown `slide.type` or `templateId` at assembly is a **terminal** error
+(should never occur — Zod validated the content at generation), not a retry:
+re-running cannot fix invalid input.
 
-## 7. PDF storage in R2
+## 7. PDF storage in R2 — store the key, sign on read
 
-- **Key:** `artifacts/${artifactId}/${version}/document.pdf` (#102 §8) — verbatim.
-  **Version-scoped**, so a refine (new version, #103 §11) renders to a fresh key
-  and never clobbers a prior version's PDF.
-- **Overwrite-on-retry is safe.** A whole-job retry (#103 §7–8) targets the *same*
-  `(artifactId, version)`, so re-rendering PUTs the same key — idempotent, no
-  orphan (#103 §8's "retry overwrites rather than appends").
-- **`pdfUrl` gates `READY`.** Until `uploadFile` returns and `pdfUrl` is written,
-  the version stays `GENERATING` (#102 §2). List/preview surfaces use `pdfUrl` as
-  the document thumbnail (#102 §8) — the rendered PDF *is* the preview; no separate
-  thumbnail asset for launch.
-- **Cleanup** stays a later background sweep (#102 §8 / §11), not inline — a
-  soft-deleted or superseded version's PDF is reclaimed by that sweep, not by the
-  renderer.
+- **Key:** `artifacts/${artifactId}/${version}/document.pdf` (#102 §8) —
+  verbatim. **Version-scoped**, so a refine (new version, #103 §11) renders to
+  a fresh key and never clobbers a prior version's PDF.
+- **Persist the key (`pdfKey`), not a raw URL.** `uploadFile` returns a
+  `…r2.cloudflarestorage.com` URL, but the bucket is **private** — nothing in
+  the app serves that URL to clients today; the existing media flow stores an
+  `r2Key` and reads server-side via `getFile`. So the version stores the
+  **key**, and:
+  - **Client reads** (#102's GET/list, where the render is the document's
+    preview/thumbnail) exchange it for a short-lived **signed URL** via the
+    existing `getSignedUrl(key)` at response time.
+  - **Publish** (#106) fetches the buffer server-side via `getFile(key)` to
+    upload to LinkedIn — which needs the key anyway, and is exactly how
+    `linkedin-media.service.ts` already handles media.
+  - *Interlock note for #110:* this renames #102 §4's `pdfUrl?` field to
+    `pdfKey?` — same slot, same READY-gating semantics, corrected to what a
+    private bucket can actually serve. (The key is also derivable from
+    `(artifactId, version)`; storing it keeps reads convention-free.)
+- **Overwrite-on-retry is safe.** A whole-job retry (#103 §7–8) targets the
+  *same* `(artifactId, version)`, so re-rendering PUTs the same key —
+  idempotent, no orphans (#103 §8's "retry overwrites rather than appends").
+- **`pdfKey` gates `READY`.** Until the upload returns and `pdfKey` is
+  written, the version stays `GENERATING` (#102 §2). The rendered PDF *is* the
+  preview; no separate thumbnail asset for launch.
+- **Cleanup** stays a later background sweep (#102 §8/§11), not inline — a
+  soft-deleted or superseded version's PDF is reclaimed by that sweep, not by
+  the renderer.
 
 ## 8. Where it lives — assets + typed registry
 
 Mirrors the mail-template idiom (`src/mail/templates.ts` typed registry +
-`assets/mail/templates/*.hbs`):
+`assets/mail/templates/*.hbs`), as a new **`src/carousel/`** feature module:
 
 ```
 assets/carousel/
   base.css
   templates/
-    bold/      cover.hbs content.hbs list.hbs quote.hbs cta.hbs theme.css
-    minimal/   …
-    editorial/ …
-    gradient/  …
+    bold/       cover.hbs content.hbs list.hbs quote.hbs cta.hbs theme.css fixture.json
+    minimal/    …
+    editorial/  …
+    gradient/   …
+
+src/carousel/
+  carousel.module.ts
+  carousel-renderer.service.ts       # assembleHtml + render + store (§6)
+  carousel-renderer.service.spec.ts  # CLAUDE.md: every service ships a spec
+  templates.ts                       # registry (below) + boot-time compile/validation
+  schemas.ts                         # slideFieldSchemas / slideSchema / slidesSchema (§3)
+  utils/html-to-pdf.util.ts          # moved from src/mark (§11), renamed to kebab-case
 ```
 
 ```ts
-// a typed registry, keyed by StylePreset → SlideType → { hbs, fields (Zod) }
-export const carouselTemplates: Record<StylePreset,
-  Record<SlideType, { hbs: `${string}.hbs`; fields: z.ZodType }>> = { … };
+// schemas are per slide type (§3) — the registry maps theme × type to markup only
+export const carouselTemplates: Record<
+  StylePreset,
+  Record<SlideType, { hbs: `${string}.hbs` }>
+> = { … };
 ```
 
-- The **Zod field schemas are exported** from here and consumed by (a) #102's
-  `ArtifactContent` document union (the `Slide` discriminated union), and (b)
-  #104's agent generation (the shape it must fill). One source of truth for the
-  slide contract.
-- The `CarouselRenderer` service gets a `carousel-renderer.service.spec.ts` when
-  implemented (CLAUDE.md: every service ships a spec) — assembly is pure-ish
-  (string in/out) so it unit-tests without Browserless (mock `htmlToPdf` /
-  `uploadFile`).
+- **The Zod schemas in `schemas.ts` are the single source of truth** for the
+  slide contract, consumed by (a) #102's `ArtifactContent` document union and
+  (b) #104's `generate()` output validation. The registry deliberately does
+  **not** carry schemas — keying them by theme (v1 of this doc did) would
+  invite per-theme divergence of a contract that must stay uniform (§3).
+- Assembly is pure string-in/string-out, so `carousel-renderer.service.spec.ts`
+  unit-tests it without Browserless (mock `htmlToPdf` / `uploadFile`); the
+  registry spec iterates every theme's fixture deck through `assembleHtml`
+  (§3).
 
 ## 9. Security — LLM fields never become markup
 
 Every slide field is **LLM-generated**, i.e. untrusted text flowing into HTML.
 
-- **Handlebars double-stache auto-escapes** (`{{field}}`), so `<script>`/`</section>`
-  in a field renders as inert text, not markup — no injection into the rendered
-  page. Templates **must not** use triple-stache `{{{…}}}` for any field; that is
-  a review checkpoint for every `.hbs` in the launch set.
-- **Rendering is sandboxed anyway** — it runs in Browserless purely to paint a PDF;
-  there are no cookies, no same-origin secrets, no navigation. Even so, escaping is
-  kept as defence in depth so a malformed slide can never break out of its box or
-  corrupt neighbouring slides.
-- **No `data:`/remote URLs from fields.** Fields are plain text (caps in §3);
-  images/fonts come only from the template's own inlined assets, never from AI
-  output. (Revisit when the future `image` slide type lands — user images will
-  need the existing R2 upload + validation path, not raw field URLs.)
+- **Handlebars double-stache auto-escapes** (`{{field}}`), so `<script>` /
+  `</section>` in a field renders as inert text — a field can't inject markup
+  or break out of its slide box.
+- **Interpolation is restricted to element text content** (§2). Escaping is
+  only a complete defence in that context — fields never appear in attribute,
+  URL, or style position, so there is no context where escaped-but-dangerous
+  values (e.g. `javascript:` URLs) could matter.
+- **Triple-stache is banned and machine-enforced** — registry boot fails on any
+  template source containing `{{{` (§6), so the rule can't erode as templates
+  are added. No custom Handlebars helpers that emit `SafeString`s either;
+  built-in `{{#each}}`/`{{#if}}` only.
+- **Rendering is sandboxed anyway** — Browserless paints a PDF from an inert
+  document; there are no cookies, no same-origin secrets, no navigation.
+  Escaping is kept as defence in depth, not the only wall.
+- **No `data:`/remote URLs from fields.** Fields are plain text (§3);
+  fonts/decoration come only from the template's own inlined assets, never
+  from AI output. (Revisit when the future `image` slide type lands — user
+  images go through the existing R2 upload + validation path, not raw field
+  URLs.)
 
 ## 10. Boundaries (owned by other tickets)
 
 | Concern | Owner |
 |---|---|
 | *When* `RENDER_PDF` runs; retry/idempotency of the render step | #103 |
-| The agent that fills slide fields / picks theme+types; per-slide prompts | #104 |
-| `DOCUMENT` artifact/version schema, `pdfUrl` READY gate, R2 key convention | #102 |
+| The agent that fills slide fields / picks theme+types; prompt wording (caps, emoji policy, theme-choice guidance) | #104 |
+| `DOCUMENT` artifact/version schema, READY gate, R2 key convention (with the §7 `pdfKey` rename) | #102 |
+| Signed-URL exchange on GET/list responses | #102 |
 | Credit surcharge for a Browserless render | #105 |
-| `step.progress` during render (e.g. per-page) if surfaced | #107 |
-| Uploading the finished PDF as a LinkedIn document on publish | #106 |
-| Future: `image` slide type; per-slide PNG thumbnails; background R2 cleanup | future |
+| `step.progress` during render, if surfaced | #107 |
+| Fetching the PDF and uploading it as a LinkedIn document on publish | #106 |
+| Future: `image` slide type; per-slide PNG thumbnails; background R2 cleanup; re-render on manual slide `PATCH` mechanics | future |
 
 ## 11. Migration note
 
-Per the #100 clean write-over (relaunch, no users): **new surface, no migration.**
-This adds `assets/carousel/**`, a `carouselTemplates` registry, and a
-`CarouselRenderer` service, and it reuses the **existing** `htmlToPdf` and
-`uploadFile` utilities unchanged. `src/mark/utils/html_to_pdf.util.ts` currently
-lives under `src/mark`, which #103/§charter-#9 dissolves — on implementation the
-util moves to a neutral home (e.g. `src/render/` or `src/s3` neighbourhood)
-alongside the new renderer; its logic is untouched. No `PostDraft`-era carousel
-code exists to replace.
+Per the #100 clean write-over (relaunch, no users): **new surface, no
+migration.** This adds `assets/carousel/**` and the `src/carousel/` module
+(§8), and reuses the existing `htmlToPdf` and `uploadFile`/`getSignedUrl`/
+`getFile` utilities with their logic untouched. `src/mark/utils/
+html_to_pdf.util.ts` currently lives under `src/mark`, which #103/charter #9
+dissolves — on implementation the util moves to `src/carousel/utils/` and is
+renamed **`html-to-pdf.util.ts`** (the current snake_case name violates the
+repo's kebab-case file convention). No `PostDraft`-era carousel code exists to
+replace.

--- a/docs/carousel-template-system-design.md
+++ b/docs/carousel-template-system-design.md
@@ -1,0 +1,305 @@
+# Carousel Template System — Design
+
+> Status: design spec for wayfinder map #99, ticket #108 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled in a grilling session
+> on 2026-07-09.
+> Blocked by: #102 (artifact schema), which is closed. This ticket owns the
+> `Slide` shape #102 §4 deliberately left opaque, plus how slides become a
+> LinkedIn document PDF.
+
+Feeds the final spec assembly (#110). Interlocking tickets are referenced inline
+at each boundary.
+
+## Framing (charter-derived givens)
+
+- **A carousel is a LinkedIn *document* post.** #101's research established the
+  channel: a multi-page PDF uploaded as a document (≤100 MB / ≤300 pages), shown
+  as a swipeable carousel. So "carousel" = a PDF where **one page = one slide**.
+- **#102 fixed the surrounding contract.** A `DOCUMENT` artifact version stores
+  `content.document = { slides: Slide[]; pdfUrl?; pageCount? }` (#102 §4);
+  `pdfUrl` is the R2 render output that gates `READY` (#102 §2); the R2 key is
+  `artifacts/${artifactId}/${version}/document.pdf` (#102 §8); `slides` is the
+  editable source of truth, `pdfUrl` the disposable derived render. #102 §4
+  explicitly parked the **internal `Slide` shape** here, guessing
+  `{ templateId, fields }`.
+- **This slots into the engine's `RENDER_PDF` step.** #103 §2 runs `RENDER_PDF`
+  for documents only; it "calls the existing Browserless→PDF path and writes the
+  R2 `pdfUrl`." #108 owns what that step *renders* (templates + field schema +
+  assembly); #103 owns *when* it runs.
+- **The infra already exists and fits.** `htmlToPdf()`
+  (`src/mark/utils/html_to_pdf.util.ts`) already defaults to **1080×1350, zero
+  margin, `printBackground: true`** — the exact slide canvas. `uploadFile()`
+  (`src/s3/s3.client.ts`) already puts a `Buffer` to R2 and returns a URL.
+  Handlebars is already a dependency, used via a **typed template registry** +
+  `.hbs` files in `assets/` (`src/mail/*`). #108 composes these, inventing no new
+  infra.
+
+The pipeline this ticket defines:
+
+```
+Slide[] (+ templateId)  →  assemble HTML (Handlebars per slide, one page each)
+                        →  htmlToPdf()  →  uploadFile() → R2  →  pdfUrl
+```
+
+---
+
+## 1. Template model — theme (deck) × slide *type* (role)
+
+The unit a user/AI picks is a **theme** (a visual deck design). Within a theme,
+each slide is rendered by a **slide-type** variant. A document has **one theme**
+and an ordered list of typed slides:
+
+```ts
+type StylePreset = 'bold' | 'minimal' | 'editorial' | 'gradient';   // = theme id (§5)
+type SlideType   = 'cover' | 'content' | 'list' | 'quote' | 'cta';
+
+// document content (refines #102 §4)
+{ commentary?: string;
+  document: { templateId: StylePreset;   // the theme — one per deck
+              slides: Slide[];           // 2–15 for launch (§3)
+              pdfUrl?: string;
+              pageCount?: number } }
+
+Slide = { type: SlideType; fields: <type-specific, Zod-validated §3> };
+```
+
+**This refines #102 §4's `{ templateId, fields }` guess** deliberately:
+
+- **Theme is document-level, not per-slide.** A carousel's whole point is a
+  consistent brand look across pages; letting each slide pick a different theme
+  would produce an incoherent deck. One `templateId` per document.
+- **`type` is per-slide.** Real carousels are *not* homogeneous — a cover (hook),
+  body slides, and a CTA/outro are visually distinct roles. So the varying axis
+  *within* a deck is the slide **type**, each a variant `.hbs` under the theme.
+
+**Rejected — per-slide `templateId` (#102's literal guess).** Maximum freedom,
+but invites a Frankendeck of clashing styles and gives the AI a selection problem
+it shouldn't have. Theme-once + typed-slides is the constraint that keeps output
+on-brand.
+
+**Rejected — one monolithic template per theme (no slide types).** Every slide
+would share one layout; you couldn't give the cover a hero treatment or the CTA a
+button. Slide types are cheap (small `.hbs` variants) and buy the visual variety
+carousels need.
+
+## 2. Template format
+
+Each slide-type variant is a **Handlebars `.hbs` fragment** that renders exactly
+one **1080×1350** slide; a theme also ships one **`theme.css`**.
+
+- **Fixed canvas, one page per slide.** Every slide renders inside
+  `<section class="slide">` sized to exactly `1080px × 1350px` with
+  `page-break-after: always`. Puppeteer (via `htmlToPdf`, whose defaults already
+  match — width `1080px`, height `1350px`, zero margin, `printBackground`)
+  paginates **one slide per PDF page**. No per-slide `htmlToPdf` calls — the whole
+  deck is one HTML document rendered once.
+- **Self-contained HTML, everything inlined.** Browserless renders remote HTML
+  with no reliable access to our asset host, so the assembled document inlines
+  **all** CSS (base reset + `theme.css`) in a single `<head>` `<style>`, and
+  embeds fonts and any decorative images as **`data:` URIs**. No external
+  `<link>`/`<img src=http…>`/`@import`. This makes the render deterministic and
+  fast (`waitUntil: networkidle0` resolves immediately with nothing to fetch).
+- **Layered CSS.** A shared **`base.css`** (reset, the `.slide` frame box, spacing
+  scale, the `page-break` rule) + a per-theme **`theme.css`** (palette,
+  type scale, backgrounds). Slide-type `.hbs` files carry only structural markup
+  and semantic class names the theme styles.
+- **Placeholders are auto-escaped `{{field}}`.** Slide fields are LLM-generated
+  (§9), so templates use **double-stache** `{{title}}` (Handlebars
+  HTML-escapes by default) and **never** triple-stache `{{{…}}}`. Loops use
+  `{{#each items}}`.
+
+**Rejected — raw HTML authored by the AI (no template).** #102 §4 already ruled
+this out ("structured content that fills a curated template, *not* raw HTML"). It
+would be an XSS vector, produce inconsistent layouts, and make overflow
+unmanageable. The AI fills **fields**, never markup.
+
+**Rejected — a headless design lib / SVG / canvas renderer.** We already have a
+working Browserless→PDF path tuned to 1080×1350; HTML/CSS is the most malleable
+authoring surface and the lowest-friction path to a launch set.
+
+## 3. Structured content schema (what the AI fills)
+
+Each slide type has a **Zod field schema** — the contract the agent (#104) fills
+and the boundary at which output is validated (repo split: Zod for LLM data). The
+launch shapes, with **character caps** so text fits the fixed frame:
+
+```ts
+cover:   { eyebrow?: string(≤24); title: string(≤70); subtitle?: string(≤120) }
+content: { heading: string(≤60);  body: string(≤280) }
+list:    { heading: string(≤60);  items: string(≤80)[] (2–6) }
+quote:   { quote: string(≤200);   attribution?: string(≤48) }
+cta:     { headline: string(≤70); action: string(≤40); handle?: string(≤40) }
+
+Slide = z.discriminatedUnion('type', [ /* one arm per SlideType */ ]);
+document.slides: Slide[]  // z.array(Slide).min(2).max(15)
+```
+
+- **Caps are the fit contract.** A fixed 1080×1350 slide has no scroll — overflow
+  is the enemy. Caps are chosen so worst-case text fits each theme's type scale.
+  They are enforced **three ways, defence in depth:** (1) the agent prompt (#104)
+  states the caps so the model aims within them; (2) Zod rejects over-cap output
+  at the generation boundary; (3) `theme.css` sets `overflow: hidden` +
+  `text-overflow: ellipsis` as a last-resort clamp so a slip never breaks layout.
+- **A Zod failure is a terminal generation error.** Per #103 §7, Zod-invalid LLM
+  output (after the agent's own internal retries) is `retryable: false` → the run
+  fails cleanly rather than rendering a broken slide. In practice the prompt caps
+  make this rare.
+- **Slide count 2–15 for launch.** LinkedIn allows ≤300 pages (#101), but a good
+  carousel is short; 2–15 bounds both UX and render time. `pageCount = slides.length`.
+- **Launch is text-only.** No user-supplied slide images in v1 (keeps rendering
+  deterministic — no asset fetch/upload/sizing). Visual richness comes from theme
+  CSS (gradients, shapes, type). Image slides are noted future work (§10), and the
+  `Slide` union is a discriminated union precisely so an `image` type can be added
+  without touching existing arms.
+
+## 4. Template selection — user-picked *or* AI-picked
+
+Two distinct decisions, split by who's better placed to make them:
+
+- **Theme (`templateId`) — user-picked, else AI-picked.** #102 §6's create input
+  already carries `stylePreset?: StylePreset`. When the user picks a theme it is
+  used verbatim. When omitted, the **agent picks** a theme from the launch set
+  based on the prompt/topic (e.g. `editorial` for a thought-piece, `bold` for a
+  punchy hook). The chosen `templateId` is persisted on `document` either way, so
+  a refine (#103 §11) keeps the same theme unless the user changes it.
+- **Slide structure (count, per-slide `type`, field values) — always AI.** The
+  narrative arc — how many slides, which is a `cover` vs `list` vs `cta`, and what
+  each says — is authored by the agent as it composes the deck. The user does not
+  hand-assemble slides at generation time (they can manually `PATCH` afterward per
+  #102 §5).
+
+**Rejected — user hand-builds the deck slide-by-slide up front.** That's a
+page-builder product, not the AI-generation flow #99 is about. Manual editing is
+the post-generation `PATCH` path (#102 §5), not the create path.
+
+**Rejected — AI free-picks any CSS/colours.** Off-brand, unbounded, and defeats
+the point of a *curated* template set. The AI picks *within* the curated themes.
+
+## 5. Launch template set
+
+Four themes, each implementing all five slide types — small enough to hand-craft
+and QA, varied enough to cover common voices:
+
+| `templateId` | Voice | Look |
+|---|---|---|
+| `bold` | Punchy, hook-driven | High-contrast, oversized display type, solid accent blocks |
+| `minimal` | Clean, professional | Lots of whitespace, restrained palette, thin rules |
+| `editorial` | Thought-leadership | Serif headings, magazine grid, muted paper tones |
+| `gradient` | Energetic, modern | Vivid gradient backgrounds, white type, rounded shapes |
+
+- Each theme = `assets/carousel/templates/<templateId>/` containing
+  `cover.hbs`, `content.hbs`, `list.hbs`, `quote.hbs`, `cta.hbs`, `theme.css`.
+- `base.css` is shared across all themes.
+- Adding a theme later = a new folder + one registry entry (§8); no engine change.
+
+## 6. Rendering pipeline
+
+A single `CarouselRenderer` owns assembly + render; the engine's `RENDER_PDF`
+step calls it. Steps:
+
+1. **Assemble HTML** — `assembleHtml(templateId, slides)`:
+   - read `base.css` + `<templateId>/theme.css`, inline both into one `<style>`;
+   - for each slide, `Handlebars.compile(<templateId>/<slide.type>.hbs)(slide.fields)`,
+     wrapped in the `.slide` section;
+   - concatenate slides in order into one `<html>` document.
+2. **Render** — `htmlToPdf(html)` (existing util; defaults already 1080×1350,
+   zero-margin, `printBackground`). Returns a `Buffer`. The util already throws a
+   descriptive error on Browserless failure, which the `RENDER_PDF` step surfaces
+   as a (retryable) `WorkflowError` (#103 §7 — Browserless timeout is transient).
+3. **Store** — `uploadFile('artifacts/${artifactId}/${version}/document.pdf',
+   buffer, 'application/pdf')` → returns the R2 URL.
+4. **Write back** — the step writes `render = { pdfUrl, pageCount: slides.length }`
+   to `RunState` (#103 §3); `PERSIST_VERSION` writes `document.pdfUrl` /
+   `pageCount` onto the version, flipping it `READY` (#102 §2).
+
+- **Handlebars is compiled per render** (matching `mail.service.ts:88`); template
+  sources may be cached in-process since `.hbs` files are static assets.
+- **Template registry (§8)** validates `slide.type ∈ theme's variants` and gives
+  `assembleHtml` the `.hbs` path + the Zod schema; an unknown type is a terminal
+  error (should never occur — the agent only emits registered types).
+
+## 7. PDF storage in R2
+
+- **Key:** `artifacts/${artifactId}/${version}/document.pdf` (#102 §8) — verbatim.
+  **Version-scoped**, so a refine (new version, #103 §11) renders to a fresh key
+  and never clobbers a prior version's PDF.
+- **Overwrite-on-retry is safe.** A whole-job retry (#103 §7–8) targets the *same*
+  `(artifactId, version)`, so re-rendering PUTs the same key — idempotent, no
+  orphan (#103 §8's "retry overwrites rather than appends").
+- **`pdfUrl` gates `READY`.** Until `uploadFile` returns and `pdfUrl` is written,
+  the version stays `GENERATING` (#102 §2). List/preview surfaces use `pdfUrl` as
+  the document thumbnail (#102 §8) — the rendered PDF *is* the preview; no separate
+  thumbnail asset for launch.
+- **Cleanup** stays a later background sweep (#102 §8 / §11), not inline — a
+  soft-deleted or superseded version's PDF is reclaimed by that sweep, not by the
+  renderer.
+
+## 8. Where it lives — assets + typed registry
+
+Mirrors the mail-template idiom (`src/mail/templates.ts` typed registry +
+`assets/mail/templates/*.hbs`):
+
+```
+assets/carousel/
+  base.css
+  templates/
+    bold/      cover.hbs content.hbs list.hbs quote.hbs cta.hbs theme.css
+    minimal/   …
+    editorial/ …
+    gradient/  …
+```
+
+```ts
+// a typed registry, keyed by StylePreset → SlideType → { hbs, fields (Zod) }
+export const carouselTemplates: Record<StylePreset,
+  Record<SlideType, { hbs: `${string}.hbs`; fields: z.ZodType }>> = { … };
+```
+
+- The **Zod field schemas are exported** from here and consumed by (a) #102's
+  `ArtifactContent` document union (the `Slide` discriminated union), and (b)
+  #104's agent generation (the shape it must fill). One source of truth for the
+  slide contract.
+- The `CarouselRenderer` service gets a `carousel-renderer.service.spec.ts` when
+  implemented (CLAUDE.md: every service ships a spec) — assembly is pure-ish
+  (string in/out) so it unit-tests without Browserless (mock `htmlToPdf` /
+  `uploadFile`).
+
+## 9. Security — LLM fields never become markup
+
+Every slide field is **LLM-generated**, i.e. untrusted text flowing into HTML.
+
+- **Handlebars double-stache auto-escapes** (`{{field}}`), so `<script>`/`</section>`
+  in a field renders as inert text, not markup — no injection into the rendered
+  page. Templates **must not** use triple-stache `{{{…}}}` for any field; that is
+  a review checkpoint for every `.hbs` in the launch set.
+- **Rendering is sandboxed anyway** — it runs in Browserless purely to paint a PDF;
+  there are no cookies, no same-origin secrets, no navigation. Even so, escaping is
+  kept as defence in depth so a malformed slide can never break out of its box or
+  corrupt neighbouring slides.
+- **No `data:`/remote URLs from fields.** Fields are plain text (caps in §3);
+  images/fonts come only from the template's own inlined assets, never from AI
+  output. (Revisit when the future `image` slide type lands — user images will
+  need the existing R2 upload + validation path, not raw field URLs.)
+
+## 10. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| *When* `RENDER_PDF` runs; retry/idempotency of the render step | #103 |
+| The agent that fills slide fields / picks theme+types; per-slide prompts | #104 |
+| `DOCUMENT` artifact/version schema, `pdfUrl` READY gate, R2 key convention | #102 |
+| Credit surcharge for a Browserless render | #105 |
+| `step.progress` during render (e.g. per-page) if surfaced | #107 |
+| Uploading the finished PDF as a LinkedIn document on publish | #106 |
+| Future: `image` slide type; per-slide PNG thumbnails; background R2 cleanup | future |
+
+## 11. Migration note
+
+Per the #100 clean write-over (relaunch, no users): **new surface, no migration.**
+This adds `assets/carousel/**`, a `carouselTemplates` registry, and a
+`CarouselRenderer` service, and it reuses the **existing** `htmlToPdf` and
+`uploadFile` utilities unchanged. `src/mark/utils/html_to_pdf.util.ts` currently
+lives under `src/mark`, which #103/§charter-#9 dissolves — on implementation the
+util moves to a neutral home (e.g. `src/render/` or `src/s3` neighbourhood)
+alongside the new renderer; its logic is untouched. No `PostDraft`-era carousel
+code exists to replace.

--- a/docs/credit-usage-system-design.md
+++ b/docs/credit-usage-system-design.md
@@ -1,0 +1,355 @@
+# Credit-Based Usage System — Design
+
+> Status: design spec for wayfinder map #99, ticket #105 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled 2026-07-09.
+> Implements the `CreditMeter` interface #103 defines and consumes the raw usage
+> signals #104 emits. Generalizes the existing `mark_tokens` per-period budget into
+> a cost-backed **credit** meter that gates *all* artifact generation.
+
+Feeds the final spec assembly (#110). This ticket owns **credit denomination, the
+token/cost→credit exchange, surcharge amounts, the `Tier`/`Usage` schema changes, the
+enforcement points, and the Paddle/tier-config implications**. The engine's hook timing
+(#103 §9) and the agent's raw signals (#104 §7) are givens.
+
+## Framing (charter-derived givens)
+
+- **Charter #8:** usage gating moves to token-backed **credits** per tier per period;
+  non-LLM actions (web search, Browserless render) carry **fixed credit surcharges**.
+- **Charter #9 / #104:** `src/mark` is dissolved. The existing `mark_tokens` budget
+  (`FeatureGatingService.assertMarkTokenQuota` / `incrementMarkTokenUsage`, the `MarkRun`
+  doc) is the **prior art and the seed** — credits are its generalization, not a
+  greenfield build.
+- **Clean write-over (#100):** relaunch, no users. No migration/backfill of usage rows,
+  no coexistence window — `mark_tokens` is renamed/reshaped in place and `ai_drafts`
+  retired outright.
+- **#103 §9 owns hook *timing*; #105 owns *conversion + amounts*.** #105 does **not**
+  move where the meter fires; it defines what a recorded signal is worth in credits, the
+  balance guard, and the debit.
+- **#104 §7 emits raw signals, not credits:** each LLM turn → `record({ kind: 'llm',
+  amount: usage.cost, detail: { model, totalTokens } })` where `usage.cost` is the
+  **real per-call USD cost** from OpenRouter's `costDetails`; each web search →
+  `record({ kind: 'web_search', amount: 1 })`. Converting those to credits is this
+  ticket's job.
+
+---
+
+## 1. Credit denomination — a cost-backed unit
+
+**A credit is a fixed slice of underlying model spend.** Define the peg once, in config:
+
+```
+1 credit = $0.001 of raw provider cost      →  CREDITS_PER_USD = 1000
+```
+
+`CREDITS_PER_USD` and a margin multiplier `CREDIT_MARKUP` (default `1.0`) are global env
+(`ConfigService`, code defaults, added to `.env.example`) — never per-tier. Per-tier
+config carries **only the allowance** (§5).
+
+LLM cost → credits (in `record`, kind `'llm'`):
+
+```
+credits = ceil(amount_usd * CREDITS_PER_USD * CREDIT_MARKUP)
+```
+
+Because the amount is OpenRouter's authoritative per-call `usage.cost` — which already
+prices each model's input and output tokens at that model's real rate — the credit price
+of a call is **automatically correct per model and self-updating** when OpenRouter changes
+prices. This directly retires the price-blindness caveat banked from the Mark design (a
+raw token budget "changes operator margin, not the user's allowance" when the model
+swaps); a cost-backed credit does not drift.
+
+**Rejected — raw token count as the unit (the current `mark_tokens` model).** A token is
+price-blind: 1000 tokens of a frontier model and 1000 of a cheap one cost the operator
+wildly different amounts, yet debit the same budget. It also needs a hand-maintained
+per-model token→credit table that drifts every time provider prices move. `usage.cost`
+already encodes all of that.
+
+**Rejected — store raw USD and skip credits entirely.** Fractional dollars ($0.031) are
+an awkward, leaky unit to show users and to sell in Paddle plans; a whole-number credit
+is a clean allowance ("2,000 credits/mo") and hides the operator's true cost/margin.
+
+**Rejected — a fixed markup baked so deep users can't be repriced.** Margin lives in two
+tunable levers — `CREDIT_MARKUP` (pad conversion) and the Paddle **price** of a credit
+allowance — so pricing can move without a code change.
+
+## 2. The token→credit exchange the issue names
+
+The issue asks for "LLM-token→credit exchange rates." In this design the exchange is
+**realized through cost, not a literal token table** — §1's `usage.cost` *is* the
+per-model token exchange, applied continuously. Tokens are still carried on
+`detail.totalTokens` for **display, audit, and the fallback path**, not for pricing.
+
+**Fallback token rate (only when cost is missing).** If a provider/model returns
+`usage.cost` as `0`/`undefined`, fall back to a token estimate so a run is never
+under-charged to zero:
+
+```
+credits = ceil(totalTokens / 1000 * FALLBACK_CREDITS_PER_1K_TOKENS)   // FALLBACK_… is env
+```
+
+This is a coarse safety net (one flat rate, not per-model). For OpenRouter v1 (#104 §9),
+`cost` is always present, so the fallback should effectively never fire; it exists so a
+future provider without cost reporting can't slip through free. Log a warning when it does.
+
+## 3. Fixed surcharges for non-LLM actions
+
+Web search (Tavily) and PDF render (Browserless) cost the operator real money but emit no
+`usage.cost`. Each carries a **flat credit surcharge**, priced in the same credit unit so
+it is commensurable with LLM credits (i.e. set each ≈ the action's real cost × peg × markup):
+
+| Signal `kind`  | Fired by (#104/#103)                    | Env constant                    | Illustrative |
+|----------------|------------------------------------------|----------------------------------|--------------|
+| `web_search`   | research agent, per Tavily call (#104 §7) | `CREDIT_SURCHARGE_WEB_SEARCH`   | `8`          |
+| `pdf_render`   | RENDER_PDF step, per Browserless render (#103 §4) | `CREDIT_SURCHARGE_PDF_RENDER` | `5` |
+
+Surcharge signals carry `amount` as a **count**, not dollars:
+
+```
+credits = amount * CREDIT_SURCHARGE_<KIND>
+```
+
+`UsageKind` is defined here (the enum #103 §9 references):
+
+```ts
+type UsageKind = 'llm' | 'web_search' | 'pdf_render';
+```
+
+So **`record`'s `amount` is polymorphic by `kind`** — USD for `llm`, a unit count for
+surcharges. This asymmetry is inherited from #103/#104's committed `record({ kind, amount })`
+shape; #105 pins the interpretation in one conversion table (§4) rather than reshaping the
+upstream signal.
+
+**Rejected — a separate `record` overload per kind (dollars vs count).** Splits the one
+narrow hook #103 deliberately kept, for no gain; a `switch (kind)` in the converter is
+enough.
+
+**Rejected — surcharge as a % of the run's LLM credits.** A web search's cost is fixed and
+independent of how expensive the generation model is; a flat credit charge models reality.
+
+## 4. `CreditMeterService` — realizing #103's `CreditMeter`
+
+#103 §9/§10 hands each run a `ctx.meter: CreditMeter`:
+
+```ts
+interface CreditMeter {
+  assertBalance(userId: string): Promise<void>;                        // pre-run guard
+  record(usage: { kind: UsageKind; amount: number; detail?: unknown }): void; // during
+  commit(runId: string): Promise<void>;                                // post-run debit
+}
+```
+
+**Split of ownership.** #103 owns the *stateful, per-run* half (the attempt-scoped
+`creditsUsed` accumulator on `WorkflowRun`, per-attempt reset, `usage.tick` emission).
+#105 owns the *stateless* half — a singleton injectable `CreditMeterService` the engine
+composes into `ctx.meter`:
+
+```ts
+@Injectable()
+class CreditMeterService {
+  toCredits(usage: { kind: UsageKind; amount: number }): number; // §1–§3 conversion — pure
+  assertBalance(userId: string): Promise<void>;                  // §6 pre-run guard
+  debit(userId: string, credits: number): Promise<void>;         // §6 period-aggregate write
+}
+```
+
+- `record` (engine-side) calls `toCredits(...)`, adds the result to the attempt-scoped
+  `creditsUsed`, and emits `usage.tick` carrying the credit delta + running total (the
+  detail #107's SSE renders live).
+- `commit(runId)` (engine-side) reads the winning attempt's `creditsUsed` and calls
+  `debit(userId, creditsUsed)` — the **only** real write to the period aggregate.
+- `assertBalance` delegates straight to `CreditMeterService`.
+
+`toCredits` is pure and synchronous (config in, integer out) — trivially unit-testable per
+the repo's manual-construction style, and it keeps `record` non-async (#103 requires
+`record` to return `void`).
+
+**Rejected — put the attempt-scoped accumulator in `CreditMeterService`.** It is per-run
+state that belongs on the `WorkflowRun` the engine already owns and resets per attempt
+(#103 §9); duplicating it here invites double-count and a second source of truth.
+
+**Rejected — fold everything into `FeatureGatingService`.** The meter needs the run
+record and the engine's emit; `FeatureGatingService` owns tier/period/`Usage` primitives
+only. `CreditMeterService` depends **on** `FeatureGatingService` for those (see §5/§6) and
+adds conversion — a clean layering, mirroring how `MarkUsageService` sat above the gating
+service today.
+
+## 5. Schema & config changes
+
+**`FeatureKey` — rename, don't add.** `mark_tokens` → `credits` (it is already a variable
+per-period consumption meter; we are re-denominating and re-scoping it, not inventing a
+sibling). `ai_drafts` is **removed** (§7). Final set:
+
+```ts
+export const FEATURE_KEYS = {
+  CREDITS: 'credits',                    // was mark_tokens — the consumption meter
+  CONNECTED_ACCOUNTS: 'connected_accounts', // capacity counter — unchanged
+  SCHEDULED_POSTS: 'scheduled_posts',       // capacity counter — unchanged
+} as const;
+```
+
+**`Tier.limits`** — the `Feature` union drops `ai_drafts`/`mark_tokens`, gains `credits`:
+
+```ts
+type Feature = 'credits' | 'connected_accounts' | 'scheduled_posts';
+```
+
+`limits.credits` is the per-period allowance: a positive integer, `-1` = unlimited
+(short-circuits the guard, as the current `assertScheduledPostQuota`/`assertMarkTokenQuota`
+already do), `0` = **AI disabled on this plan** (every run blocked — the free/no-AI tier).
+
+**`Usage`** — schema unchanged. Consumption is recorded exactly as today, keyed
+`(user_id, 'credits', periodStart)`, with the same unique index and the same `$inc` upsert
++ E11000-retry write path (`incrementMarkTokenUsage` becomes `incrementCreditUsage`, unit
+now credits). **Period resolution is reused verbatim** — subscription
+`currentPeriodStart` or UTC-month start (`resolveUsagePeriod`). Credits reset each period;
+**no rollover** in v1.
+
+**No new `MarkRun`-style ledger collection.** The per-run credit breakdown already lives on
+the `WorkflowRun` (#103's `creditsUsed` + the recorded ticks); the period total lives on
+`Usage`. That covers dashboard, SSE, and audit without a third store. The `MarkRun`
+collection is deleted with the rest of `src/mark`.
+
+**Config (new global env, `.env.example`):** `CREDITS_PER_USD`, `CREDIT_MARKUP`,
+`FALLBACK_CREDITS_PER_1K_TOKENS`, `CREDIT_SURCHARGE_WEB_SEARCH`,
+`CREDIT_SURCHARGE_PDF_RENDER`. Retire all `MARK_*`.
+
+## 6. Enforcement points
+
+Three touch points, matching #103 §9's commit-on-success timing:
+
+1. **HTTP pre-check (fast 4xx).** `POST /artifacts` calls `assertBalance(userId)` before
+   enqueueing the run, so an out-of-credits user gets an immediate
+   `FeatureGateForbiddenException` (code `FEATURE_LIMIT_EXCEEDED`, feature `credits`,
+   `limit`/`currentUsage`, `upgradeHint`) instead of a queued run that fails. This is the
+   same exception shape the frontend already handles.
+2. **Worker pre-run guard (defensive).** The engine calls `ctx.meter.assertBalance(userId)`
+   before the step loop (#103 §9). Insufficient → **terminal** `WorkflowError` → run/version
+   `FAILED`, reason `"insufficient credits"`. Guards the race where balance drained between
+   enqueue and pickup.
+3. **Post-run debit (commit-on-success).** On `run.completed`, `commit(runId)` debits the
+   winning attempt's `creditsUsed`. Failed/retried attempts debit **nothing** — the operator
+   absorbs transient-failure spend (#103 §8). Settlement is **best-effort** (try/catch + log;
+   never fail a user's *completed* run over an accounting write, carried over from the Mark
+   settlement rule).
+
+**Balance semantics — headroom check, not fit check.** `assertBalance` passes iff
+`used < limit` (or `limit === -1`). It does **not** verify the whole run will fit, because
+commit-on-success has no pre-run estimate to fit against (#103 rejected pre-authorization —
+no estimator, no hold). A user with 5 credits left may start a run that settles at 60 and
+overshoot the period; the **next** run's guard blocks (`used ≥ limit`). Bounded overshoot
+is accepted and intentional — the agent's max-iteration cap (#104 §2) caps a single run's
+worst case, and this mirrors the current Mark gate ("the allowed run may overshoot; next
+run's gate catches it").
+
+**No mid-run cutoff in v1.** #103's hooks accumulate live `creditsUsed`, so a cutoff
+(abort when `used + creditsUsed ≥ limit` mid-loop) is a *later* addition needing no new
+plumbing — explicitly left as room, not built.
+
+**Refine runs.** Refine reuses cached research (#104 §6/#103 §11) → **no `web_search`
+surcharge**, only the generation LLM call (+ a `pdf_render` surcharge for DOCUMENT). Refine
+is metered and gated identically; it is just cheaper.
+
+## 7. Coexistence with the existing counters
+
+The four current features split cleanly into **one consumption meter** and **two capacity
+counters**:
+
+| Current feature       | Fate                          | Why |
+|-----------------------|-------------------------------|-----|
+| `mark_tokens`         | → **`credits`** (renamed, re-denominated) | already the per-period consumption meter |
+| `ai_drafts`           | **retired**                   | "N drafts/month" is replaced by credit consumption — every generation run debits credits, so a separate draft counter is redundant double-gating |
+| `scheduled_posts`     | **unchanged counter**         | scheduling is a plan *capacity* limit, not compute; no LLM/tool cost to meter |
+| `connected_accounts`  | **unchanged counter**         | account capacity, not consumption; still a discrete `countDocuments` gate |
+
+So generation moves entirely onto credits; the two remaining counters stay exactly as they
+are (`assertScheduledPostQuota`, `assertConnectedAccountCapacity`, `assertCompanyPagesAccess`
+untouched). There is **no coexistence window** for `ai_drafts` — the clean write-over (#100)
+deletes the draft path that gated it (#104 §12 removes `createDraft`/`createLinkedInPost`),
+so the counter has no remaining caller.
+
+`getDashboardUsage` returns the new shape: `credits` (used/limit/remaining, `-1` for
+unlimited) alongside `connected_accounts` and `scheduled_posts`; the `ai_drafts` and
+`mark_tokens` keys are dropped.
+
+## 8. Paddle / tier-config implications
+
+- **Each plan's Paddle price maps to a tier, and each tier carries `limits.credits`** —
+  the credit allowance is set in tier config next to the existing limits (operator-tuned,
+  seeded from: target model cost per average run × expected runs/mo × `CREDIT_MARKUP`).
+  Illustrative ladder — free `0` (no AI) or a small trial grant, Starter `2000`, Pro
+  `10000`, top tier `-1` (unlimited).
+- **Sizing anchor (illustrative, at `CREDITS_PER_USD = 1000`, markup `1.0`):** an
+  insight post ≈ research (~$0.02) + generation (~$0.01) + 1 web search (`8`) ≈ **~38
+  credits**; a quick post (no research) ≈ **~12 credits**; a carousel adds a `pdf_render`
+  (`5`). So "2,000 credits" ≈ 50 insight posts or ~160 quick posts — the operator sizes
+  the ladder against these.
+- **Upgrades take effect immediately.** The allowance is read live from the resolved tier
+  at guard time while the `Usage` aggregate persists, so a mid-period upgrade instantly
+  raises headroom without touching usage rows (existing `resolveEntitlementTier` behavior).
+  Downgrade lowers the ceiling the same way; a user already over the new ceiling is simply
+  blocked until the next period — no clawback.
+- **Reset cadence = the existing usage period** (subscription `currentPeriodStart`, or
+  UTC-month for default-tier users). Reused verbatim; no new billing wiring.
+- **Out of scope for v1 (room left, not built):** credit top-ups / one-off purchases,
+  overage billing, and rollover. The whole-number credit unit and the `Usage` aggregate
+  leave room for a future top-up (add to allowance or a separate grant bucket) without a
+  reshape.
+
+**Rejected — model credits as a Paddle metered/usage-billed item.** Overkill for launch:
+prepaid per-tier allowances (what we already have machinery for) cover the plan model; true
+metered billing is a later pricing decision, not a launch blocker.
+
+## 9. Visibility
+
+- **Dashboard** — `getDashboardUsage.usage.credits = { used, limit, remaining }`
+  (`remaining === -1` when unlimited), for the plan/usage screen.
+- **Live (SSE, #107)** — `usage.tick` events carry the per-signal credit delta and running
+  `creditsUsed`, so a long research run shows a climbing credit count; the terminal
+  `run.completed` / dashboard reflects the committed total. `limit === 0` lets the frontend
+  distinguish "AI not on your plan" from "out of credits this period" (carried over from the
+  Mark `mark_tokens: 0` convention).
+
+## 10. Error taxonomy
+
+| Condition | Where | Handling |
+|---|---|---|
+| No balance at request time | HTTP `POST /artifacts` | `FeatureGateForbiddenException` → 403, code `FEATURE_LIMIT_EXCEEDED`, feature `credits` |
+| No balance at run start | engine pre-run guard | terminal `WorkflowError` → run/version `FAILED` `"insufficient credits"` (no retry) |
+| Debit write fails post-run | `commit` | best-effort: caught + logged; the completed run is **not** failed |
+| Missing `usage.cost` | `toCredits` | §2 token fallback + warn log (never charge 0) |
+
+Failed and retried runs debit nothing (#103 §8) — users are charged **once, only for
+successful runs**.
+
+## 11. Migration note (clean write-over, #100)
+
+- **Rename** `FEATURE_KEYS.MARK_TOKENS` → `CREDITS` (`'mark_tokens'` → `'credits'`);
+  drop `AI_DRAFTS` from `FEATURE_KEYS`, the `Feature`/`Tier.limits` union, and
+  `getDashboardUsage`.
+- **`FeatureGatingService`:** `assertMarkTokenQuota` → `assertBalance` (headroom check, §6),
+  `incrementMarkTokenUsage` → `incrementCreditUsage`/`debit`, `getMarkTokenBudget` folded
+  into the `credits` slot of `getDashboardUsage`. Remove `assertAiDraftQuota` /
+  `incrementAiDraftUsage` and their callers (the deleted draft path, #104 §12).
+- **New `CreditMeterService`** (§4) in the feature-gating module (or a thin `src/credits`
+  module importing `FeatureGatingModule`) implementing `toCredits` / `assertBalance` /
+  `debit`; the engine composes it + per-run state into `ctx.meter` (#103 §10).
+- **Delete** `src/mark` entirely, including the `MarkRun` collection and all `MARK_*` config
+  (charter #9); the Tavily helper's surcharge signal is now `web_search` via #104's tool.
+- **Config:** add `CREDITS_PER_USD`, `CREDIT_MARKUP`, `FALLBACK_CREDITS_PER_1K_TOKENS`,
+  `CREDIT_SURCHARGE_WEB_SEARCH`, `CREDIT_SURCHARGE_PDF_RENDER` to `.env.example`; remove all
+  `MARK_*`.
+- **Tests** (CLAUDE.md): `credit-meter.service.spec.ts` (conversion per kind incl. fallback
+  and rounding; surcharge math) and updated `feature-gating.service.spec.ts` (headroom
+  guard, `credits` debit, dashboard shape, `-1`/`0` edge cases), manual construction +
+  `makeService()` + `jest.mock(..., { virtual: true })`, run with `bun jest`.
+
+## 12. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| `CreditMeter` hook *timing*, attempt-scoped `creditsUsed`, per-attempt reset, `commit` call site, `usage.tick` emission | #103 |
+| Raw usage signals (`usage.cost` per turn, tool-fired), agent max-step cap | #104 |
+| `usage.tick` SSE framing / client credit-counter rendering | #107 |
+| `pdf_render` surcharge fire site (RENDER_PDF step) | #103 / #108 |
+| Concrete per-tier credit allowances, Paddle price↔tier mapping (values) | operator / #110 tier seed |
+| Credit top-ups, overage billing, rollover, mid-run cutoff | future |

--- a/docs/linkedin-poll-document-api-research.md
+++ b/docs/linkedin-poll-document-api-research.md
@@ -1,0 +1,317 @@
+# LinkedIn Poll & Document (Carousel) Post API Research
+
+> Status: research report for wayfinder map #99, ticket #101.
+> Author: generated for Christopher Pam.
+> Scope: primary-source API research only. No code changes. Every factual claim
+> cites the first-party LinkedIn doc page (learn.microsoft.com/linkedin) that owns it.
+
+All findings below are drawn from the versioned **REST** API docs (the `/rest/*`
+surface the app already targets in `src/post/linkedin-media.service.ts`), not the
+legacy `/v2/ugcPosts` API. The app currently sends `LinkedIn-Version: 202601`,
+which maps to the doc moniker `li-lms-2026-01`. Every API discussed here lists
+`li-lms-2026-01` in its supported moniker range, so **202601 is a valid version
+for polls, documents, and the Posts API**
+([Posts API moniker range](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04),
+[Poll API moniker range](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05),
+[Documents API moniker range](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+
+---
+
+## 1. Poll posts
+
+**Endpoint & method.** A poll is created through the *same* Posts endpoint the app
+already uses — there is no separate poll endpoint. You `POST https://api.linkedin.com/rest/posts`
+with a `content.poll` object. The dedicated Poll API doc says polls are created and
+managed "using the Posts API" and "Updating poll content is not allowed"
+([Poll API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
+
+**No binary upload.** Polls have no media asset. There is no `initializeUpload`
+step — the whole poll is inline JSON in the post body
+([Poll API create request](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
+
+**Request shape** (verbatim from the doc):
+
+```json
+{
+ "author": "urn:li:organization:2414183",
+ "commentary": "test poll",
+ "visibility": "PUBLIC",
+ "distribution": {
+   "feedDistribution": "MAIN_FEED",
+   "targetEntities": [],
+   "thirdPartyDistributionChannels": []
+ },
+ "lifecycleState": "PUBLISHED",
+ "isReshareDisabledByAuthor": false,
+ "content": {
+     "poll": {
+       "question" :"What is your favorite color?",
+       "options" : [ { "text" : "Red" }, { "text" : "Blue" }, {"text": "Yellow"}, {"text": "green"} ],
+       "settings" : { "duration" : "THREE_DAYS" }
+     }
+ }
+}
+```
+
+Source: [Poll API — Create Poll content](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05).
+A successful create returns `201 Created` with the new post ID in the `x-restli-id`
+response header (same convention as image/video posts).
+
+**Constraints** (all from the Poll / PollSettings / PollOption schema tables,
+[Poll API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)):
+
+| Constraint | Value |
+| --- | --- |
+| Number of options | **min 2, max 4** ("There must be at least two. Maximum 4 options.") |
+| Option `text` length | **max 30 characters** |
+| `question` length | **max 140 characters** (create-only required) |
+| `settings.duration` | one of `ONE_DAY`, `THREE_DAYS`, `SEVEN_DAYS`, `FOURTEEN_DAYS` (**required**) |
+| `settings.voteSelectionType` | `SINGLE_VOTE` (default). `MULTIPLE_VOTE` is documented as "To be supported later in future" — treat as unavailable today |
+| `settings.isVoterVisibleToAuthor` | defaults `true`; **`false` is not supported and returns 400** |
+| Post `visibility` | `PUBLIC` in the sample; the field itself accepts `PUBLIC` / `CONNECTIONS` per the Posts schema |
+
+**Access / restriction.** The doc states plainly: **"API partners can only create
+non-sponsored poll posts."** Polls are also organic-only in the Posts content-type
+matrix — `Poll` is `Organic: Yes / Sponsored: No`
+([Posts API content-type table](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04)).
+Required scopes are `w_member_social` (member author) or `w_organization_social`
+(org author, requires ADMINISTRATOR / DIRECT_SPONSORED_CONTENT_POSTER / CONTENT_ADMIN
+page role) — the same scopes the app already uses for image/video posts
+([Poll API — Permissions](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
+There is also a content-policy caveat: poll authors "may not ask for political
+opinions, health status, or other sensitive data"
+([Poll API note](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
+
+---
+
+## 2. Document posts (PDF / carousel)
+
+**Terminology — important.** On LinkedIn there are two different things both loosely
+called "carousel":
+
+1. **Document post** — a multi-page **PDF/PPT/DOC** rendered as a swipeable,
+   page-by-page card unit in the feed. This is the organic "carousel/PDF" format
+   end users see. It is created as a normal post with a **document URN** in
+   `content.media` ([Documents API — Create Document content](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+2. **`content.carousel`** — a *distinct*, **sponsored-only** ad format made of image
+   `cards` with landing pages. The Posts content-type matrix marks `Carousels` as
+   `Organic: No / Sponsored: Yes`, and the Posts doc says "Only create sponsored
+   carousel post. Organic carousel is currently not supported."
+   ([Posts API — Carousel section](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04)).
+
+**So for our use case (organic "carousel"-style PDF posts), the artifact is a
+document post — a multi-page PDF — not `content.carousel`.** The `content.carousel`
+type is not available to us for organic posting.
+
+**Endpoint & method (asset).** `POST https://api.linkedin.com/rest/documents?action=initializeUpload`
+— directly analogous to `/rest/images?action=initializeUpload` and
+`/rest/videos?action=initializeUpload`
+([Documents API — Initialize Document Upload](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+
+Init request body (verbatim) — identical envelope to the image init the app already sends:
+
+```json
+{
+  "initializeUploadRequest": {
+        "owner": "urn:li:organization:1234567"
+  }
+}
+```
+
+Init response (verbatim):
+
+```json
+{
+   "value": {
+       "uploadUrlExpiresAt": 1650567510704,
+       "uploadUrl": "https://www.linkedin.com/dms-uploads/D5510AQHXjcP8QBYD9A/ads-uploadedDocument/0?ca=vector_ads&cn=uploads&sync=0&v=beta&ut=36ezHi_Pod5aM1",
+       "document": "urn:li:document:C5F10AQGKQg_6y2a4sQ"
+   }
+}
+```
+
+**Constraints** ([Documents API — "Important" note](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)):
+
+| Constraint | Value |
+| --- | --- |
+| Max file size | **100 MB** ("The file size can't exceed 100MB and 300 pages") |
+| Max page count | **300 pages** |
+| Accepted formats | **PPT, PPTX, DOC, DOCX, PDF** |
+
+**Attaching to a post.** The returned `document` URN goes into `content.media.id`
+— the exact same `content.media` shape used for single images and single videos.
+Create request (verbatim):
+
+```json
+{
+    "author": "urn:li:organization:1234567",
+    "commentary": "test strings!",
+    "visibility": "PUBLIC",
+    "distribution": {
+        "feedDistribution": "MAIN_FEED",
+        "targetEntities": [],
+        "thirdPartyDistributionChannels": []
+    },
+    "content": {
+        "media": {
+            "title":"Example.pdf",
+            "id": "urn:li:document:D5510AQFx87994pYx0Q"
+        }
+    },
+    "lifecycleState": "PUBLISHED",
+    "isReshareDisabledByAuthor": false
+}
+```
+
+Source: [Documents API — Create Document content](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11).
+This is the app's existing `IContent.media` shape (`{ id, title, altText? }`) with a
+`urn:li:document:*` id instead of `urn:li:image:*` / `urn:li:video:*`. Documents are
+organic-capable: the content-type matrix lists `Documents` as `Organic: Yes /
+Sponsored: Yes` ([Posts API content-type table](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04)).
+
+---
+
+## 3. Upload flows
+
+**Document upload is single-shot, like images — NOT chunked like videos.** Using the
+`uploadUrl` from init, you do one PUT of the whole file. The doc's sample uses
+`curl --upload-file ~/Desktop/Mydoc.pdf` (a single HTTP PUT) and shows a bare
+`HTTP/2 201` response with no body
+([Documents API — Upload the Document](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+
+Key differences vs the app's video flow (which the app implements in
+`uploadVideo`): documents have **no `uploadInstructions` array, no per-chunk ETags,
+and no `finalizeUpload` step**. There is nothing analogous to `videos?action=finalizeUpload`.
+The doc explicitly notes `SYNCHRONOUS_UPLOAD` is **not** supported for documents
+([Documents API — Initialize note](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+
+**Headers.** The init/GET calls require the standard trio the app already sends:
+`Linkedin-Version: {YYYYMM}`, `X-Restli-Protocol-Version: 2.0.0`, and
+`Authorization: Bearer …` ([Documents API — Schema note](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+The actual binary PUT to `uploadUrl` in the doc's curl example carries only
+`Authorization` (mirrors how the app PUTs image bytes with `Content-Type:
+application/octet-stream`).
+
+**Status polling.** A document asset has a `status` field:
+`WAITING_UPLOAD` → `PROCESSING` → `AVAILABLE`, or `PROCESSING_FAILED` on error
+([Documents API — status schema](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/documents-api?view=li-lms-2025-11)).
+You can `GET https://api.linkedin.com/rest/documents/{documentUrn}` to read it — the
+same AVAILABLE-polling pattern the app uses for video via `waitForVideoAvailable`.
+The doc does not state that polling to `AVAILABLE` is *required* before attaching the
+document to a post (it demonstrates upload → immediately create post), so whether a
+wait is strictly necessary is not confirmed from primary sources — see Open questions.
+
+---
+
+## 4. Combining artifact types
+
+**Content types are mutually exclusive — one content type per post.** `content` is a
+union: every documented example sets exactly one of `content.media` (single
+image / video / **document**), `content.multiImage`, `content.poll`,
+`content.article`, or `content.carousel`. The Posts API presents them as distinct
+"Content Types" rows in its support matrix and never shows two set together
+([Posts API content-type table](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04)).
+
+Consequences for map #99:
+
+- **Poll + image / poll + document: not possible.** A poll post carries only
+  `content.poll`; there is no field to attach media to a poll
+  ([Poll API schema](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
+- **Document + image: not possible.** A document post is `content.media` with a
+  single document URN; you cannot also attach an image in the same post.
+- **Anything + text: yes.** `commentary` is a top-level field independent of
+  `content`, so *every* content type (poll, document, image, video, multiImage)
+  can carry accompanying text ([Posts API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04)).
+- **`multiImage`** (many images) and single `media` are themselves mutually
+  exclusive — exactly as the app already models in `publishOnLinkedIn`
+  (single → `content.media`, many → `content.multiImage`).
+
+Caveat: the docs never print a single explicit sentence "content sub-fields are
+mutually exclusive." This conclusion is inferred from the union-style schema, the
+one-type-per-example convention, and the separate-rows content matrix. It is
+consistent across every LinkedIn example but is an inference, not a verbatim rule —
+flagged in Open questions.
+
+---
+
+## 5. How polls / documents compose with the existing R2 media machinery
+
+Recap of the current pipeline (`src/post/post.service.ts`,
+`src/post/linkedin-media.service.ts`, `src/workflow/media-upload.queue.ts`): media
+bytes are stored in R2 at `media-uploads/${postId}/${mediaId}`, a BullMQ
+`media-upload` job later fetches from R2 and calls `uploadImage`/`uploadVideo`, then
+patches the `PostDraft.media[]` entry's `id` to the returned LinkedIn URN with
+`status: READY`. At publish, `publishOnLinkedIn` folds READY media into `content`.
+
+### Documents — YES, reuse the R2 → worker → initializeUpload pattern almost verbatim
+
+A PDF is binary like an image/video, so it fits the existing machinery with minimal
+change:
+
+- **R2 storage:** unchanged — store the PDF at the same `media-uploads/${postId}/${mediaId}`
+  key.
+- **New upload method** (call it `uploadDocument`): modeled on `uploadImage`, **not**
+  `uploadVideo`. It does init → single PUT → return `value.document`. **No chunking,
+  no ETags, no finalizeUpload** (see §3). This is strictly simpler than the video path.
+- **Media type:** the worker's branch (`item.mediaType === 'VIDEO' ? uploadVideo :
+  uploadImage`) needs a third `'DOCUMENT'` branch. `MediaUploadJobItem.mediaType` and
+  the `PostDraft.media[].type` enum must gain `'DOCUMENT'`.
+- **Content assembly:** in `publishOnLinkedIn`, a single document becomes
+  `content.media = { id: <documentUrn>, title }` — the *same* branch shape as a single
+  image/video, just sourced from a document-typed media entry. `IContent` needs no new
+  field; the document URN rides in the existing `media.id`.
+- **Optional AVAILABLE poll:** if we decide to wait for processing, add a
+  `waitForDocumentAvailable` mirroring `waitForVideoAvailable` but hitting
+  `/rest/documents/{urn}` (see §3 caveat on whether this is required).
+- **Constraints to enforce before upload:** reject > 100 MB / > 300 pages / non
+  PPT-PPTX-DOC-DOCX-PDF (§2).
+
+Net: documents are the *easiest* new artifact — they slot into the image-style
+single-PUT path and the existing `content.media` publish branch.
+
+### Polls — NO upload at all; they bypass the R2/media machinery entirely
+
+Polls have **no binary asset**, so they never touch R2, the `media-upload` queue, or
+`LinkedinMediaService`. A poll is pure inline JSON assembled at publish time. What is
+needed instead:
+
+- Persist poll definition (question, options[], duration, voteSelectionType) on the
+  post document — a new field, *not* a `media[]` entry.
+- Extend `IContent` with a `poll?: { question; options: {text}[]; settings: {duration;
+  voteSelectionType?} }` field and build it in `publishOnLinkedIn`.
+- Enforce poll constraints (2–4 options, ≤30 chars/option, ≤140 char question, valid
+  duration enum, `isVoterVisibleToAuthor` must be true) at DTO-validation time.
+- Because content types are mutually exclusive (§4), a poll post must *not* also have
+  READY media — the publish logic must pick poll XOR media, not merge them.
+
+---
+
+## 6. Open questions / access caveats
+
+- **Community Management API product access.** All three APIs live under LinkedIn's
+  Marketing / Community Management surface and require `w_member_social` /
+  `w_organization_social`. The app **already** posts images and videos through
+  `/rest/posts` with these scopes, so this access appears already granted — but it is
+  worth confirming the connected LinkedIn app's product grant explicitly includes the
+  **Community Management API** (formerly Marketing Developer Platform) for polls and
+  documents, since LinkedIn gates these features at the app-product level, not per
+  endpoint. Not verifiable from the public docs alone.
+- **Polls are organic + non-sponsored only, and API-partner-restricted to
+  non-sponsored.** Confirmed verbatim ("API partners can only create non-sponsored
+  poll posts"). No workaround for sponsored polls.
+- **Organic `content.carousel` is unavailable.** "Organic carousel is currently not
+  supported" — the organic swipeable format must be a **document (PDF) post**, not
+  `content.carousel`. Confirmed.
+- **Is waiting for document `AVAILABLE` required before attaching to a post?** The
+  Documents doc shows upload immediately followed by post creation and does not state a
+  mandatory wait. The video flow *does* require AVAILABLE. This is **not confirmed**
+  for documents from primary sources — recommend defensively polling `/rest/documents/{urn}`
+  to `AVAILABLE` (as we do for video) and verifying behavior in a sandbox.
+- **`multiImage` / `poll` are member-and-org organic only; `MultiImage` is `Sponsored: No`.**
+  Confirmed from the content-type matrix. No caveat for our organic use.
+- **Mutual-exclusivity of `content` sub-fields is inferred, not a verbatim rule.** See
+  §4 — consistent across all examples and the schema, but LinkedIn never prints an
+  explicit "you cannot combine these" sentence. Treat as strongly supported but
+  worth a one-shot sandbox confirmation.
+- **`MULTIPLE_VOTE` polls** are documented as future ("To be supported later in
+  future"). Do not build UI depending on multi-select today.

--- a/docs/post-schema-and-publish-flow-design.md
+++ b/docs/post-schema-and-publish-flow-design.md
@@ -1,0 +1,281 @@
+# Post Schema & Publish Flow — Design
+
+> Status: design spec for wayfinder map #99, ticket #106 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled 2026-07-09.
+> Blocked by #100 (compat audit — resolved as a clean write-over) and #101 (LinkedIn
+> poll/document API research); both docs land in `docs/`.
+> Supersedes `src/database/schemas/post-draft.schema.ts` and the `PostDraft`-coupled
+> half of `src/post/post.service.ts`.
+
+Feeds the final spec assembly (#110). Consumes the `Artifact` library (#102), the
+LinkedIn publish facts (#101), and the credit counters (#105). Interlocking tickets are
+referenced inline.
+
+## Framing (charter-derived givens)
+
+- **Charter #1 / #102:** content lives as an **`Artifact`** (a user-owned library entity,
+  account-agnostic) until the user chooses to post it. A `Post` *references* artifacts; it
+  does not hold content.
+- **Charter #2:** a `Post` references **multiple** artifacts (leaves room for a future
+  image artifact accompanying text). But **#101 §4:** a LinkedIn post carries **commentary
+  + at most one mutually-exclusive content object** (poll *xor* document *xor* image/media).
+  So the multi-ref array is real in the schema but **publish-composition enforces LinkedIn's
+  one-content-object rule** — for v1 (artifact types POST/POLL/DOCUMENT, image is future) a
+  post binds **exactly one** artifact.
+- **Clean write-over (#100 §0):** relaunch, no users. Drop `postdrafts`, build `posts`
+  clean — no backfill, no `_id` preservation, no coexistence window, no versioned
+  endpoints. The compat audit's data-migration hazards (H1/H4/H6/H9/H10) are moot; its
+  *engineering residue* (H2/H3/H7/H8) is addressed in §7.
+
+---
+
+## 1. The core decision: a Post is a **publish record**, not a draft
+
+In the `PostDraft` world the draft *was* the content (embedded `content`/`media`) and moved
+`DRAFT → SCHEDULED → PUBLISHED`. In the artifact world the **artifact is the draft** — it
+lives `READY` in the library (#102). So a `Post` is created **only when the user acts to
+publish or schedule**; there is no `DRAFT` post stage.
+
+This collapses the status enum to three states and removes a whole redundant lifecycle:
+
+```
+SCHEDULED → PUBLISHED
+SCHEDULED → FAILED        (publish attempt errored, or account disconnected — §7)
+(immediate publish) → PUBLISHED | FAILED
+```
+
+**Rejected — keep a `DRAFT` Post that mirrors the artifact's READY state** (Option A,
+`PostDraft`-shaped). It duplicates the artifact library as the drafting surface, reintroduces
+the `content`/`media` embedding #102 deliberately moved out, and adds a status with no user
+meaning ("a draft of a thing that's already a finished library item").
+
+## 2. `Post` schema
+
+```ts
+enum PostStatus { SCHEDULED = 'SCHEDULED', PUBLISHED = 'PUBLISHED', FAILED = 'FAILED' }
+
+@Schema({ timestamps: true })
+class Post {
+  _id
+  user:             ObjectId<User>              // owner, required
+  connectedAccount: ObjectId<ConnectedAccount>  // bound HERE (deferred from artifact create, #102 §6)
+  artifacts: [{                                  // ordered refs — v1: length 1 (§0 framing)
+    artifact: ObjectId<Artifact>,
+    version:  number,                            // PINNED at post creation (§4)
+  }]
+  status:           PostStatus
+  scheduledAt?:     Date                         // set when SCHEDULED
+  publishedAt?:     Date                         // set when PUBLISHED
+  channelPostId?:   string                       // LinkedIn URN from x-restli-id on publish
+  failureReason?:   string                       // set when FAILED
+  createdAt, updatedAt
+}
+```
+
+- **`artifacts` pins `{ artifact, version }`, not a bare id** — see §4 (posting captures the
+  exact version the user approved, immune to a later refine).
+- **`connectedAccount` lives on the Post**, not the artifact — the artifact is
+  account-agnostic (#102 §6); account choice is a publish-time decision. Retains the existing
+  `PERSON`/`ORGANIZATION` account model and `resolveLinkedinAuthorUrn` unchanged.
+- **No embedded `content`/`media`/`type`/`stylePreset`/`youtubeResearch`/`userIntent`/
+  `compressionResult`** — all gone. Content is read live from the pinned artifact version at
+  publish; the legacy `type` field (H3, a workflow-name string) has no successor here (the
+  artifact carries `type`).
+- **`_id` is the BullMQ `jobId` and `data.postId`** for the schedule queue (§5) — unchanged
+  contract, now keyed on `Post._id`. Safe under the clean write-over (no in-flight legacy
+  jobs at cutover; Redis flushed per #100 §0).
+
+## 3. Creating a post from an artifact
+
+One creation endpoint that captures the whole decision (artifact + version + account + when):
+
+```
+POST /posts   { artifactId, version?, connectedAccount, scheduledAt? }
+```
+
+Flow:
+
+1. **Resolve & authorize** — load the artifact owner-scoped (`Forbidden` if not the
+   caller's, same pattern as `PostService`); resolve `version` (defaults to the artifact's
+   `currentVersion`); resolve the connected account via the existing
+   `getOwnedUsableLinkedinConnectedAccount(userId, accountId, action)`.
+2. **Validate publishability**
+   - the pinned artifact **version must be `READY`** (#102 §2) — cannot post a `GENERATING`
+     or `FAILED` version;
+   - the **composition is valid for LinkedIn** — for v1 (single artifact) trivially so; the
+     check is the seam where a future text+image pair is validated against #101 §4's
+     mutual-exclusivity;
+   - company-page authoring keeps the existing `assertCompanyPagesAccess` gate for org
+     accounts.
+3. **Branch on `scheduledAt`**
+   - **absent → publish now:** run the publish routine (§5) inline; persist `Post` as
+     `PUBLISHED` (+ `channelPostId`, `publishedAt`) or `FAILED` (+ `failureReason`).
+   - **present → schedule:** first-time schedule asserts the `scheduled_posts` counter (§7);
+     persist `Post` as `SCHEDULED` (+ `scheduledAt`); enqueue the schedule job (§5);
+     increment the counter.
+4. Return the `Post`.
+
+**Rejected — create a Post at artifact-generation time.** Breaks charter #1 (artifacts are
+account-agnostic library items); most artifacts are refined/discarded and never posted, so a
+Post per artifact is mostly dead records.
+
+## 4. Version pinning — post the version the user approved
+
+An artifact is **mutable**: refine appends a new `currentVersion`, and a manual `PATCH` edits
+the head in place (#102 §5). A Post therefore stores **`{ artifact, version }`**, pinned at
+creation, and publishes **that** version's content — not "whatever is latest at fire time."
+
+- A post **scheduled** for next Tuesday publishes the version approved today, even if the
+  artifact is refined thrice before then.
+- If the pinned version is later **soft-deleted or otherwise unresolvable** at fire time, the
+  worker fails the Post gracefully (`FAILED`, reason `"source artifact unavailable"`) rather
+  than publishing stale or empty content.
+
+**Rejected — always publish the artifact's current head at fire time.** Surprising: a refine
+meant to save as a *new* draft would silently rewrite an already-scheduled post. Pinning makes
+"what will go out" deterministic at schedule time.
+
+## 5. Publish flow — what's reused vs rebuilt
+
+Publish is **one routine** (`publishPost(postId)`), invoked **inline** for immediate publish
+and by the **`post-schedule` worker** at fire time — same code both paths (DRY; the worker
+handler in `workflow.worker.ts` already reads `job.data.postId` and calls a publish method).
+
+**Reused verbatim from today's `publishOnLinkedIn`:**
+
+- The `POST {LINKEDIN_API_BASE}/posts` call with the `LinkedIn-Version: 202601` /
+  `X-Restli-Protocol-Version: 2.0.0` / `Bearer` header trio (#101 confirms 202601 is valid
+  for posts, polls, and documents).
+- `resolveLinkedinAuthorUrn(connectedAccount)`, the `visibility`/`distribution`/
+  `lifecycleState`/`isReshareDisabledByAuthor` envelope, `commentary` via
+  `formatLinkedinContent`, `x-restli-id` capture into `channelPostId`.
+- Connected-account decryption (`encryptionService.decrypt`) and the
+  `"Organization permissions must be used"` → reconnect error mapping.
+- **`ScheduleQueue` / the `post-schedule` queue unchanged** — `addScheduleJob(postId,
+  userId, delay)`, `jobId: postId`, `removeOnFail: false`; worker → `publishPost`.
+
+**Rebuilt — content composition reads the artifact, not `post.content`/`post.media[]`:**
+
+The old code folded `post.content` + READY `post.media[]` into `IContent`. The new code
+resolves each pinned artifact version's **`ArtifactContent`** (#102 §4) and composes per type,
+using the **#101** publish facts:
+
+| Artifact `type` | `commentary` | `content` object | LinkedIn asset upload at publish |
+|---|---|---|---|
+| **POST** | the text | *(none)* | none |
+| **POLL** | optional | `content.poll = { question, options[], settings:{ duration, voteSelectionType:'SINGLE_VOTE', isVoterVisibleToAuthor:true } }` | **none** — poll is inline JSON (#101 §1, §5) |
+| **DOCUMENT** | optional | `content.media = { id: <documentUrn>, title }` | **yes** — upload the version's R2 `pdfUrl` → LinkedIn (#101 §2–3) |
+
+- **`IContent` gains a `poll` arm** (today it has only `media`/`multiImage`); document rides
+  in the existing `media.id` with a `urn:li:document:*` id (no new `IContent` field — #101 §5).
+- **Duration mapping:** #102 stores `durationDays: 1|3|7|14` → LinkedIn `settings.duration`
+  `ONE_DAY|THREE_DAYS|SEVEN_DAYS|FOURTEEN_DAYS`; `voteSelectionType` fixed `SINGLE_VOTE`,
+  `isVoterVisibleToAuthor` fixed `true` (`false` returns 400 — #101 §1).
+- **Document asset upload happens at publish time**, sourcing the already-rendered PDF from
+  the artifact version's R2 `pdfUrl` (rendered during generation, #102 §4 / #108). A new
+  `uploadDocument` on `LinkedinMediaService` — modeled on `uploadImage`, **not** `uploadVideo`:
+  `POST /rest/documents?action=initializeUpload` → single PUT of the PDF bytes → the returned
+  `value.document` URN; **no chunking / ETags / finalize** (#101 §3). Defensively poll
+  `GET /rest/documents/{urn}` to `AVAILABLE` before attaching (mirrors `waitForVideoAvailable`;
+  #101 §3 flags the wait as unconfirmed — poll to be safe). Enforce ≤100 MB / ≤300 pages
+  before upload (#101 §2).
+
+**Retired for v1 (preserved as the future-image seed, not deleted):** the **post-level
+embedded-media user-upload path** — `addLinkedinMedia`, the presigned `initiate/complete`
+direct-to-R2 flow, and the `media-upload` queue that patched `PostDraft.media.$`. Artifact
+content is produced by *generation* (documents pre-rendered to R2), so a post never uploads
+user media in v1. `LinkedinMediaService`'s **LinkedIn-upload half** (`uploadImage`/new
+`uploadDocument`, `waitFor*Available`, R2 `getFile`) is reused by `publishPost`; its
+**user-upload half** stays dormant for the future **image artifact** type (charter: image is
+later work), when a Post would reference a text artifact + an image artifact.
+
+**Immediate-publish latency note:** a DOCUMENT immediate-publish does init→PUT→poll inline, so
+the HTTP call blocks on the LinkedIn upload. Acceptable for a one-shot PUT; if it proves slow,
+route immediate publish through the schedule queue with `delay: 0` (same `publishPost`) — the
+seam is already there.
+
+## 6. Cancel / reschedule / retry
+
+- **`DELETE /posts/:id`** — cancels a `SCHEDULED` post: `scheduleQueue.queue.getJob(postId)`
+  → `remove()`, then delete the record (or mark terminal). Same job-id assumption as today,
+  now on `Post._id`. Does **not** touch the source artifact.
+- **`POST /posts/:id/schedule` `{ scheduledAt }`** — reschedule a `SCHEDULED`/`FAILED` post
+  (remove old job, add new); reuses today's remove-then-re-add logic. First-ever schedule
+  counts against `scheduled_posts`; a reschedule of an already-counted post does **not**
+  re-charge (today's `isFirstTimeSchedule` rule).
+- **`POST /posts/:id/publish`** — publish a `SCHEDULED`/`FAILED` post immediately (removes any
+  pending job, runs `publishPost`). Enables a one-click retry of a `FAILED` post.
+
+## 7. Migration residue from the compat audit (H2/H3/H7/H8)
+
+- **H2 — `@InjectModel('PostDraft')` string token** in `auth.service.ts:76` → `Post`
+  (register `{ name: Post.name, schema: PostSchema }` in `database.module`; update the
+  disconnect logic's model + queue calls). Fails loud at boot if missed.
+- **H3 — legacy `type` field** (workflow-name string): dropped, no successor on `Post` (the
+  artifact owns `type`). `getPosts`/metrics no longer aggregate on it.
+- **H7 — usage triggers:** `scheduled_posts` **stays a capacity counter** (#105 §7) —
+  `schedulePost` keeps `assertScheduledPostQuota` + `incrementScheduledPostUsage` on
+  first-time schedule; **monotonic (no decrement)** preserved (delete/cancel/disconnect do not
+  refund — an explicit carry-over of today's behavior). `ai_drafts` is **retired** (#105 §7):
+  generation is credit-metered on the artifact create/refine path (#102/#105), so post
+  creation carries **no `ai_drafts` gate**. Immediate publish is **not** counted against
+  `scheduled_posts` (matches today — only scheduling counts).
+- **H8 — account-disconnect safety** (`auth.service` disconnect): repoint the query from
+  `postdrafts status:'SCHEDULED'` to `posts status:'SCHEDULED'` for the disconnected
+  `connectedAccount`; for each, `getJob(post._id).remove()` and set the post
+  `FAILED`, reason `"connected account disconnected"` (there is no `DRAFT` to reset to —
+  §1; the **source artifact is untouched** in the library, so the user re-posts it after
+  reconnecting). Add a regression test for disconnect → schedule-job cancel (audit called this
+  out explicitly).
+
+## 8. HTTP surface (`api/v1/posts`, behind the auth guard, owner-scoped)
+
+| Method | Route | Body / Query | Result |
+|---|---|---|---|
+| POST | `/posts` | `{artifactId, version?, connectedAccount, scheduledAt?}` | `201 Post` (PUBLISHED now, or SCHEDULED) |
+| POST | `/posts/:id/publish` | — | publish now / retry a FAILED post |
+| POST | `/posts/:id/schedule` | `{scheduledAt}` | reschedule |
+| DELETE | `/posts/:id` | — | cancel a SCHEDULED post + remove job |
+| GET | `/posts` | `?status&month&connectedAccount&page` | list + `filters {availableMonths, connectedAccountIds}` |
+| GET | `/posts/:id` | — | one post (with resolved artifact refs) |
+| GET | `/posts/metrics/:connectedAccountId` | — | `{ total, monthly[] }` |
+
+- **List/detail** reuse today's `getPosts` shape and the `%Y-%m` `availableMonths`
+  aggregation, re-pointed at `posts`; `filters.connectedAccountIds` stays (posts *are*
+  account-bound, unlike artifacts). Detail resolves the `{artifact, version}` refs so the
+  client can render what was posted; content itself lives on the artifact (#102).
+- **`GET /posts/linkedin/image/:urn`** (LinkedIn image proxy) — reused unchanged.
+- Per #100 §0 there is **no versioned endpoint / read-adapter**; the SPA migrates to this
+  shape (clean write-over).
+
+## 9. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| `Artifact` schema, versions, `ArtifactContent` (poll/document shapes), READY gate, R2 `pdfUrl` | #102 |
+| LinkedIn poll/document API facts (endpoints, constraints, upload flow) | #101 (research) |
+| `Slide` internals / Browserless PDF render that fills `pdfUrl` | #108 |
+| Generation engine + run record that produces READY versions | #103 |
+| Credit gating on generation/refine; `scheduled_posts` staying a counter | #105 |
+| Image artifact type (would make `artifacts[]` length > 1) + reviving the user-upload media path | future |
+
+## 10. Migration note (clean write-over, #100)
+
+- **New `posts` collection** (`Post`/`PostStatus` above); register in `database.module`.
+  **Delete** `post-draft.schema.ts` (+ `PostDraftStatus`), and the `PostDraft`-coupled methods
+  in `post.service.ts` (`createDraft`, `updateContent`, `addLinkedinMedia`,
+  `initiate/completeMediaUpload`, embedded-`media` logic) and their DTOs; keep and re-point
+  `publishOnLinkedIn`→`publishPost`, `schedulePost`, `deletePost`, `getPosts`, `getPost`,
+  `getPostMetrics`.
+- **`agent.service.ts` `updateDraft`** and `createLinkedinDraft.step.ts` are removed with the
+  legacy engine (#104 §12) — generation now writes `Artifact` versions (#102/#103), not
+  `PostDraft`.
+- **`IContent` gains `poll`**; `LinkedinMediaService` gains `uploadDocument` +
+  `waitForDocumentAvailable`; `MediaType`/publish branch gains `DOCUMENT`.
+- **`auth.service`** disconnect logic re-pointed (H2/H8).
+- **No data migration** (drop `postdrafts`, flush Redis + R2 per #100 §0).
+- **Tests** (CLAUDE.md): `post.service.spec.ts` updated for the artifact-ref publish
+  composition (POST/POLL/DOCUMENT → `IContent`), version pinning, immediate-vs-scheduled
+  branch, disconnect→cancel; `linkedin-media.service.spec.ts` for `uploadDocument` (single
+  PUT, no finalize). Manual construction + `makeService()` + `jest.mock(..., { virtual: true })`,
+  run with `bun jest`.

--- a/docs/postdraft-to-post-compat-audit.md
+++ b/docs/postdraft-to-post-compat-audit.md
@@ -1,0 +1,242 @@
+# Compat Audit: What Breaks When `PostDraft` Becomes `Post`
+
+> Status: research report for wayfinder map #99, ticket #100.
+> Author: generated for Christopher Pam.
+> Scope: audit-only. No code changes. Recommends rename-vs-new-collection and
+> enumerates every backward-compatibility hazard for a human to weigh.
+
+Charter givens this audit assumes (from map #99):
+
+- **#2** — a new `Post` schema replaces `PostDraft`; a post references **multiple**
+  artifacts. "Rename/evolve if viable; backward compatibility must be audited."
+- **#3** — the existing workflow engine and `quickPostLinkedin`/`insightPostLinkedin`
+  stay **untouched**.
+- **#8** — usage gating moves from feature counters to token-backed **credits**.
+
+The single most important structural fact this audit surfaces: **a `PostDraft`'s
+Mongo `_id` is used verbatim as the BullMQ `jobId` (or job payload key) across all
+three queues, and is embedded in R2 object keys.** Identity is load-bearing far
+beyond the document itself.
+
+---
+
+## 1. Blast radius — everything that reads or writes `PostDraft`
+
+| Location | Access | What it does |
+|---|---|---|
+| `database/schemas/post-draft.schema.ts` | defines | Schema + `PostDraftStatus` enum. Collection name is **default-pluralized → `postdrafts`** (no explicit `collection:`). |
+| `database/database.module.ts:42` | registers | `{ name: PostDraft.name, schema: PostDraftSchema }` in the shared `MongooseModule` (global). |
+| `post/post.service.ts` | read+write | The bulk: `createDraft`, `getPosts`, `getPost`, `updateContent`, `deletePost`, `publishOnLinkedIn`, `schedulePost`, `addLinkedinMedia`, `initiate/completeMediaUpload`, `getPostMetrics`. |
+| `post/linkedin-media.service.ts` | read+write | Worker-side media processing: looks up post by id, flips `media.$.status`, overwrites `media.$.id` with the LinkedIn URN. |
+| `post/post.controller.ts` | HTTP surface | All `api/v1/posts/**` routes (see §6). |
+| `agent/agent.service.ts:37,239` | write | `updateDraft(draftId, partial)` — called from the workflow step to persist generated `content`. |
+| `workflow/steps/createLinkedinDraft.step.ts:38` | write | Persists `content` via `agentService.updateDraft(_job.id, …)` — **keyed on the BullMQ job id, which _is_ the draft `_id`.** |
+| `auth/auth.service.ts:76,603,621` | read+write | On LinkedIn account **disconnect**: finds `status: 'SCHEDULED'` drafts, removes their schedule jobs, resets them to `DRAFT`. Injects the model by the **string token `'PostDraft'`** (not `PostDraft.name`). |
+| `workflow/workers/workflow.worker.ts:81-88` | indirect | `post-schedule` worker reads `job.data.postId` and calls `postService.publishOnLinkedIn(user, postId)`. |
+
+No migration framework exists in the repo. No code references the literal
+collection name `postdrafts`. There is no explicit index declaration on the schema.
+
+---
+
+## 2. Existing production documents
+
+The live collection is `postdrafts`. Each document carries:
+
+- **Identity** used elsewhere: `_id` (see §3, §4, §6).
+- **Refs**: `user`, `connectedAccount`.
+- **Legacy-engine coupling**: `type` stores a **workflow name string** — one of
+  `quickPostLinkedin` / `insightPostLinkedin` (`ContentType`). Reusing this field
+  for new-engine artifact workflows will collide with these values.
+- **Content**: `content?`, `stylePreset?`.
+- **Embedded media**: `media[]` with a lifecycle `status`
+  (`PENDING|UPLOADING|READY|FAILED`) and an `id` that is **rewritten from a local
+  UUID to the LinkedIn URN** once `READY`.
+- **Workflow scratch**: `youtubeResearch`, `userIntent`, `compressionResult`
+  (the latter two are `select('-…')`-excluded from list responses).
+- **Publish state**: `channelPostId`, `scheduledAt`, `publishedAt`, plus timestamps.
+
+**Hazard:** any reshape that drops/moves `content`, `media`, or `type` orphans data
+in every existing document. A multi-artifact `Post` that pushes `content`/`media`
+down into `Artifact` docs is **not a field-compatible rename** — it is a structural
+migration. Existing drafts have no artifact rows and would read as empty under new
+serialization unless backfilled.
+
+---
+
+## 3. The `post-schedule` queue (in-flight jobs)
+
+Flow: `schedulePost` sets `status=SCHEDULED`, `scheduledAt`, then
+`scheduleQueue.addScheduleJob(post._id, userId, delay)` with **`jobId: postId`**
+(= the draft `_id`) and `removeOnFail: false`. The worker later reads
+`job.data.postId` and calls `publishOnLinkedIn(user, postId)`, which **re-fetches
+the draft by `_id`** and publishes it.
+
+Hazards:
+
+- **H1 (Critical) — id coupling.** A delayed job sitting in Redis at cutover holds
+  the old draft `_id` in both its `jobId` and `data.postId`. If the new `Post`
+  lives in a different collection **with fresh `_id`s**, `publishOnLinkedIn` fails
+  the `findById` → the scheduled post silently never publishes (and, with
+  `removeOnFail: false`, lingers as a failed job). **Any migration MUST preserve
+  `_id`, or the schedule queue must be drained before cutover.**
+- Cancellation logic in `deletePost`, `schedulePost` (reschedule), and
+  `auth.service` disconnect all call `scheduleQueue.queue.getJob(post._id)`. Same
+  id assumption; same breakage if `_id` changes.
+
+---
+
+## 4. The media-upload queue and R2 flow
+
+Two entry paths (`addLinkedinMedia` server-proxied; `initiate`/`completeMediaUpload`
+direct-to-R2 presigned) both:
+
+1. Write R2 objects at key **`media-uploads/${postId}/${mediaId}`** — the draft
+   `_id` is embedded in the object path.
+2. Push a `media-upload` job whose `data.postId` = draft `_id` (jobId is
+   `media-upload-${mediaId}`, `attempts: 3`, `removeOnFail: false`).
+3. `LinkedinMediaService.processMediaUpload` re-fetches the post by `postId`,
+   uploads to LinkedIn, then `updateOne({_id: postId, 'media.id': mediaId}, …)`
+   to set the URN and `status: READY`; on exhaustion, marks `FAILED`.
+
+Hazards:
+
+- **H4 (High) — stranded in-flight media.** Items in `UPLOADING` at cutover are
+  updated by the worker via the `media.$` positional path on the **old** document
+  shape. If `media` moves into `Artifact` docs, the worker's `updateOne` no-ops and
+  media sticks in `UPLOADING` forever (`hasMediaUploadInProgress` then blocks
+  publish). Note the existing operational caveat: *the worker must be running or
+  media never leaves `UPLOADING`.*
+- **H6 (Medium) — orphaned R2 objects.** If `_id` changes, both the presigned-URL
+  slots (`initiateMediaUpload`) already issued to clients and the worker's
+  `getFile`/`deleteFile` calls point at the old `media-uploads/<oldId>/…` prefix.
+  Objects orphan; cleanup (`deleteFile`) misses them. Preserve `_id` or re-key +
+  reissue.
+
+---
+
+## 5. `scheduled_posts` feature-gating counters
+
+Good news first: **usage is decoupled from `PostDraft` identity.** `Usage` is keyed
+on `(user_id, feature, periodStart)` and stores a `count`; it never stores a draft
+`_id`. So a rename/new-collection does **not** corrupt existing counters.
+
+But the **trigger points live in `PostService`**:
+
+- `createDraft` → `assertAiDraftQuota` + `incrementAiDraftUsage` (`ai_drafts`).
+- `schedulePost` (first-time only, `status !== SCHEDULED`) → `assertScheduledPostQuota`
+  + `incrementScheduledPostUsage` (`scheduled_posts`).
+
+Hazards:
+
+- **H7 (Medium).** Counters are **monotonic** — `deletePost` and unscheduling
+  (`auth` disconnect resets `SCHEDULED→DRAFT`) never decrement. Any new flow must
+  consciously preserve or intentionally change this behavior.
+- The new engine + credits system (map #8) must **re-home these trigger points**;
+  if the new `Post` creation path forgets them, gating silently stops enforcing.
+- `getUsageSummary` (feature-gating.service ~L364) hardcodes `ai_drafts` and
+  `scheduled_posts` keys in its response shape — a client contract of its own,
+  separate from `posts`.
+
+---
+
+## 6. Client-facing API contracts (`api/v1`)
+
+The `posts` controller (guarded by `ClerkAuthGuard`) is a wide, `_id`-addressed
+surface the SPA depends on:
+
+| Route | Client dependency |
+|---|---|
+| `POST posts/:id/draft` | `:id` = **connectedAccount** id; returns a `workflowId` (= new draft `_id`) the client polls. |
+| `GET posts/:id/status` | `:id` = draft `_id` used as the **BullMQ job id**. |
+| `GET posts` | returns `data` (lean docs minus `userIntent`/`compressionResult`) + `filters { availableMonths, connectedAccountIds }`. Client reads every field name below. |
+| `GET posts/:id` | full draft doc. |
+| `PATCH posts/:id` | update `content`. |
+| `DELETE posts/:id` | delete. |
+| `PUT posts/:id/media`, `POST posts/:id/media/uploads`, `.../uploads/complete` | media flow; responses expose `media[]` entries with `id/type/status/mimeType/sizeBytes`. |
+| `POST posts/:id/publish`, `POST posts/:id/schedule` | publish/schedule. |
+| `GET posts/metrics/:connectedAccountId` | `{ total, monthly[] }`. |
+| `GET posts/linkedin/image/:urn` | LinkedIn image proxy. |
+
+**Fields the frontend is coupled to:** `_id`, `user`, `connectedAccount`, `type`,
+`status` (enum `DRAFT|SCHEDULED|PUBLISHED`), `content`, `stylePreset`, `media[]`,
+`channelPostId`, `scheduledAt`, `publishedAt`, `createdAt`, `updatedAt`.
+
+**Hazard H5 (High).** A multi-artifact reshape changes both the URL identity
+(post `_id` vs artifact `_id`) and the response body (content/media move into
+artifacts). Any of: field renames, status-enum changes, or moving `content` out of
+the post document breaks the SPA. This needs either a **read-adapter that serves the
+legacy shape** during coexistence, or an explicitly versioned endpoint. The
+client-side SSE/library contract is already flagged "Not yet specified" in the map;
+this audit adds that the **existing** `posts` contract must keep working until the
+frontend migrates.
+
+---
+
+## 7. Recommendation: new collection, not in-place rename
+
+**Recommendation: introduce new `posts` + `artifacts` collections; do NOT rename
+`postdrafts` in place. Backfill with `_id` preserved. Run a coexistence window.**
+
+Rationale:
+
+1. **It isn't a rename — it's a reshape.** Multi-artifact `Post` moves `content`
+   and `media` out of the document. A `@Schema({ collection: 'postdrafts' })` alias
+   on a `Post` class would let new code read old rows, but the shape mismatch
+   (no artifact refs, `media` in the wrong place) makes reads/serialization
+   inconsistent and forces defensive branching everywhere. Clean separation +
+   backfill is less error-prone.
+2. **Two writers during the window.** Charter #3 keeps the legacy engine and its
+   `quickPostLinkedin`/`insightPostLinkedin` workflows untouched — and those write
+   `PostDraft` today. So `postdrafts` **cannot simply vanish** at cutover unless
+   the legacy flow is also migrated (which #3 says it is not). Coexistence with two
+   collections is the honest model. **→ This is the #1 decision for the human: does
+   the legacy generation flow keep producing `PostDraft`s (argues for coexistence),
+   or is it repointed at `Post` (contradicts charter #3)?**
+3. **Identity preservation is mandatory regardless.** Because `_id` is the BullMQ
+   job key (§3, §4) and the R2 key prefix, the backfill **must copy `_id`
+   verbatim** so any in-flight jobs at cutover still resolve. Fresh `_id`s = silent
+   loss of scheduled publishes and stranded media.
+
+Migration/cutover sketch (for the eventual build effort, not this ticket):
+
+- Write a one-time backfill: `postdrafts` → `posts` (+ derived `artifacts`),
+  copying `_id`; map `content`/`media`/`type` into the new shape.
+- **Drain or let settle** the `post-schedule` and `media-upload` queues before
+  flipping the publish/worker path (avoids the H1/H4 id-resolution gap).
+- Serve the legacy `posts` API shape via a read-adapter until the SPA migrates.
+- Keep `postdrafts` read-only post-cutover as a rollback safety net; delete only
+  after the coexistence window closes.
+
+---
+
+## 8. Backward-compatibility hazard register
+
+Ranked most-severe first. "Preserve `_id`" resolves several at once.
+
+| # | Sev | Hazard | Trigger | Mitigation |
+|---|---|---|---|---|
+| H1 | **Critical** | Scheduled-publish jobs key on draft `_id` (`jobId` + `data.postId`). | Any migration that changes `_id`, or a collection swap without draining. | Preserve `_id` in backfill; drain `post-schedule` queue before cutover. |
+| H2 | **Critical** | `auth.service.ts:76` injects the model by the **string token `'PostDraft'`**, not `PostDraft.name`. | Renaming the class + updating `database.module` without updating this string → Nest DI fails at boot (fails loud, but blocks startup). | Grep for the string token; update in lockstep, or register both tokens during coexistence. |
+| H3 | High | `type` field stores a **legacy workflow name** (`quickPostLinkedin`/`insightPostLinkedin`). | New-engine artifact workflows reusing `type` collide with old values; `getPosts`/`getPostMetrics` aggregate across both. | New discriminator field (e.g. `engine`/`artifactType`); leave `type` for legacy rows. |
+| H4 | High | Embedded `media[]` lifecycle; worker mutates via `media.$` positional path; `id` overwritten with URN. | `media` moves into `Artifact`; in-flight `UPLOADING` items stranded → publish permanently blocked. | Drain `media-upload` queue before cutover; migrate media→artifact with status carried over. |
+| H5 | High | `posts` API response shape + `_id`-addressed routes. | Reshape renames fields / moves `content` out / changes `status` enum. | Read-adapter serving legacy shape, or versioned endpoints, until SPA migrates. |
+| H6 | Medium | R2 keys `media-uploads/${draftId}/${mediaId}` + already-issued presigned URLs. | `_id` change orphans objects; worker `getFile`/`deleteFile` miss them. | Preserve `_id`, or re-key + reissue presigned slots. |
+| H7 | Medium | `ai_drafts`/`scheduled_posts` counters incremented only in `PostService`; monotonic (no decrement on delete/unschedule). | New `Post` creation path forgets to re-home triggers → gating silently off. | Re-home triggers (or replace with credits per #8) as an explicit migration task; decide decrement semantics. |
+| H8 | Medium | Account-disconnect safety (`auth.service`) queries `status: 'SCHEDULED'` and cancels jobs. | New status model / field name → query no-ops → posts publish to a **disconnected** account. | Keep a compatible status query; add a regression test for disconnect→cancel. |
+| H9 | Low | Aggregations: `getPosts` `availableMonths`/`distinct(connectedAccount)`, `getPostMetrics`. | Collection split without re-pointing → months/metrics wrong or empty. | Re-point aggregations at `posts`; verify counts across coexistence. |
+| H10 | Low | No migration framework; no explicit collection name; global `MongooseModule` registration. | Backfill is greenfield; two-writer window is operationally fiddly. | Add a scripted, idempotent, `_id`-preserving backfill; document the coexistence runbook. |
+
+---
+
+## 9. Open decisions handed to the human
+
+1. **Legacy flow fate (blocks the migration model).** Does
+   `quickPostLinkedin`/`insightPostLinkedin` keep writing `PostDraft` (→ true
+   coexistence, two collections) or get repointed at `Post` (→ contradicts charter
+   #3)? Everything in §7 hinges on this.
+2. **`_id` preservation** is treated here as mandatory — confirm no requirement
+   forces fresh ids.
+3. **API coexistence strategy**: read-adapter vs versioned endpoints for the SPA.
+4. **Counter → credit cutover** (#8): are historical `ai_drafts`/`scheduled_posts`
+   counts discarded at the credit switch, or mapped forward?

--- a/docs/postdraft-to-post-compat-audit.md
+++ b/docs/postdraft-to-post-compat-audit.md
@@ -20,6 +20,38 @@ beyond the document itself.
 
 ---
 
+## 0. Resolution (2026-07-08, product owner)
+
+These decisions collapse most of this audit: **this is a product relaunch with no
+real existing users yet, so a complete write-over is authorized** — no data
+backfill, no `_id` preservation, no coexistence window, no versioned endpoints.
+
+1. **No data to migrate.** `postdrafts` can be dropped and rewritten outright.
+   Flush Redis (queues) and R2 on cutover. The *data-migration* hazards below —
+   **H1** (in-flight jobs), **H4** (stranded media), **H6** (orphaned R2 objects),
+   **H9** (aggregations), **H10** (backfill) — become **moot**. They survive only
+   as design notes, not backward-compat risks. §7's new-collection-vs-rename
+   question is likewise moot: build the new `posts` + `artifacts` schemas clean.
+2. **Legacy engine is absorbed, not preserved.** `quickPostLinkedin` and
+   `insightPostLinkedin` fold into the single artifact-build flow as a
+   **"research / no research" toggle the user picks before the build starts**
+   (research-on ≈ today's insight post; research-off ≈ today's quick post — the two
+   `ContentType`s already map exactly onto that split). ⚠️ **This reverses charter
+   decision #3** ("the existing engine and `quickPostLinkedin`/`insightPostLinkedin`
+   stay untouched") **and the map's out-of-scope line** ("Migrating
+   `quickPostLinkedin`/`insightPostLinkedin` onto the new engine"). The old engine
+   can now be **deleted**, not just left alone.
+3. **No versioned endpoints.** The `api/v1/posts/**` surface is reshaped in place;
+   **H5** needs no read-adapter.
+
+**Residual work** (engineering, not compat risk): **H2** (rename the `'PostDraft'`
+DI string token in `auth.service`), **H3** (redesign the `type` field), **H7**
+(re-home usage triggers → credits per map #8), **H8** (keep the account-disconnect
+cancel logic working against the new status model). The rest of this document is
+the original audit, retained for the design of the new schema.
+
+---
+
 ## 1. Blast radius — everything that reads or writes `PostDraft`
 
 | Location | Access | What it does |
@@ -230,6 +262,10 @@ Ranked most-severe first. "Preserve `_id`" resolves several at once.
 ---
 
 ## 9. Open decisions handed to the human
+
+> **Resolved 2026-07-08 — see §0 Resolution at the top.** Complete write-over
+> (relaunch, no users); legacy engine absorbed as a research toggle; no versioned
+> endpoints. Retained below for context.
 
 1. **Legacy flow fate (blocks the migration model).** Does
    `quickPostLinkedin`/`insightPostLinkedin` keep writing `PostDraft` (→ true

--- a/docs/sse-progress-contract-design.md
+++ b/docs/sse-progress-contract-design.md
@@ -1,0 +1,400 @@
+# SSE Progress Contract — Design
+
+> Status: design spec for wayfinder map #99, ticket #107 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled in a grilling session
+> on 2026-07-09.
+> Blocked by: #103 (workflow engine), which is closed. This ticket turns the
+> engine's **internal** emission contract (#103 §5–6) into the **client-facing**
+> SSE contract.
+
+Feeds the final spec assembly (#110). Interlocking tickets are referenced inline
+at each boundary.
+
+## Framing (charter-derived givens)
+
+- **The engine is the producer; #107 is the transport.** #103 fixed the internal
+  emission contract: a `RunEvent { runId, seq, type, ts, data }` envelope
+  (#103 §6), a per-run channel/log keyed `workflow:run:{runId}`, an
+  engine-assigned monotonic `seq` starting at 1, and the event vocabulary in
+  #103 §5. **#107 owns everything client-facing:** the SSE endpoint, wire format
+  and event naming, `Last-Event-ID` replay, heartbeats, retention, and the
+  proxy/compression concerns. This doc does **not** redesign the vocabulary — it
+  adopts #103 §5 verbatim as the client schema and specifies how it reaches the
+  browser.
+- **Two processes, one relay hop** (CLAUDE.md architecture). The engine runs in
+  the **BullMQ worker**; the SSE endpoint lives on the **HTTP server**. They
+  share Redis (`ioredis`, `REDIS_URL`, `RedisService`). So the wire is:
+  `worker step → Redis (per-run log) → HTTP-server relay → EventSource`. #103 §6
+  already put the durable per-run event log in Redis precisely so the HTTP server
+  can relay without a direct worker link.
+- **Native `EventSource`, cookie auth.** The client is a browser `EventSource`,
+  which (a) can send **only cookies**, no custom headers, and (b)
+  **auto-reconnects** with a `Last-Event-ID` header. Both facts drive the design.
+  The existing `ClerkAuthGuard` already reads the `__session` **cookie**
+  first (`clerk-auth.guard.ts:62`), so it works with `EventSource` unchanged — no
+  header-token scheme needed. *(The #107 issue says "JWT cookie"; the repo has
+  since moved to the Clerk `__session` cookie with a legacy `access_token`
+  fallback. The guard is cookie-first either way, which is what matters here.)*
+
+The lifecycle a single connection streams:
+
+```
+(connect, replay backlog) → run.started → step.started/…/step.completed × N
+                          → usage.tick × M  → run.completed | run.failed → (close)
+        ↑ heartbeats (: comment) interleaved throughout idle gaps
+```
+
+---
+
+## 1. Endpoint shape & auth
+
+**`GET /runs/:runId/events`** — one SSE stream per generation run.
+
+- **Keyed by `runId`, not artifact.** The kickoff responses already hand the
+  client a `runId` (`202 {artifactId, runId}` on create, `202 {artifactId,
+  version, runId}` on refine — #102 §6/§8, #103 §11). `runId` is the `_id` of the
+  `WorkflowRun` (#103 §4) and the Redis log key, so it is the natural, minimal
+  handle. A run belongs to exactly one artifact/version, so nothing is lost.
+- **Guard:** `@UseGuards(ClerkAuthGuard)` — the `__session` cookie rides along
+  automatically on the `EventSource` request (same-origin, or cross-origin with
+  `withCredentials: true` + CORS `credentials`).
+- **Owner scoping:** load the `WorkflowRun` by `:runId`; **403** if
+  `run.user !== req.user._id` (same owner-check pattern as `PostService` /
+  #102 §8). **404** if no such run. Do this *before* opening the stream so
+  auth/ownership failures are ordinary JSON HTTP errors, not mid-stream events.
+- **Transport handler style — raw `@Res()`, not `@Sse()`.** NestJS's `@Sse()`
+  wraps an `Observable<MessageEvent>` and is lovely for a fixed rxjs source, but
+  this endpoint needs four things that fight that abstraction:
+  1. read the inbound `Last-Event-ID` header to seek the replay cursor,
+  2. short-circuit with **HTTP 204** on reconnect to an already-finished run
+     (§5) — a status decision that must happen *before* any stream body,
+  3. set anti-buffering headers per-response (§7), and
+  4. drive an imperative `XREAD BLOCK` loop (§4) whose cadence also produces
+     heartbeats.
+
+  A raw `@Res({ passthrough: false })` handler maps cleanly onto all four
+  (`res.writeHead(...)`, `res.write(...)`, `req.on('close', …)`), so #107 uses
+  raw `res`. `@Sse()` is the rejected alternative below.
+
+**Rejected — `@Sse()` Observable handler.** Simpler for the happy path, but it
+owns the status line and content-type before we can inspect `Last-Event-ID` or
+return 204, and it hides the `res` we need for the anti-buffer headers. We'd end
+up fighting it on every one of the four points above.
+
+**Rejected — nest the route under `/artifacts/:id/...`.** Redundant: `runId`
+already uniquely identifies the run and its artifact; the extra path segment adds
+a second thing to validate for no gain.
+
+**Rejected — WebSocket (`socket.io` is already a dependency).** Progress is
+**server→client, one-way, per-run, short-lived**. SSE gives us native
+auto-reconnect + `Last-Event-ID` replay for free over plain HTTP/cookies; a
+socket adds a bidirectional channel, its own auth handshake, and room management
+we don't need. (`socket.io` stays for whatever it's currently used for; it is not
+the progress transport.)
+
+## 2. Wire format & the SSE envelope
+
+Each `RunEvent` (#103 §6) is serialized to one SSE message:
+
+```
+id: <redis-stream-entry-id>
+event: <RunEventType>            # e.g. step.completed
+data: <JSON of the event body>   # single line; see §3
+                                 # (blank line terminates the message)
+```
+
+- **`event:`** = the `RunEventType` from #103 §5 verbatim (`run.started`,
+  `step.started`, …). The client attaches typed listeners
+  (`es.addEventListener('step.completed', …)`) instead of switching inside a
+  single `onmessage`.
+- **`data:`** = `JSON.stringify` of `{ seq, ts, ...data }` — the engine's
+  per-event `data` payload (#103 §5) plus `seq` and `ts` lifted in so the client
+  gets ordering/timing without a separate envelope. JSON is emitted on a **single
+  `data:` line** (no embedded newlines) to stay within one SSE record.
+- **`id:` = the Redis Stream entry ID**, not the raw `seq`. This is the one
+  refinement of #103 §6, which flagged `seq` as "the natural basis for
+  `Last-Event-ID`" but explicitly left the `seq ↔ stream-ID` mapping to #107.
+  Using the **stream entry ID as the SSE `id`** makes replay a trivial native
+  `XREAD ... STREAMS <key> <lastEventId>` (§4/§5) with **no seq→offset index** to
+  maintain. `seq` still travels **inside `data`** as the app-level monotonic
+  counter, so the client can detect gaps/dedupe independently of the opaque
+  transport ID.
+- **`retry:`** — on connect, the server first writes a `retry: 3000` directive to
+  set the `EventSource` reconnect backoff to 3 s (browser default is
+  implementation-defined ~3 s; we pin it).
+
+**Rejected — SSE `id` = `seq`.** Would force a `seq → stream-position` lookup on
+every reconnect (an extra index or an `XRANGE` scan to translate). Native stream
+IDs already encode order and are the argument `XREAD` wants.
+
+## 3. Event vocabulary (client-facing schema)
+
+Adopted from #103 §5 **unchanged** — the engine's internal names *are* the
+client's event names (no translation layer to drift). The `data` shapes below are
+the client contract:
+
+| `event:` | Meaning | `data` (plus `seq`, `ts`) |
+|---|---|---|
+| `run.started` | Run accepted; step plan known | `{ kind, type, steps: WorkflowStep[] }` |
+| `step.started` | A step began | `{ step, index, total }` |
+| `step.completed` | A step finished | `{ step, index, total }` |
+| `step.progress` | Fine-grained within a step (optional) | `{ step, ...signal }` e.g. `{ sourcesFound }` (#104 §7) |
+| `usage.tick` | Credits consumed | `{ kind, credits, detail? }` (#105 `UsageKind`) |
+| `step.failed` | Step failed **but will retry** (non-terminal) | `{ step, retryable: true, message }` |
+| `run.completed` | Terminal ✔ — version is now `READY` | `{ artifactId, version }` |
+| `run.failed` | Terminal ✘ | `{ failureReason }` |
+
+- **"Artifact ready" = `run.completed`.** The issue lists "artifact ready" in the
+  vocabulary; there is deliberately **no separate `artifact.ready` event**. A run
+  completing *is* the target version reaching `READY` (#102 §2 — a document only
+  reaches `READY` once its `pdfUrl` is rendered), so `run.completed
+  {artifactId, version}` is the single, non-ambiguous "go look at it now" signal.
+  The client refetches `GET /artifacts/:id?version=<version>` on this event.
+- **`step.progress` is optional and step-defined.** The core never synthesizes it;
+  a step emits it via `ctx.emit` only when it has a meaningful sub-signal
+  (research `sourcesFound`, PDF `pageRendered`). Clients must treat it as
+  best-effort UI polish, never as a required checkpoint.
+- **Progress-bar math** is `index/total` from `step.started/completed`, where
+  `total = steps.length` from `run.started`. Because #103 §2's builder emits an
+  **honest** step list (only steps that actually run), `total` is exact — no
+  skipped-step gaps in the bar.
+- **Two terminal events, `run.completed` | `run.failed`.** Exactly one fires per
+  run; it is always the last data event before the close handshake (§6).
+  `step.failed` (`retryable: true`) is **not** terminal — it announces a
+  transient blip while BullMQ retries the whole job (#103 §7), and the client
+  should show "retrying…", not "failed".
+
+**Client-side discriminated union** (the consumable schema, for a typed frontend):
+
+```ts
+type WorkflowStep =
+  | 'RESOLVE_INPUT' | 'RESEARCH' | 'GENERATE' | 'RENDER_PDF' | 'PERSIST_VERSION';
+
+type ProgressEvent =
+  | { event: 'run.started';   data: { seq: number; ts: number; kind: 'INITIAL' | 'REFINE'; type: 'POST' | 'POLL' | 'DOCUMENT'; steps: WorkflowStep[] } }
+  | { event: 'step.started';  data: { seq: number; ts: number; step: WorkflowStep; index: number; total: number } }
+  | { event: 'step.completed';data: { seq: number; ts: number; step: WorkflowStep; index: number; total: number } }
+  | { event: 'step.progress'; data: { seq: number; ts: number; step: WorkflowStep; [k: string]: unknown } }
+  | { event: 'usage.tick';    data: { seq: number; ts: number; kind: string; credits: number; detail?: unknown } }
+  | { event: 'step.failed';   data: { seq: number; ts: number; step: WorkflowStep; retryable: true; message: string } }
+  | { event: 'run.completed'; data: { seq: number; ts: number; artifactId: string; version: number } }
+  | { event: 'run.failed';    data: { seq: number; ts: number; failureReason: string } };
+```
+
+## 4. Transport — one Redis Stream per run, `XREAD BLOCK` relay
+
+#103 §6 recommended (and deferred the final choice to #107) a **bounded Redis
+Stream per run** as the durable log, with the emitter both publishing to a
+pub/sub channel *and* appending to the stream. **#107 adopts the Stream as the
+single source and drops the separate pub/sub relay:**
+
+- **Key:** `workflow:run:{runId}` — a Redis **Stream** (`XADD`). Each event's
+  auto-generated entry ID becomes the SSE `id` (§2).
+- **The HTTP relay reads with `XREAD BLOCK`, not `SUBSCRIBE`.** For each open
+  connection the relay loops:
+
+  ```
+  XREAD BLOCK <heartbeatMs> COUNT <n> STREAMS workflow:run:{runId} <cursor>
+  ```
+
+  where `cursor` starts at the replay point (§5) and advances to the last entry
+  ID delivered. This **single mechanism** gives replay, live tail, and heartbeat
+  cadence at once: entries returned → write them as SSE events; a block **timeout
+  with no entries** → write a heartbeat comment (§6) and loop.
+- **Why this beats pub/sub for SSE:** `XREAD` from a durable log has **no
+  subscribe-race** (the #103 §6 hazard — events fired before a late subscriber
+  attaches are simply still in the stream) and **unifies replay + live** (pub/sub
+  can't replay, so it would need a *second* `XRANGE` path stitched to a live
+  subscription, with a seam between them). The pub/sub channel #103 §6 mentioned
+  becomes unnecessary; the engine only needs to `XADD`.
+- **Per-connection Redis connection.** A blocking `XREAD` monopolizes its
+  `ioredis` connection, so the relay uses `RedisService.getClient().duplicate()`
+  per SSE connection and **quits it on disconnect** (`req.on('close')`). This is
+  the accepted cost of blocking reads; connection count is bounded by concurrent
+  viewers of in-flight runs (small — a user watches their own generation).
+
+**Engine-side note (informs #103's implementation, not a re-decision):** #103 §6
+said "the emitter both publishes and appends." Under this doc the append (`XADD`
+to `workflow:run:{runId}` with `MAXLEN ~ 1000`) is the *only* required
+side-effect; the pub/sub publish can be dropped.
+
+**Rejected — pub/sub for live + `XRANGE` for replay.** Two code paths and a
+hand-off seam (which events belong to replay vs live?) reintroducing exactly the
+subscribe-race #103 §6 wanted gone. `XREAD BLOCK` collapses both.
+
+**Rejected — poll the `WorkflowRun` Mongo doc.** The run record only holds coarse
+`currentStep` (#103 §4), not the event stream; polling it can't deliver
+`usage.tick`/`step.progress` and adds DB load. It is used **only** as the
+cold-start fallback (§5), not the live path.
+
+## 5. Reconnect semantics (`Last-Event-ID` + replay)
+
+`EventSource` auto-reconnects and resends the last `id` it saw as the
+**`Last-Event-ID`** request header. The handler (`@Headers('last-event-id')`)
+branches:
+
+- **No `Last-Event-ID` (fresh connect):** replay the **whole** stream from the
+  start, then tail. Cursor = `0` (`XREAD ... STREAMS key 0`). This is what lets a
+  client that connects *after* `run.started` already fired still render the full
+  progress history — the backlog is in the stream.
+- **With `Last-Event-ID` (reconnect):** resume **after** that entry. Cursor =
+  the received ID (`XREAD ... STREAMS key <lastEventId>` returns strictly newer
+  entries). No duplicates, no gap — the durable log guarantees every event
+  between disconnect and reconnect is still there (within retention, §8).
+- **Terminal-run short-circuit (the reconnect-loop guard):** if, at connect time,
+  the run is already `COMPLETED`/`FAILED` **and** the client's `Last-Event-ID`
+  already covers the terminal entry (i.e. nothing newer to send), respond
+  **HTTP 204 No Content**. Per the SSE spec a `204` tells `EventSource` to
+  **stop reconnecting** — this is how we prevent a finished run from being polled
+  forever by a stale tab. If the run is terminal but the client is *behind*
+  (missed the terminal event), we still open, replay the remaining tail including
+  the terminal event, run the close handshake (§6), and let the *next* reconnect
+  hit the 204.
+- **Cold-start fallback (stream gone, run still known):** if the stream key has
+  expired (§8) but the `WorkflowRun` doc exists, synthesize a **single snapshot**
+  from the durable record (#103 §4: `status`, `currentStep`) — emit a
+  `run.started` (reconstructed `steps` from `buildWorkflow(input)`) and, if
+  terminal, the matching `run.completed`/`run.failed` — then close. The client
+  reaches a correct final UI state even after the fine-grained log is reclaimed.
+  This is exactly the "reconnect fallback" #103 §4 parked `currentStep` for.
+
+## 6. Heartbeats & the terminal/close handshake
+
+- **Heartbeats** — every `XREAD BLOCK` timeout with no new entries writes an SSE
+  **comment line** `: hb\n\n`. Comments are ignored by `EventSource` (no event
+  fires) but keep the socket and any intermediary from idling out. Cadence:
+  **15 s** (the `heartbeatMs` block timeout), comfortably under the common 30–60 s
+  proxy/idle timeouts. Heartbeats carry no `id`, so they never perturb
+  `Last-Event-ID`.
+- **Initial frame** — immediately on open, before any replay, write
+  `retry: 3000\n\n` (§2) and one heartbeat comment. The early write **forces the
+  response headers to flush** past any buffering proxy (§7) so the client's
+  `onopen` fires promptly.
+- **Close handshake** — after the terminal event (`run.completed` | `run.failed`)
+  is written, the server **ends the response** (`res.end()`). Because
+  `EventSource` would otherwise auto-reconnect, the client is expected to call
+  `es.close()` in its `run.completed`/`run.failed` handler; the server's 204
+  short-circuit (§5) is the backstop if it doesn't. There is **no bespoke `end`
+  event** — the two terminal events already are the end-of-stream signal, and
+  duplicating that as a third event invites clients to key off the wrong one.
+
+## 7. Proxy-buffering & compression (the gotchas)
+
+SSE dies silently behind anything that buffers the response. Concrete mitigations
+for **this** codebase:
+
+- **Response headers** set on the raw `res` before the first write:
+  - `Content-Type: text/event-stream; charset=utf-8`
+  - `Cache-Control: no-cache, no-transform` (`no-transform` also tells proxies
+    not to recompress/mangle)
+  - `Connection: keep-alive`
+  - `X-Accel-Buffering: no` — disables **nginx** response buffering for this
+    response specifically (the single most common "SSE works locally, not in
+    prod" cause).
+- **Disable gzip for this route.** `main.ts:17–24` registers the global
+  `compression` middleware with a custom `filter`, and it **already excludes the
+  streaming `/mark/chat` route** (`main.ts:20`). The SSE route is added to the
+  same exclusion — compression buffers the stream to build its window and would
+  stall progress:
+
+  ```ts
+  filter: (req, res) => {
+    if (req.path.endsWith('/mark/chat')) return false;
+    if (req.path.includes('/runs/') && req.path.endsWith('/events')) return false;
+    return compression.filter(req, res);
+  }
+  ```
+
+  (Equivalently, the handler can send `Content-Encoding: identity`, but reusing
+  the established `filter` exclusion is the repo-idiomatic move.)
+- **Flush early and often.** The initial `retry:` + heartbeat write (§6) plus
+  `res.flushHeaders()` defeats connection-level buffering that waits for a first
+  byte. With `X-Accel-Buffering: no` and compression off, subsequent `res.write`s
+  reach the client unbuffered.
+- **Explicit teardown.** `req.on('close', …)` quits the per-connection `ioredis`
+  client (§4) and clears the heartbeat loop, so a closed tab or dropped proxy
+  connection never leaks a blocking Redis connection.
+
+## 8. Retention / TTL
+
+- **`MAXLEN` on `XADD`** — the stream is capped (`XADD ... MAXLEN ~ 1000`, the
+  approximate trim #103 §6 recommended). A single run emits well under 1000 events
+  (5 steps × a few events + usage ticks), so the cap only bounds pathological
+  runs; it is the safety valve, not the normal retention.
+- **`EXPIRE` on terminal** — when the terminal event is appended, set
+  `EXPIRE workflow:run:{runId} 3600` (1 h). This keeps the log around long enough
+  for a client that reconnects shortly after completion to replay the full run,
+  while guaranteeing reclamation. After expiry, the §5 cold-start fallback (from
+  the durable `WorkflowRun`) still yields a correct final state.
+- **No separate cleanup job** — `MAXLEN` bounds live size and `EXPIRE` reclaims
+  finished runs, so Redis self-manages. (The `WorkflowRun` Mongo doc persists
+  independently per #103 §4; SSE retention does not touch it.)
+
+## 9. Error & edge cases
+
+| Situation | Response |
+|---|---|
+| No such `runId` | `404` JSON (before stream opens) |
+| Run not owned by caller | `403` JSON (before stream opens) |
+| Unauthenticated | `401` via `ClerkAuthGuard` (before stream opens) |
+| Run exists, not yet started (enqueued, worker not picked up) | Open stream, emit heartbeats; first real event arrives when the worker `XADD`s `run.started`. `XREAD` from `0` naturally waits. |
+| Reconnect mid-run | Replay after `Last-Event-ID`, then tail (§5) |
+| Reconnect after terminal, client current | `204` → client stops reconnecting (§5) |
+| Reconnect after terminal, client behind | Replay tail incl. terminal, close; next reconnect → `204` |
+| Stream expired, run doc present | Synthesized snapshot from `WorkflowRun`, then close (§5 fallback) |
+| Stream expired, run doc gone | `404` |
+| `run.failed` (terminal failure) | Delivered as a normal SSE event, **not** an HTTP error — the connection succeeded; the *run* failed. Client renders the failure from `data.failureReason`. |
+
+- **Failures are data, not HTTP status.** Only pre-stream problems (auth,
+  ownership, unknown run) are HTTP errors. Once the stream is open, everything —
+  including `run.failed` — is an SSE event, so a mid-run failure never looks like
+  a transport error to the client.
+
+## 10. Client consumption (reference sketch)
+
+```js
+const es = new EventSource(`/api/v1/runs/${runId}/events`, { withCredentials: true });
+
+es.addEventListener('run.started', (e) => initProgress(JSON.parse(e.data).steps));
+es.addEventListener('step.started',   (e) => markActive(JSON.parse(e.data)));
+es.addEventListener('step.completed', (e) => advance(JSON.parse(e.data)));   // index/total
+es.addEventListener('usage.tick',     (e) => bumpCredits(JSON.parse(e.data)));
+es.addEventListener('step.failed',    (e) => showRetrying(JSON.parse(e.data)));
+
+es.addEventListener('run.completed', (e) => {
+  const { artifactId, version } = JSON.parse(e.data);
+  refetchArtifact(artifactId, version);   // now READY
+  es.close();                             // deliberate close — no reconnect
+});
+es.addEventListener('run.failed', (e) => {
+  showError(JSON.parse(e.data).failureReason);
+  es.close();
+});
+es.onerror = () => {/* transient; EventSource auto-reconnects with Last-Event-ID */};
+```
+
+- The browser supplies `Last-Event-ID` automatically on reconnect; the client
+  writes no reconnect logic. It only decides to **stop** (call `close()` on the
+  terminal events).
+
+## 11. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| Event vocabulary, `RunEvent` envelope, `seq` assignment, `XADD` to the per-run log | #103 |
+| `usage.tick` payload (`UsageKind`, credit amounts) | #105 |
+| `step.progress` signals per step (e.g. `sourcesFound`) | #104 (research) / #108 (render) |
+| Artifact version → `READY` semantics the `run.completed` refetch targets | #102 |
+| Kickoff endpoints returning `runId` | #102 (`POST /artifacts`, `/refine`) |
+| Where credit hooks fire (source of `usage.tick`) | #103 §9 / #105 |
+
+## 12. Migration note
+
+Per the #100 clean write-over (relaunch, no users): this is **new surface**, no
+migration. A new SSE controller (`GET /runs/:runId/events`) is added on the HTTP
+server, backed by the per-run Redis Stream #103's engine already `XADD`s to.
+Nothing legacy is replaced — the `PostDraft`-era flow had no progress stream (the
+open issue #31 "remove draft step and change to stream" is *subsumed* by this
+design). The only cross-cutting edit outside the new controller is the one-line
+`compression` `filter` exclusion in `main.ts` (§7), mirroring the existing
+`/mark/chat` exclusion.

--- a/docs/workflow-engine-design.md
+++ b/docs/workflow-engine-design.md
@@ -1,0 +1,441 @@
+# Workflow Engine — Design
+
+> Status: design spec for wayfinder map #99, ticket #103 (grilling outcome).
+> Author: generated for Christopher Pam. Decisions settled in a grilling session
+> on 2026-07-09.
+> Supersedes the current `src/workflow/engine/*` (the `PostDraft`-era engine).
+> **The old engine is absorbed, not preserved** — per the #100 resolution,
+> `quickPostLinkedin`/`insightPostLinkedin` collapse into one artifact-build flow
+> toggled by `withResearch`; the old engine can be deleted. This reverses the stale
+> "old engine stays untouched" wording in the #103 issue body (see map #99 charter
+> #3, revised 2026-07-08).
+
+Feeds the final spec assembly (#110). Interlocking tickets are referenced inline at
+each boundary.
+
+## Framing (charter-derived givens)
+
+- **One engine, one build flow.** A single artifact-build pipeline serves all
+  generations. Two axes vary it: `withResearch` (on/off — the collapse of
+  quick/insight per #100) and artifact `type` (`POST` | `POLL` | `DOCUMENT` per
+  #102). There is no separate "quick" vs "insight" workflow.
+- **Executes in the BullMQ worker** (charter #4); step events publish to Redis
+  pub/sub keyed by run id; the HTTP server relays them over SSE (#107).
+- **Iteration is refine-after-completion** (charter #5) — no mid-run pause/resume.
+  A refine is a *new run* over an existing artifact that appends a new version
+  (#102 §5).
+- **The engine serves the #102 artifact library.** `POST /artifacts` (and
+  `/refine`) create the artifact + `GENERATING` version *first*, then enqueue a run
+  that fills that fixed version. The engine never creates artifacts; it fills
+  versions.
+- **The engine is a deep, well-sealed module.** It depends on *narrow role
+  interfaces* (agent loop, artifact writer, credit meter), implemented by the
+  modules that own them (#104 / #102 / #105). #103 owns the engine, the step model,
+  the run record, the event-emission contract, error/retry semantics, and refine
+  re-entry — not those modules' internals.
+
+The end-to-end flow the engine runs:
+
+```
+resolveInput → [research] → generate(type) → [renderPdf (DOCUMENT only)] → persistVersion
+```
+
+Bracketed steps are conditional (composed in by the builder — §2).
+
+---
+
+## 1. Step model — linear ordered list, typed state
+
+The engine keeps the old model's **linear ordered step list** (it fits genuinely
+linear pipelines and matches the team's mental model) but **replaces the untyped
+`{ data, initialInput, metadata: Record<string, any> }` bag** with a typed,
+progressively-built run-state.
+
+- A `WorkflowDefinition` is still `{ name, steps: WorkflowStep[] }`.
+- `runWorkflow` still loops the steps in order.
+- What changes: how steps are *composed* (§2), how state is *typed* (§3), and the
+  cross-cutting concerns the engine now owns (events §5–6, retry §7, credits §9).
+
+**Rejected — graph/DAG with conditional edges.** These flows have no real
+branching or fan-out; a DAG would be machinery we never exercise. The two variation
+axes are handled by *composition* (§2), not runtime edges.
+
+## 2. Composition — `buildWorkflow({ type, withResearch })`
+
+The concrete step list for each of the 6 `(type × withResearch)` combinations is
+assembled by a **builder** from a few named fragments, rather than 6 enumerated
+static lists (which drift) or one maximal skip-flag list (which lies about what
+runs and pollutes the event stream):
+
+```ts
+function buildWorkflow({ type, withResearch, kind }: BuildSpec): WorkflowDefinition {
+  return {
+    name: `artifact:${type}`,
+    steps: [
+      WorkflowStep.RESOLVE_INPUT,
+      // refine reuses cached research → research fragment omitted (see §8)
+      ...(withResearch && kind === RunKind.INITIAL ? [WorkflowStep.RESEARCH] : []),
+      WorkflowStep.GENERATE, // dispatches on `type` internally
+      ...(type === ArtifactType.DOCUMENT ? [WorkflowStep.RENDER_PDF] : []),
+      WorkflowStep.PERSIST_VERSION,
+    ],
+  };
+}
+```
+
+- The **emitted step sequence is honest** — only steps that actually run appear.
+  This matters because that sequence feeds the SSE progress stream (#107) and the
+  progress-percentage math.
+- `GENERATE` dispatches on `type` (POST → commentary; POLL → poll object; DOCUMENT
+  → slides). The per-type generation prompts are the agent's concern (#104); the
+  slide/template shape is #108's. The step just calls `ctx.agent` and writes the
+  typed `content` slot.
+- `RENDER_PDF` runs only for documents (gates `READY` per #102 §2); it calls the
+  existing Browserless→PDF path and writes the R2 `pdfUrl` (key convention from
+  #102 §8: `artifacts/${artifactId}/${version}/document.pdf`).
+
+**The registry** maps the single *content-build* concept to this builder, not to a
+static per-type array. There is no longer a `ContentType`-keyed registry of hand-
+written step lists.
+
+## 3. Run-state typing — named slots + typed patch
+
+The step list is assembled *dynamically* by the builder, so TypeScript can't infer a
+fully-chained input→output pipeline (that only works for a fixed tuple of steps).
+The pragmatic model: **one `RunState` interface with typed, named optional slots;
+each step returns a typed partial patch the engine shallow-merges.**
+
+```ts
+interface BuildInput {
+  type: ArtifactType;
+  prompt: string;
+  withResearch: boolean;
+  stylePreset?: StylePreset;
+  userId: string;         // owner (for credit assert/commit)
+  artifactId: string;     // fixed target family
+  version: number;        // fixed target version (already GENERATING)
+  kind: RunKind;          // INITIAL | REFINE
+}
+
+interface RunState {
+  input: BuildInput;                          // set by RESOLVE_INPUT
+  research?: ResearchResult;                  // set by RESEARCH, or seeded on refine (§8)
+  refine?: { priorContent: ArtifactContent;   // set by RESOLVE_INPUT on a refine run
+             feedback: string };
+  content?: ArtifactContent;                  // set by GENERATE (Zod union per #102 §4)
+  render?: { pdfUrl: string; pageCount: number }; // set by RENDER_PDF (documents)
+}
+
+type StepHandler = (state: RunState, ctx: StepContext) => Promise<Partial<RunState>>;
+```
+
+- Each step **reads the slots it needs** (guarding at runtime with a clear
+  `WorkflowError` if a required upstream slot is missing) and **writes only its own
+  slots** via the returned patch. No `any`; slots are strongly typed.
+- The **returned-patch style (not in-place mutation)** gives the event layer a clean
+  "here's what this step produced" hook and keeps each step's read/write surface
+  honest.
+- The builder guarantees ordering, so the runtime precondition guards rarely fire —
+  they're a safety net, not control flow.
+
+**Rejected — fully generic per-step `In`/`Out` compile-time chaining.** Maximal
+safety, but incompatible with a runtime-built dynamic step array; it would force us
+to give up the builder or hand-write a typed chain per combination.
+
+**Rejected — a single mutable object steps mutate in place** (old style, but typed).
+In-place mutation makes "what did this step change" invisible to the event layer.
+
+## 4. Run record — durable `WorkflowRun` collection
+
+`runId` is the `_id` of a dedicated **`WorkflowRun` Mongo collection**, reused as the
+BullMQ `jobId`. This gives one durable record per generation, 1:1 with a job, with a
+clean identity chain **run ↔ job ↔ Redis channel** (`workflow:run:{runId}`), and it
+decouples durable state from BullMQ's eviction policy (jobs are removed on
+completion). It's the home #102 §7 already points at for research context.
+
+```ts
+enum RunKind   { INITIAL = 'INITIAL', REFINE = 'REFINE' }
+enum RunStatus { RUNNING = 'RUNNING', COMPLETED = 'COMPLETED', FAILED = 'FAILED' }
+
+WorkflowRun {
+  _id:            ObjectId          // = runId = BullMQ jobId
+  user:           ObjectId<User>
+  artifact:       ObjectId<Artifact>
+  targetVersion:  number            // the version this run fills
+  kind:           RunKind
+  status:         RunStatus
+  input:          BuildInput        // the request that spawned the run
+  currentStep?:   WorkflowStep      // updated at each step boundary (reconnect fallback)
+  researchContext?: ResearchResult  // persisted when RESEARCH completes (refine reuse + debug)
+  creditsUsed:    number            // attempt-scoped accumulator (reset each attempt — §9)
+  failureReason?: string            // set when FAILED
+  createdAt, updatedAt              // Mongoose timestamps
+}
+```
+
+**What is persisted, and when** (charter #5 fixed no mid-run resume, so there are no
+per-step checkpoints *for resume* — a retry re-runs the whole job):
+
+- **On create** (at enqueue): `{ status: RUNNING, kind, artifact, targetVersion,
+  input, creditsUsed: 0 }`.
+- **On each step boundary:** update `currentStep` (+ `status`). One cheap
+  `updateOne` between steps — enough for the SSE-reconnect status fallback (#107)
+  and post-mortem debugging.
+- **When `RESEARCH` completes:** persist `researchContext` (the one durable thing
+  refine reuse needs).
+- **During run:** accumulate `creditsUsed` via `meter.record` (§9).
+- **On terminal:** set `status: COMPLETED | FAILED` (+ `failureReason`).
+- **Never** copies the generated content — that lives on the artifact version (#102);
+  the run holds only the `(artifact, targetVersion)` reference.
+
+**Rejected — no collection (runId = jobId, state in job data).** Dies on job
+eviction; can't serve refine's cached-research need or reconnect; forces
+`removeOnComplete: false` (unbounded Redis growth).
+
+**Rejected — snapshot the whole `RunState` after every step.** Enables a resume we
+explicitly don't do (charter #5), duplicates content already on the artifact, and
+means heavier writes.
+
+**Rejected — fold the run record into the artifact version.** Already rejected by
+#102 §7 (keeps research off the artifact to avoid the `PostDraft` bloat).
+
+## 5. Event emission — who emits what
+
+The engine is the **producer**; #107 owns the SSE endpoint, the client-facing event
+schema/naming, `Last-Event-ID` cursoring, heartbeats, and log retention. #103 fixes
+the *internal* emission contract.
+
+**The engine core wraps each step** (it owns the loop), so lifecycle events are
+guaranteed complete and match the honest builder sequence (§2). **Steps emit only
+what the core can't observe.**
+
+| Event | Emitted by | `data` |
+|---|---|---|
+| `run.started` | core | `{ kind, type, steps: WorkflowStep[] }` |
+| `step.started` | core (wrap) | `{ step, index, total }` |
+| `step.completed` | core (wrap) | `{ step, index, total }` |
+| `step.failed` | core (wrap) | `{ step, retryable, message }` |
+| `step.progress` | step (`ctx.emit`) | `{ step, ...fine-grained }` (e.g. `sourcesFound`) — optional |
+| `usage.tick` | `ctx.meter.record` | `{ kind, credits, detail? }` |
+| `run.completed` | core | `{ artifactId, version }` |
+| `run.failed` | core | `{ failureReason }` |
+
+- `usage.tick` is emitted **by `meter.record`** (§9), *not* raw `ctx.emit` — the one
+  call both accounts and announces. `ctx.emit` is reserved for `step.progress`.
+- `step.failed` on a **non-terminal** (will-retry) failure leaves the version
+  `GENERATING`; only the terminal handler flips it (§8).
+
+**Rejected — engine emits only run start/end; steps emit their own lifecycle.**
+Every step would have to remember to emit start/complete → drift and gaps in the
+progress stream.
+
+**Rejected — a rich, highly-granular vocabulary defined here.** Over-specifies what
+is really #107's client-facing schema and couples the engine to presentation.
+
+## 6. Emission envelope, channel, and ordering
+
+```ts
+interface RunEvent {
+  runId: string;
+  seq:   number;   // monotonic per run, engine-assigned, starts at 1
+  type:  RunEventType;
+  ts:    number;   // epoch ms
+  data:  unknown;  // type-specific (§5 table)
+}
+```
+
+- **Channel:** `workflow:run:{runId}` (per-run Redis pub/sub channel). The client
+  gets `runId` from the `202` kickoff response (#102) and #107 subscribes on its
+  behalf.
+- **`seq`:** the **engine emitter assigns** a monotonic per-run integer. It's the
+  ordering key and the natural basis for #107's `Last-Event-ID`. Steps supply only
+  `{ type, data }`; the core stamps `runId` / `seq` / `ts`.
+- **The emitter both publishes and appends.** A single production point (a) publishes
+  the envelope to the per-run channel for live relay and (b) appends it to a durable
+  per-run event log. This removes the subscribe-race (events fired before a separate
+  persister subscribes are lost) and gives #107 an ordered, replayable log to build
+  on.
+  - **Recommended log mechanism:** a bounded **Redis Stream** per run (natural
+    stream IDs, `XADD` + `MAXLEN` trimming, `XRANGE` replay-after-`seq`). This is a
+    recommendation — #107 owns the final transport/retention choice and may map
+    `seq` ↔ stream ID as it sees fit.
+
+**Rejected — fire-and-forget pub/sub only, #107 persists by subscribing.** Cleaner
+ownership line, but reintroduces the subscribe-race and adds a second consumer.
+
+## 7. Error / retry semantics
+
+A retry re-runs the **whole** job from step 1 (no per-step checkpoints, §4). Some
+failures are transient (LLM 429/5xx, network, Browserless timeout) and worth
+retrying; others are terminal (invalid input, insufficient credits, Zod-invalid LLM
+output after a step's own internal retries) and retrying just burns time and credits.
+
+- **BullMQ config:** `attempts: 3`, `backoff: { type: 'exponential' }`.
+- **Error taxonomy:** a `WorkflowError { retryable: boolean; reason: string }`.
+  - **Transient** (`retryable: true`) — thrown normally, rides the attempt budget.
+  - **Terminal** (`retryable: false`) — the engine rethrows as BullMQ's
+    `UnrecoverableError`, which stops retries immediately regardless of attempts
+    left.
+- This mirrors how the existing `media-upload` worker already reasons about
+  `attemptsMade` vs `opts.attempts` (`workflow.worker.ts`), so it's idiomatic here.
+
+**Rejected — no retries (every failure terminal).** Throws away the easy win on the
+transient LLM/network blips that dominate real failures.
+
+**Rejected — unbounded/high retries.** Risks credit burn and long-stuck runs on
+genuinely-terminal errors.
+
+## 8. Failure side-effects and re-run idempotency
+
+**Re-run idempotency (why whole-job retry is safe):** a run targets a *fixed*
+`(artifactId, version)` that #102 created as `GENERATING` at kickoff. Every step —
+including `PERSIST_VERSION` — writes to that same fixed version, so a retry
+*overwrites* content rather than appending a new version. No duplicate versions. The
+only non-idempotent side-effect is usage accounting, handled by the attempt-scoped
+reset in §9.
+
+**Terminal-failure handler** (a job-level `failed` handler mirroring the
+`media-upload` `exhausted` pattern in `workflow.worker.ts`), fired **only** on
+attempts-exhausted or `UnrecoverableError`:
+
+1. Set the artifact's **target version → `FAILED`** with `failureReason` (#102 §2).
+2. Set **`WorkflowRun` → `FAILED`** with `failureReason`.
+3. Emit **`run.failed`** `{ failureReason }` (terminal SSE event for #107).
+4. **No credit commit** (§9) — the user is not charged for a failed run.
+
+Intermediate (will-retry) failures emit `step.failed` and leave the version
+`GENERATING`.
+
+**Rejected — delete the artifact/version on failure.** Loses #102's deliberate
+`FAILED` version status; the user can't see the failed generation in the library to
+refine or retry it.
+
+## 9. Credit-metering hooks (interface + timing)
+
+`CreditMeter` is a #103-defined narrow interface, *implemented* by #105 (which owns
+denomination, token→credit exchange rates, and surcharge amounts). #103 owns only
+*where the hooks fire*.
+
+```ts
+interface CreditMeter {
+  assertBalance(userId: string): Promise<void>;             // pre-run guard
+  record(usage: { kind: UsageKind; amount: number; detail?: unknown }): void; // during
+  commit(runId: string): Promise<void>;                     // post-run debit
+}
+```
+
+- **Pre-run** — the engine calls `assertBalance(userId)` before the step loop.
+  Insufficient balance → **terminal** `WorkflowError` (no retry); the failure
+  handler (§8) sets version + run → `FAILED` reason `"insufficient credits"`.
+  *(The HTTP endpoint should also pre-check for a fast 4xx — that's #105/#102; this
+  is the defensive run-start guard.)*
+- **During run** — steps call `ctx.meter.record(...)` for each LLM call and each
+  fixed surcharge (web search, Browserless render). `record`:
+  1. accumulates into an **attempt-scoped** `creditsUsed` on the `WorkflowRun`, and
+  2. emits the `usage.tick` event (§5).
+- **Per attempt** — the engine **resets** the attempt-scoped `creditsUsed` at the
+  start of each attempt, so a whole-job retry can't double-count.
+- **Post-run** — on `run.completed` the engine calls `meter.commit(runId)`: the
+  **only** real debit, for the winning attempt's usage. On failure → **no commit**.
+
+**Net effect:** users are charged **once, only for successful runs**. Failed runs and
+burned retries cost the user nothing (we absorb the transient-failure cost). There is
+**no mid-run cutoff** — the agent loop's max-iteration cap (#104) bounds worst-case
+spend; #105 may add a cutoff later, and these hooks leave room.
+
+**Rejected — debit incrementally as usage happens.** Accurate live balance, but
+charges for failed/retried runs and needs refund logic.
+
+**Rejected — pre-authorize an estimate and settle at end.** Cleanest accounting, but
+needs an estimator and a hold mechanism we don't have.
+
+## 10. Step context (`ctx`)
+
+Steps receive a `StepContext` of **narrow role interfaces** — defined by the engine
+(its needs), implemented by the owning modules — so the engine depends on interfaces,
+not concrete services, and steps mock trivially under the repo's
+manual-construction test style.
+
+```ts
+interface StepContext {
+  logger:    Logger;
+  agent:     AgentRunner;    // #104 — research + generation via the tool-calling agent loop
+  artifacts: ArtifactWriter; // #102 — set version content, flip status, read prior version
+  meter:     CreditMeter;    // #105 — §9
+  emit:      (e: { type: RunEventType; data: unknown }) => void; // step.progress only (§5)
+  run:       RunRecordHandle; // read/patch this WorkflowRun (researchContext, currentStep)
+}
+```
+
+- `AgentRunner`, `ArtifactWriter`, `CreditMeter`, `RunRecordHandle` are **thin
+  interfaces scoped to what steps actually call** — not the full surfaces of
+  `AgentService` / the artifact service / the credit service.
+- The **concrete instances are resolved once in the worker bootstrap** (the existing
+  `app.get(...)` pattern in `workflow.worker.ts`) and passed into `runWorkflow` as
+  `ctx`.
+- `emit` is scoped so the engine core stamps `runId` / `seq` / `ts`; steps supply
+  only `{ type, data }`.
+
+**Rejected — pass concrete NestJS services.** Couples the engine to those modules'
+full surfaces and drags heavy mocks into step tests.
+
+**Rejected — pass the Nest `ApplicationContext`/injector.** Maximum flexibility,
+worst testability, hidden dependencies.
+
+## 11. Refine re-entry
+
+A refine is a **new run** (`kind: REFINE`) over an existing artifact. #102's
+`POST /artifacts/:id/refine {feedback}` appends a new `GENERATING` version and
+returns `202 {artifactId, version, runId}`, then kicks off the run that fills it.
+
+- **Seeding.** `RESOLVE_INPUT` builds `RunState` with:
+  - `input` = the family-level `source {prompt, withResearch, stylePreset}` (#102 §7),
+  - `refine = { priorContent, feedback }` — prior version content + the new feedback,
+  - `research` = **copied from the artifact's latest `COMPLETED` `WorkflowRun`'s
+    `researchContext`** (if any).
+- **Research is skipped.** The builder omits the `RESEARCH` fragment for
+  `kind: REFINE` (§2) — the `research` slot is pre-filled from cache. This is exactly
+  what #102 §7 parked research context on the run record to enable: refine stays
+  cheap and fast, and **re-charges no web-search surcharge**. If the original was
+  research-off, there's simply no cached research and `GENERATE` runs on
+  prompt + feedback.
+- **`GENERATE` consumes the `refine` slot** — prior content + feedback inform the
+  revision. The *revision prompt* shape is #104's concern; #103 only defines the
+  slot and the research-skip.
+
+**Rejected — always re-run research on refine.** Freshest sources, but re-charges the
+web-search surcharge and adds latency on every tweak.
+
+**Rejected — a per-refine "re-research" toggle now.** More surface than launch needs;
+noted as future work.
+
+## 12. Boundaries (owned by other tickets)
+
+| Concern | Owner |
+|---|---|
+| Agent loop internals, tool registry, per-type/revision prompts | #104 |
+| `AgentRunner` *implementation* (research + generation) | #104 |
+| Credit denomination, token→credit rates, surcharge amounts, `Tier`/`Usage` schema; optional mid-run cutoff | #105 |
+| `ArtifactWriter` *implementation*; artifact/version schema | #102 |
+| Post binding, connected-account, publish, scheduling | #106 |
+| SSE endpoint, client-facing event schema, `Last-Event-ID` replay, heartbeats, log retention | #107 |
+| `Slide` internal shape / carousel templates / Browserless render details | #108 |
+
+## 13. Migration note
+
+Per the #100 resolution this is a clean write-over (relaunch, no users):
+
+- `src/workflow/engine/*` and the `ContentType`-keyed `WorkflowRegistry` are rebuilt
+  to this design; the `quickPostLinkedin` / `insightPostLinkedin` workflow
+  definitions and their `ContentType` split are **deleted** (folded into the
+  `withResearch` toggle).
+- The `WorkflowStep` enum is redefined to the fragments in §2
+  (`RESOLVE_INPUT`, `RESEARCH`, `GENERATE`, `RENDER_PDF`, `PERSIST_VERSION`);
+  the `PostDraft`-era steps (`EXTRACT_INTENT`, `GET_QUERIES`, `CREATE_LINKEDIN_DRAFT`,
+  …) are removed.
+- A new `WorkflowRun` schema (§4) is added under `src/database/schemas`.
+- The worker's `workflow` queue consumer (`workflow.worker.ts`) is rewired to build
+  `StepContext` from the narrow role interfaces (§10) and to attach the
+  terminal-failure handler (§8), reusing the `media-upload` `exhausted`-handler
+  idiom already present.
+- No data migration; there are no existing runs to preserve.


### PR DESCRIPTION
Lands the spec of record for the LinkedIn artifact workflow, plus the ten design documents it was assembled from.

`docs/artifact-workflow-prd.md` is the spec of record. Where a sibling design doc disagrees with it, the PRD wins — it closes the seven seams (R1–R7) the parallel design tickets left open or contradictory, and corrects a set of stale claims that no longer hold against `HEAD`.

## Why this lands on `main` rather than the epic branch

Issue #111 links the PRD as `blob/main/docs/artifact-workflow-prd.md`. Landing it here makes that link resolve, and puts the spec on the base branch of every implementation PR that will be reviewed against it.

## Contents

| Document | Ticket |
|---|---|
| `postdraft-to-post-compat-audit.md` | #100 |
| `linkedin-poll-document-api-research.md` | #101 |
| `artifact-schema-and-library-api-design.md` | #102 |
| `workflow-engine-design.md` | #103 |
| `agent-loop-and-research-agent-design.md` | #104 |
| `credit-usage-system-design.md` | #105 |
| `post-schema-and-publish-flow-design.md` | #106 |
| `sse-progress-contract-design.md` | #107 |
| `carousel-template-system-design.md` | #108 |
| `artifact-workflow-step-pipelines-design.md` | #109 |
| `artifact-workflow-prd.md` | #110 |

Documentation only — no `src/` changes, no runtime surface. The 14 commits are preserved rather than squashed so the per-ticket design trail stays legible (the carousel design in particular was revised twice and then had review findings applied).

## Follow-on

Implementation lands on a long-lived `epic/artifact-workflow` branch cut from this merge, with tickets #112–#129 merging into it as squashed slices. This PR does not close #111, which tracks the PRD through slice 7.

Closes #110
Part of #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
