### PR TITLE
feat: add single-turn LLM primitives and typed errors (#112)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@nestjs/mongoose": "^11.0.4",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
-        "@openrouter/sdk": "^0.5.1",
+        "@openrouter/sdk": "^0.13.39",
         "@paddle/paddle-node-sdk": "^3.7.0",
         "@supadata/js": "^1.3.2",
         "@tavily/core": "^0.7.3",
@@ -376,7 +376,7 @@
 
     "@nuxt/opencollective": ["@nuxt/opencollective@0.4.1", "", { "dependencies": { "consola": "^3.2.3" }, "bin": { "opencollective": "bin/opencollective.js" } }, "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ=="],
 
-    "@openrouter/sdk": ["@openrouter/sdk@0.5.1", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Kl0N1jIj7A3lnkM5dO3SGP8JP3jAozzs6JWcHVuZUBt5DsGKxFGNH1Y15bCfsJiLNA2ylAQpCN3aNcgEYkkL5Q=="],
+    "@openrouter/sdk": ["@openrouter/sdk@0.13.39", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oNPm4qlr0Q512FWIkbj+8wkA0tvEJ/XglAJ6jrxrbjNI+e7UGyYVMnJnmiUR74Hwfg5lNuVe+LwYIaL9QIUd/g=="],
 
     "@paddle/paddle-node-sdk": ["@paddle/paddle-node-sdk@3.7.0", "", {}, "sha512-VUlmBCGmCJU7mv1H/t7PDVg2GvnPy9tt3rnqbkf4BqpxL6zxKtgFxxXT/B7k6QX//L5lW6fC58ax/a86DJ/zcw=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nestjs/mongoose": "^11.0.4",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
-    "@openrouter/sdk": "^0.5.1",
+    "@openrouter/sdk": "^0.13.39",
     "@paddle/paddle-node-sdk": "^3.7.0",
     "@supadata/js": "^1.3.2",
     "@tavily/core": "^0.7.3",

--- a/src/llm/errors/index.ts
+++ b/src/llm/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './llm.error';

--- a/src/llm/errors/llm.error.spec.ts
+++ b/src/llm/errors/llm.error.spec.ts
@@ -1,0 +1,112 @@
+import { LLMError, toLLMError } from './llm.error';
+
+/** Stand-in for the SDK's `OpenRouterError`, which carries `statusCode`. */
+const makeHttpError = (statusCode: number, message = 'boom') =>
+  Object.assign(new Error(message), { statusCode });
+
+/** Stand-in for the SDK's `HTTPClientError` subclasses, identified by `name`. */
+const makeTransportError = (name: string) =>
+  Object.assign(new Error(name), { name });
+
+describe('LLMError', () => {
+  describe('constructor', () => {
+    it('should retain the retryable flag, status code and cause', () => {
+      const cause = new Error('underlying');
+      const error = new LLMError('failed', {
+        retryable: true,
+        statusCode: 429,
+        cause,
+      });
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('LLMError');
+      expect(error.message).toBe('failed');
+      expect(error.retryable).toBe(true);
+      expect(error.statusCode).toBe(429);
+      expect(error.cause).toBe(cause);
+    });
+  });
+});
+
+describe('toLLMError', () => {
+  it('should return the same instance when given an LLMError', () => {
+    const original = new LLMError('already typed', { retryable: false });
+
+    expect(toLLMError(original)).toBe(original);
+  });
+
+  describe('retryable classification', () => {
+    it('should mark a 429 rate limit as retryable', () => {
+      const error = toLLMError(makeHttpError(429, 'Rate limit exceeded'));
+
+      expect(error.retryable).toBe(true);
+      expect(error.statusCode).toBe(429);
+      expect(error.message).toBe('Rate limit exceeded');
+    });
+
+    it('should mark a 401 auth failure as terminal', () => {
+      const error = toLLMError(makeHttpError(401, 'Unauthorized'));
+
+      expect(error.retryable).toBe(false);
+      expect(error.statusCode).toBe(401);
+    });
+
+    it.each([500, 502, 503, 504])(
+      'should mark a %i server error as retryable',
+      (statusCode) => {
+        expect(toLLMError(makeHttpError(statusCode)).retryable).toBe(true);
+      },
+    );
+
+    it('should mark a 408 request timeout as retryable', () => {
+      expect(toLLMError(makeHttpError(408)).retryable).toBe(true);
+    });
+
+    it.each([400, 402, 403, 404, 422])(
+      'should mark a %i client error as terminal',
+      (statusCode) => {
+        expect(toLLMError(makeHttpError(statusCode)).retryable).toBe(false);
+      },
+    );
+
+    it.each(['ConnectionError', 'RequestTimeoutError'])(
+      'should mark transport failure %s as retryable',
+      (name) => {
+        const error = toLLMError(makeTransportError(name));
+
+        expect(error.retryable).toBe(true);
+        expect(error.statusCode).toBeUndefined();
+      },
+    );
+
+    it('should mark an aborted request as terminal, since the caller cancelled it', () => {
+      expect(
+        toLLMError(makeTransportError('RequestAbortedError')).retryable,
+      ).toBe(false);
+    });
+
+    it('should mark an unrecognised error as terminal', () => {
+      const error = toLLMError(new Error('who knows'));
+
+      expect(error.retryable).toBe(false);
+      expect(error.message).toBe('who knows');
+    });
+  });
+
+  describe('degenerate inputs', () => {
+    it('should fall back to a default message when the status error has none', () => {
+      const error = toLLMError({ statusCode: 503 });
+
+      expect(error.message).toBe('Provider request failed with status 503');
+      expect(error.retryable).toBe(true);
+    });
+
+    it('should not throw when given a non-error value', () => {
+      const error = toLLMError('a bare string');
+
+      expect(error).toBeInstanceOf(LLMError);
+      expect(error.retryable).toBe(false);
+      expect(error.cause).toBe('a bare string');
+    });
+  });
+});

--- a/src/llm/errors/llm.error.ts
+++ b/src/llm/errors/llm.error.ts
@@ -1,0 +1,72 @@
+/**
+ * A provider-agnostic LLM failure.
+ *
+ * `retryable` is decided here, in the LLM layer, because only this layer knows
+ * provider error semantics. Callers above it (the agent loop, the workflow
+ * engine) branch on the flag without knowing what a 429 is.
+ */
+export class LLMError extends Error {
+  readonly retryable: boolean;
+  readonly statusCode?: number;
+
+  constructor(
+    message: string,
+    options: { retryable: boolean; statusCode?: number; cause?: unknown },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = 'LLMError';
+    this.retryable = options.retryable;
+    this.statusCode = options.statusCode;
+  }
+}
+
+/**
+ * Transport-level failures where the request never got a verdict from the
+ * provider, so replaying it is safe. `RequestAbortedError` is excluded: an
+ * abort is the caller's own decision, not a fault to retry through.
+ */
+const RETRYABLE_TRANSPORT_ERRORS = new Set([
+  'ConnectionError',
+  'RequestTimeoutError',
+]);
+
+const isRetryableStatus = (statusCode: number): boolean =>
+  statusCode === 408 || statusCode === 429 || statusCode >= 500;
+
+const readStatusCode = (error: unknown): number | undefined => {
+  const statusCode = (error as { statusCode?: unknown })?.statusCode;
+  return typeof statusCode === 'number' ? statusCode : undefined;
+};
+
+const readMessage = (error: unknown, fallback: string): string => {
+  const message = (error as { message?: unknown })?.message;
+  return typeof message === 'string' && message.length > 0 ? message : fallback;
+};
+
+/**
+ * Normalize anything thrown by a provider SDK into an `LLMError`.
+ *
+ * Matches structurally rather than with `instanceof` against the SDK's error
+ * classes: a duplicated copy of the package in the module graph would defeat
+ * `instanceof`, and every one of those classes exposes `statusCode` or `name`.
+ */
+export const toLLMError = (error: unknown): LLMError => {
+  if (error instanceof LLMError) return error;
+
+  const statusCode = readStatusCode(error);
+  if (statusCode !== undefined) {
+    return new LLMError(
+      readMessage(error, `Provider request failed with status ${statusCode}`),
+      { retryable: isRetryableStatus(statusCode), statusCode, cause: error },
+    );
+  }
+
+  const name = (error as { name?: unknown })?.name;
+  const retryable =
+    typeof name === 'string' && RETRYABLE_TRANSPORT_ERRORS.has(name);
+
+  return new LLMError(readMessage(error, 'Provider request failed'), {
+    retryable,
+    cause: error,
+  });
+};

--- a/src/llm/interfaces/llm.interfaces.ts
+++ b/src/llm/interfaces/llm.interfaces.ts
@@ -1,9 +1,77 @@
-export interface LLMStrategy {
-  generateCompletion(
-    messages: Array<LLMMessage>,
-    options?: CompletionOptions,
-  ): Promise<string>;
-  streamCompletion?(prompt: string, options?: any): AsyncIterable<string>;
+import type { ZodType } from 'zod';
+
+export enum LLMProvider {
+  OPENAI = 'openai',
+  CLAUDE = 'claude',
+  OPENROUTER = 'openrouter',
+}
+
+export enum MessageRole {
+  User = 'user',
+  Assistant = 'assistant',
+  System = 'system',
+  Tool = 'tool',
+}
+
+export interface SystemMessage {
+  role: MessageRole.System;
+  content: string;
+}
+
+export interface UserMessage {
+  role: MessageRole.User;
+  content: string;
+}
+
+/** An assistant turn. Carries `toolCalls` when the model asked for tools. */
+export interface AssistantMessage {
+  role: MessageRole.Assistant;
+  content?: string;
+  toolCalls?: ToolCall[];
+}
+
+/** The result of executing one tool call, fed back into the next turn. */
+export interface ToolResultMessage {
+  role: MessageRole.Tool;
+  content: string;
+  toolCallId: string;
+}
+
+export type LLMMessage =
+  | SystemMessage
+  | UserMessage
+  | AssistantMessage
+  | ToolResultMessage;
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: ZodType;
+}
+
+export interface ToolCall {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+export interface Usage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  /** Real per-call USD cost from the provider. `0` when the provider omits it. */
+  cost: number;
+}
+
+export interface CompletionResult {
+  text: string;
+  usage: Usage;
+}
+
+export interface ToolTurnResult {
+  text?: string;
+  toolCalls: ToolCall[];
+  usage: Usage;
 }
 
 export type CompletionOptions = {
@@ -12,19 +80,27 @@ export type CompletionOptions = {
   temperature?: number;
 };
 
-export interface LLMMessage {
-  role: MessageRole;
-  content: string;
-}
+export interface LLMStrategy {
+  complete(
+    messages: Array<LLMMessage>,
+    options?: CompletionOptions,
+  ): Promise<CompletionResult>;
 
-export enum MessageRole {
-  User = 'user',
-  Assistant = 'assistant',
-  System = 'system',
-}
+  /** Exactly one turn. Executing the returned tool calls is the caller's job. */
+  completeWithTools(
+    messages: Array<LLMMessage>,
+    tools: Array<ToolDefinition>,
+    options?: CompletionOptions,
+  ): Promise<ToolTurnResult>;
 
-export enum LLMProvider {
-  OPENAI = 'openai',
-  CLAUDE = 'claude',
-  OPENROUTER = 'openrouter',
+  stream?(
+    messages: Array<LLMMessage>,
+    options?: CompletionOptions,
+  ): AsyncIterable<string>;
+
+  /** @deprecated Use `complete`, which also reports usage. */
+  generateCompletion(
+    messages: Array<LLMMessage>,
+    options?: CompletionOptions,
+  ): Promise<string>;
 }

--- a/src/llm/llm.service.spec.ts
+++ b/src/llm/llm.service.spec.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+
+// `llm.service` reaches the ESM-only SDK through LLMFactoryService -> strategies.
+jest.mock('@openrouter/sdk', () => ({ OpenRouter: jest.fn() }), {
+  virtual: true,
+});
+
+import { LLMService } from './llm.service';
+import { LLMProvider, MessageRole, ToolDefinition } from './interfaces';
+
+const messages = [{ role: MessageRole.User as const, content: 'hi' }];
+
+const tools: ToolDefinition[] = [
+  {
+    name: 'searchWeb',
+    description: 'Search the web',
+    parameters: z.object({ query: z.string() }),
+  },
+];
+
+const usage = {
+  promptTokens: 10,
+  completionTokens: 5,
+  totalTokens: 15,
+  cost: 0.0001,
+};
+
+const makeService = () => {
+  const strategy = {
+    complete: jest.fn(),
+    completeWithTools: jest.fn(),
+    generateCompletion: jest.fn(),
+  };
+  const llmFactory = { getStrategy: jest.fn().mockReturnValue(strategy) };
+  const service = new LLMService(llmFactory as any);
+  return { service, mocks: { strategy, llmFactory } };
+};
+
+let service: LLMService;
+let mocks: ReturnType<typeof makeService>['mocks'];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ({ service, mocks } = makeService());
+});
+
+describe('LLMService', () => {
+  describe('complete', () => {
+    it('should return the strategy result when the provider is supported', async () => {
+      const expected = { text: 'hello', usage };
+      mocks.strategy.complete.mockResolvedValue(expected);
+
+      await expect(
+        service.complete(LLMProvider.OPENROUTER, messages),
+      ).resolves.toEqual(expected);
+    });
+
+    it('should resolve the strategy for the requested provider', async () => {
+      mocks.strategy.complete.mockResolvedValue({ text: '', usage });
+
+      await service.complete(LLMProvider.OPENROUTER, messages, {
+        model: 'openai/gpt-5-mini',
+      });
+
+      expect(mocks.llmFactory.getStrategy).toHaveBeenCalledWith(
+        LLMProvider.OPENROUTER,
+      );
+      expect(mocks.strategy.complete).toHaveBeenCalledWith(messages, {
+        model: 'openai/gpt-5-mini',
+      });
+    });
+
+    it('should propagate the error when the provider is unsupported', async () => {
+      mocks.llmFactory.getStrategy.mockImplementation(() => {
+        throw new Error('Unsupported LLM provider: openai');
+      });
+
+      await expect(
+        service.complete(LLMProvider.OPENAI, messages),
+      ).rejects.toThrow('Unsupported LLM provider: openai');
+    });
+  });
+
+  describe('completeWithTools', () => {
+    it('should return the tool turn result when the model calls a tool', async () => {
+      const expected = {
+        toolCalls: [{ id: 'c1', name: 'searchWeb', input: { query: 'nest' } }],
+        usage,
+      };
+      mocks.strategy.completeWithTools.mockResolvedValue(expected);
+
+      await expect(
+        service.completeWithTools(LLMProvider.OPENROUTER, messages, tools),
+      ).resolves.toEqual(expected);
+    });
+
+    it('should forward the tools and options to the strategy', async () => {
+      mocks.strategy.completeWithTools.mockResolvedValue({
+        toolCalls: [],
+        usage,
+      });
+
+      await service.completeWithTools(LLMProvider.OPENROUTER, messages, tools, {
+        temperature: 0.1,
+      });
+
+      expect(mocks.strategy.completeWithTools).toHaveBeenCalledWith(
+        messages,
+        tools,
+        { temperature: 0.1 },
+      );
+    });
+
+    it('should propagate a retryable LLMError raised by the strategy', async () => {
+      mocks.strategy.completeWithTools.mockRejectedValue(
+        Object.assign(new Error('Rate limit exceeded'), { retryable: true }),
+      );
+
+      await expect(
+        service.completeWithTools(LLMProvider.OPENROUTER, messages, tools),
+      ).rejects.toMatchObject({ retryable: true });
+    });
+  });
+
+  describe('generateCompletions', () => {
+    it('should return the raw text from the strategy', async () => {
+      mocks.strategy.generateCompletion.mockResolvedValue('legacy text');
+
+      await expect(
+        service.generateCompletions(LLMProvider.OPENROUTER, messages),
+      ).resolves.toBe('legacy text');
+      expect(mocks.strategy.generateCompletion).toHaveBeenCalledWith(
+        messages,
+        undefined,
+      );
+    });
+  });
+});

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -1,11 +1,39 @@
 import { Injectable } from '@nestjs/common';
 import { LLMFactoryService } from './llmFactory.service';
-import { CompletionOptions, LLMMessage, LLMProvider } from './interfaces';
+import {
+  CompletionOptions,
+  CompletionResult,
+  LLMMessage,
+  LLMProvider,
+  ToolDefinition,
+  ToolTurnResult,
+} from './interfaces';
 
 @Injectable()
 export class LLMService {
   constructor(private llmFactory: LLMFactoryService) {}
 
+  async complete(
+    provider: LLMProvider,
+    messages: Array<LLMMessage>,
+    options?: CompletionOptions,
+  ): Promise<CompletionResult> {
+    const strategy = this.llmFactory.getStrategy(provider);
+    return strategy.complete(messages, options);
+  }
+
+  /** One turn only. The caller executes the returned tool calls. */
+  async completeWithTools(
+    provider: LLMProvider,
+    messages: Array<LLMMessage>,
+    tools: Array<ToolDefinition>,
+    options?: CompletionOptions,
+  ): Promise<ToolTurnResult> {
+    const strategy = this.llmFactory.getStrategy(provider);
+    return strategy.completeWithTools(messages, tools, options);
+  }
+
+  /** @deprecated Use `complete`, which also reports usage. */
   async generateCompletions(
     provider: LLMProvider,
     messages: Array<LLMMessage>,

--- a/src/llm/strategies/openrouter.strategy.spec.ts
+++ b/src/llm/strategies/openrouter.strategy.spec.ts
@@ -1,0 +1,440 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { z } from 'zod';
+import { LLMError } from '../errors';
+import { LLMMessage, MessageRole, ToolDefinition } from '../interfaces';
+
+const send = jest.fn();
+
+jest.mock(
+  '@openrouter/sdk',
+  () => ({
+    OpenRouter: jest.fn().mockImplementation(() => ({ chat: { send } })),
+  }),
+  { virtual: true },
+);
+
+import { OpenRouterStrategy } from './openrouter.strategy';
+
+const usage = {
+  promptTokens: 120,
+  completionTokens: 30,
+  totalTokens: 150,
+  cost: 0.00042,
+};
+
+const makeStrategy = () => {
+  const configService = { get: jest.fn(() => 'test-api-key') };
+  const strategy = new OpenRouterStrategy(configService as any);
+  return { strategy, mocks: { configService, send } };
+};
+
+type ChatRequestPayload = {
+  model: string;
+  messages: unknown[];
+  tools?: unknown[];
+  maxTokens?: number;
+  temperature?: number;
+  stream: boolean;
+};
+
+/** The `chatRequest` payload handed to the SDK on the most recent call. */
+const lastChatRequest = (): ChatRequestPayload => {
+  const calls = send.mock.calls as Array<[{ chatRequest: ChatRequestPayload }]>;
+  return calls[0][0].chatRequest;
+};
+
+let strategy: OpenRouterStrategy;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ({ strategy } = makeStrategy());
+});
+
+describe('OpenRouterStrategy', () => {
+  describe('constructor', () => {
+    it('should throw when OPENROUTER_API_KEY is not configured', () => {
+      const configService = { get: jest.fn(() => undefined) };
+
+      expect(() => new OpenRouterStrategy(configService as any)).toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('complete', () => {
+    it('should return the text and mapped usage when the model responds', async () => {
+      send.mockResolvedValue({
+        choices: [{ message: { content: 'hello world' } }],
+        usage,
+      });
+
+      await expect(
+        strategy.complete([{ role: MessageRole.User, content: 'hi' }]),
+      ).resolves.toEqual({
+        text: 'hello world',
+        usage: {
+          promptTokens: 120,
+          completionTokens: 30,
+          totalTokens: 150,
+          cost: 0.00042,
+        },
+      });
+    });
+
+    it('should report a zero cost when the provider omits it', async () => {
+      send.mockResolvedValue({
+        choices: [{ message: { content: 'x' } }],
+        usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+      });
+
+      const result = await strategy.complete([
+        { role: MessageRole.User, content: 'hi' },
+      ]);
+
+      expect(result.usage.cost).toBe(0);
+    });
+
+    it('should report zeroed usage when the response carries none', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+
+      const result = await strategy.complete([
+        { role: MessageRole.User, content: 'hi' },
+      ]);
+
+      expect(result.usage).toEqual({
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        cost: 0,
+      });
+    });
+
+    it('should return a fresh usage object each time, so callers can accumulate into it', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+      const messages = [{ role: MessageRole.User as const, content: 'hi' }];
+
+      const first = await strategy.complete(messages);
+      first.usage.totalTokens += 100;
+      const second = await strategy.complete(messages);
+
+      expect(second.usage.totalTokens).toBe(0);
+    });
+
+    it('should send the requested model, temperature and token cap', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+
+      await strategy.complete([{ role: MessageRole.User, content: 'hi' }], {
+        model: 'anthropic/claude-4.5-sonnet',
+        max_tokens: 512,
+        temperature: 0.2,
+      });
+
+      expect(lastChatRequest()).toMatchObject({
+        model: 'anthropic/claude-4.5-sonnet',
+        maxTokens: 512,
+        temperature: 0.2,
+        stream: false,
+      });
+    });
+
+    it('should fall back to the default model when none is given', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+
+      await strategy.complete([{ role: MessageRole.User, content: 'hi' }]);
+
+      expect(lastChatRequest().model).toBe('openai/gpt-5-mini');
+    });
+
+    it('should not send a tools key', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+
+      await strategy.complete([{ role: MessageRole.User, content: 'hi' }]);
+
+      expect(lastChatRequest()).not.toHaveProperty('tools');
+    });
+
+    it('should throw a terminal LLMError when the model returns no text', async () => {
+      send.mockResolvedValue({
+        choices: [{ message: { content: null } }],
+        usage,
+      });
+
+      await expect(
+        strategy.complete([{ role: MessageRole.User, content: 'hi' }]),
+      ).rejects.toMatchObject({
+        name: 'LLMError',
+        retryable: false,
+      });
+    });
+  });
+
+  describe('message mapping', () => {
+    beforeEach(() => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+    });
+
+    it('should map system and user messages verbatim', async () => {
+      await strategy.complete([
+        { role: MessageRole.System, content: 'be terse' },
+        { role: MessageRole.User, content: 'hi' },
+      ]);
+
+      expect(lastChatRequest().messages).toEqual([
+        { role: 'system', content: 'be terse' },
+        { role: 'user', content: 'hi' },
+      ]);
+    });
+
+    it('should serialise an assistant tool call into the SDK shape', async () => {
+      const messages: LLMMessage[] = [
+        {
+          role: MessageRole.Assistant,
+          toolCalls: [
+            { id: 'call_1', name: 'searchWeb', input: { query: 'nest' } },
+          ],
+        },
+      ];
+
+      await strategy.complete(messages);
+
+      expect(lastChatRequest().messages[0]).toEqual({
+        role: 'assistant',
+        toolCalls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: {
+              name: 'searchWeb',
+              arguments: '{"query":"nest"}',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should keep assistant prose when the turn has both content and tool calls', async () => {
+      await strategy.complete([
+        {
+          role: MessageRole.Assistant,
+          content: 'let me look that up',
+          toolCalls: [{ id: 'call_1', name: 'searchWeb', input: {} }],
+        },
+      ]);
+
+      expect(lastChatRequest().messages[0]).toMatchObject({
+        role: 'assistant',
+        content: 'let me look that up',
+      });
+    });
+
+    it('should map a tool result message onto toolCallId', async () => {
+      await strategy.complete([
+        {
+          role: MessageRole.Tool,
+          content: '{"ok":true}',
+          toolCallId: 'call_1',
+        },
+      ]);
+
+      expect(lastChatRequest().messages[0]).toEqual({
+        role: 'tool',
+        content: '{"ok":true}',
+        toolCallId: 'call_1',
+      });
+    });
+  });
+
+  describe('completeWithTools', () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: 'searchWeb',
+        description: 'Search the web',
+        parameters: z.object({ query: z.string() }),
+      },
+    ];
+
+    it('should convert Zod parameters to JSON Schema without the $schema key', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: null } }] });
+
+      await strategy.completeWithTools(
+        [{ role: MessageRole.User, content: 'find me things' }],
+        tools,
+      );
+
+      expect(lastChatRequest().tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'searchWeb',
+            description: 'Search the web',
+            parameters: {
+              type: 'object',
+              properties: { query: { type: 'string' } },
+              required: ['query'],
+            },
+          },
+        },
+      ]);
+    });
+
+    it('should omit the tools key when given an empty tool list', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+
+      await strategy.completeWithTools(
+        [{ role: MessageRole.User, content: 'hi' }],
+        [],
+      );
+
+      expect(lastChatRequest()).not.toHaveProperty('tools');
+    });
+
+    it('should return parsed tool calls and usage when the model calls a tool', async () => {
+      send.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: null,
+              toolCalls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: {
+                    name: 'searchWeb',
+                    arguments: '{"query":"nestjs testing"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage,
+      });
+
+      const result = await strategy.completeWithTools(
+        [{ role: MessageRole.User, content: 'find me things' }],
+        tools,
+      );
+
+      expect(result.toolCalls).toEqual([
+        { id: 'call_1', name: 'searchWeb', input: { query: 'nestjs testing' } },
+      ]);
+      expect(result.usage.cost).toBe(0.00042);
+      expect(result).not.toHaveProperty('text');
+    });
+
+    it('should treat empty tool arguments as an empty input object', async () => {
+      send.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: null,
+              toolCalls: [
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: { name: 'now', arguments: '' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const result = await strategy.completeWithTools([], tools);
+
+      expect(result.toolCalls[0].input).toEqual({});
+    });
+
+    it('should return an empty toolCalls list and the text when the model answers directly', async () => {
+      send.mockResolvedValue({
+        choices: [{ message: { content: 'the answer is 42' } }],
+        usage,
+      });
+
+      const result = await strategy.completeWithTools(
+        [{ role: MessageRole.User, content: 'answer' }],
+        tools,
+      );
+
+      expect(result).toEqual({
+        text: 'the answer is 42',
+        toolCalls: [],
+        usage: {
+          promptTokens: 120,
+          completionTokens: 30,
+          totalTokens: 150,
+          cost: 0.00042,
+        },
+      });
+    });
+
+    it('should throw a retryable LLMError when tool arguments are malformed JSON', async () => {
+      send.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: null,
+              toolCalls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'searchWeb', arguments: '{"query": ' },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      await expect(strategy.completeWithTools([], tools)).rejects.toMatchObject(
+        {
+          name: 'LLMError',
+          retryable: true,
+        },
+      );
+    });
+  });
+
+  describe('error classification', () => {
+    it('should surface a 429 as a retryable LLMError', async () => {
+      send.mockRejectedValue(
+        Object.assign(new Error('Rate limit exceeded'), { statusCode: 429 }),
+      );
+
+      const error = await strategy
+        .complete([{ role: MessageRole.User, content: 'hi' }])
+        .catch((e: LLMError) => e);
+
+      expect(error).toBeInstanceOf(LLMError);
+      expect(error).toMatchObject({ retryable: true, statusCode: 429 });
+    });
+
+    it('should surface a 401 as a terminal LLMError', async () => {
+      send.mockRejectedValue(
+        Object.assign(new Error('Unauthorized'), { statusCode: 401 }),
+      );
+
+      const error = await strategy
+        .completeWithTools([{ role: MessageRole.User, content: 'hi' }], [])
+        .catch((e: LLMError) => e);
+
+      expect(error).toBeInstanceOf(LLMError);
+      expect(error).toMatchObject({ retryable: false, statusCode: 401 });
+    });
+  });
+
+  describe('generateCompletion', () => {
+    it('should return only the text, preserving the legacy contract', async () => {
+      send.mockResolvedValue({
+        choices: [{ message: { content: 'legacy' } }],
+        usage,
+      });
+
+      await expect(
+        strategy.generateCompletion([
+          { role: MessageRole.User, content: 'hi' },
+        ]),
+      ).resolves.toBe('legacy');
+    });
+  });
+});

--- a/src/llm/strategies/openrouter.strategy.ts
+++ b/src/llm/strategies/openrouter.strategy.ts
@@ -1,11 +1,117 @@
-import { CompletionOptions, LLMMessage, LLMStrategy } from '../interfaces';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { OpenRouter } from '@openrouter/sdk';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import type {
+  ChatFunctionTool,
+  ChatMessages,
+  ChatResult,
+  ChatUsage,
+} from '@openrouter/sdk/models';
+import { z } from 'zod';
+import {
+  CompletionOptions,
+  CompletionResult,
+  LLMMessage,
+  LLMStrategy,
+  MessageRole,
+  ToolCall,
+  ToolDefinition,
+  ToolTurnResult,
+  Usage,
+} from '../interfaces';
+import { LLMError, toLLMError } from '../errors';
+
+const DEFAULT_MODEL = 'openai/gpt-5-mini';
+
+// A fresh object per call: callers accumulate usage across turns by mutation.
+const emptyUsage = (): Usage => ({
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+  cost: 0,
+});
+
+/** OpenRouter reports cost only when the provider supplies it. */
+const toUsage = (usage: ChatUsage | undefined): Usage =>
+  usage
+    ? {
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        totalTokens: usage.totalTokens,
+        cost: usage.cost ?? 0,
+      }
+    : emptyUsage();
+
+const toChatMessage = (message: LLMMessage): ChatMessages => {
+  switch (message.role) {
+    case MessageRole.System:
+      return { role: 'system', content: message.content };
+    case MessageRole.User:
+      return { role: 'user', content: message.content };
+    case MessageRole.Tool:
+      return {
+        role: 'tool',
+        content: message.content,
+        toolCallId: message.toolCallId,
+      };
+    case MessageRole.Assistant:
+      return {
+        role: 'assistant',
+        // Omit rather than send '': some providers reject an empty content block.
+        ...(message.content !== undefined ? { content: message.content } : {}),
+        toolCalls: message.toolCalls?.map((call) => ({
+          id: call.id,
+          type: 'function',
+          function: {
+            name: call.name,
+            arguments: JSON.stringify(call.input ?? {}),
+          },
+        })),
+      };
+  }
+};
+
+const toChatTool = (tool: ToolDefinition): ChatFunctionTool => {
+  const parameters = z.toJSONSchema(tool.parameters, {
+    target: 'draft-7',
+    io: 'input',
+  });
+  // Providers reject the dialect marker inside a function's parameter schema.
+  delete parameters.$schema;
+
+  return {
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters,
+    },
+  };
+};
+
+/** Tool arguments arrive as a JSON string the model wrote, so they can be malformed. */
+const parseToolArguments = (args: string, toolName: string): unknown => {
+  if (args.trim() === '') return {};
+
+  try {
+    return JSON.parse(args) as unknown;
+  } catch (error) {
+    // A resample of the same request may well produce valid JSON.
+    throw new LLMError(
+      `Model returned malformed arguments for tool "${toolName}"`,
+      { retryable: true, cause: error },
+    );
+  }
+};
+
+const readText = (
+  content: ChatResult['choices'][number]['message']['content'],
+) => (typeof content === 'string' ? content : undefined);
 
 @Injectable()
 export class OpenRouterStrategy implements LLMStrategy {
   private client: OpenRouter;
+
   constructor(private config: ConfigService) {
     const apiKey = this.config.get<string>('OPENROUTER_API_KEY');
     if (!apiKey)
@@ -16,20 +122,75 @@ export class OpenRouterStrategy implements LLMStrategy {
       apiKey,
     });
   }
+
+  async complete(
+    messages: Array<LLMMessage>,
+    options?: CompletionOptions,
+  ): Promise<CompletionResult> {
+    const result = await this.send(messages, options);
+    const text = readText(result.choices[0]?.message?.content);
+
+    if (text === undefined) {
+      throw new LLMError('OpenRouter returned no text content', {
+        retryable: false,
+      });
+    }
+
+    return { text, usage: toUsage(result.usage) };
+  }
+
+  async completeWithTools(
+    messages: Array<LLMMessage>,
+    tools: Array<ToolDefinition>,
+    options?: CompletionOptions,
+  ): Promise<ToolTurnResult> {
+    const result = await this.send(messages, options, tools);
+    const message = result.choices[0]?.message;
+
+    const toolCalls: ToolCall[] = (message?.toolCalls ?? []).map((call) => ({
+      id: call.id,
+      name: call.function.name,
+      input: parseToolArguments(call.function.arguments, call.function.name),
+    }));
+
+    const text = readText(message?.content);
+
+    return {
+      // A tool-calling turn usually has no prose; omit the key rather than pass ''.
+      ...(text ? { text } : {}),
+      toolCalls,
+      usage: toUsage(result.usage),
+    };
+  }
+
+  /** @deprecated Use `complete`, which also reports usage. */
   async generateCompletion(
     messages: Array<LLMMessage>,
     options?: CompletionOptions,
   ): Promise<string> {
-    const completions = await this.client.chat.send({
-      model: options?.model || 'openai/gpt-5-mini',
+    const { text } = await this.complete(messages, options);
+    return text;
+  }
+
+  private async send(
+    messages: Array<LLMMessage>,
+    options?: CompletionOptions,
+    tools?: Array<ToolDefinition>,
+  ): Promise<ChatResult> {
+    // Built outside the try: a fault in our own conversion is not a provider fault.
+    const chatRequest = {
+      model: options?.model || DEFAULT_MODEL,
       maxTokens: options?.max_tokens,
-      messages,
-      stream: false,
-    });
+      temperature: options?.temperature,
+      messages: messages.map(toChatMessage),
+      ...(tools?.length ? { tools: tools.map(toChatTool) } : {}),
+      stream: false as const,
+    };
 
-    const content = completions.choices[0].message.content;
-    if (typeof content === 'string') return content;
-
-    throw new Error(`Unsupported content type: ${typeof content}`);
+    try {
+      return await this.client.chat.send({ chatRequest });
+    } catch (error) {
+      throw toLLMError(error);
+    }
   }
 }


### PR DESCRIPTION
Implements **T1: LLM layer: single-turn primitives + typed errors**.

Spec of record: `docs/artifact-workflow-prd.md` §7 (Layer 1).

## What landed

- `LLMStrategy` grows `complete()` and `completeWithTools()` (**one turn**; executing the returned tool calls is the caller's job) plus a reserved, unimplemented `stream?()`. `generateCompletion()` stays as a deprecated text-only wrapper so `AgentService` keeps working until #128 dissolves `src/mark`.
- Shared types per PRD §7: `ToolDefinition`, `ToolCall`, `Usage {promptTokens, completionTokens, totalTokens, cost}`, `CompletionResult`, `ToolTurnResult`, and the message variants — assistant-with-tool-calls and `role: 'tool'` results.
- Typed `LLMError { retryable }`. This layer owns retryable classification because it knows provider error semantics: `429` / `408` / `5xx` / transport faults are retryable; `4xx` and auth are terminal. An aborted request is terminal — the caller cancelled it, it isn't a fault to retry through.
- `LLMService` exposes `complete` / `completeWithTools` through the existing factory dispatch.

## Two deliberate deviations from the ticket text

**1. `@openrouter/sdk` upgraded `0.5.1` → `0.13.39`.**

The ticket's acceptance criterion — *"`completeWithTools` returns … a populated `usage.cost`"* — is not achievable on `0.5.1`:

| | `0.5.1` | `0.13.39` |
|---|---|---|
| `chat.send` request | flat `{messages, model}` | nested `{chatRequest: {…}}` |
| response type | `ChatResponse` | `ChatResult` |
| `usage.cost` / `costDetails` | **absent** | present |

On `0.5.1` the usage type has no cost field, `ChatGenerationParams` has no usage-accounting toggle, and the response is parsed through a plain `z.object`, so a `cost` key returned by the API is stripped before we see it. PRD §7 was written against a newer SDK than `package.json` pinned.

This is load-bearing beyond this ticket: `docs/credit-usage-system-design.md` §1 makes credits cost-backed (`1 credit = $0.001 of raw provider cost`), so **#114 inherits the problem**. Blast radius of the bump is one file — `openrouter.strategy.ts` is the sole import site.

**2. Zod → JSON Schema via `z.toJSONSchema`, not the SDK's `tool()` helper.**

The ticket names `tool()` for schema conversion, but `tool()` builds *orchestrator* tool objects carrying an `execute` function (for the `callModel` loop this PRD explicitly rejects), while `chat.send` wants plain JSON Schema on `tools[].function.parameters`. Same intent, correct mechanism. The dialect marker `$schema` is stripped — providers reject it inside a function's parameter schema.

## Verification

All three "Done when" criteria checked against a **real OpenRouter tool-calling model**, not only mocks:

```
toolCalls: [{"id":"call_…","name":"get_weather","input":{"city":"Lagos"}}]
usage:     {"promptTokens":55,"completionTokens":15,"totalTokens":70,"cost":0.00001725}
401 check -> LLMError statusCode: 401 retryable: false
```

A live `429` isn't practically reproducible; it's covered by unit test alongside `408`, `5xx`, `4xx`, transport faults and degenerate inputs.

- `bun jest` — 338 tests, 37 suites, green (49 in `src/llm`).
- `bun run build` — clean.
- `bunx eslint src/llm` — no new findings. The 6 remaining errors are pre-existing in `parsers/responseParser.service.ts`, untouched here.

## Notes for review

- `Usage.cost` is `0` when the provider omits it, which is the signal #114's documented token-rate fallback keys off.
- `toLLMError` classifies **structurally** (`statusCode`, `name`) rather than by `instanceof` against the SDK's error classes — a duplicated copy of the package in the module graph would silently defeat `instanceof`.
- `toUsage` returns a **fresh** object per call; `AgentRunner` accumulates usage across turns by mutation, and a shared constant would corrupt every later no-usage call. There's a regression test for it.
- The SDK is ESM-only. `require()` of it works on Node 22.20 (`require(esm)`), so the compiled server and worker are fine, but Jest's CJS transform chokes — hence the `{virtual: true}` mock in `llm.service.spec.ts`, which reaches the SDK transitively through `LLMFactoryService`.

Part of #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
