### PR TITLE
docs: correct the LLM layer spec after implementing #112

### DIFF
--- a/docs/agent-loop-and-research-agent-design.md
+++ b/docs/agent-loop-and-research-agent-design.md
@@ -18,7 +18,7 @@ agent loop"). Interlocking tickets are referenced inline at each boundary.
   mid-run — the agent cannot ask the user questions.
 - The agent runs on the **`src/llm` OpenRouter stack**, not the Vercel AI SDK. The old
   `ai` / `@ai-sdk/gateway` deps were deliberately removed when `src/mark` was stripped;
-  only `@openrouter/sdk` (^0.5.1), `@tavily/core` (^0.7.3) and `zod` (^4) remain.
+  only `@openrouter/sdk` (^0.13.39), `@tavily/core` (^0.7.3) and `zod` (^4) remain.
 - `src/mark` is dissolved (charter #9); its `MARK_*` multi-provider abstraction is
   retired. The surviving `src/mark/search.ts` Tavily helper is the seed for the one
   research tool.
@@ -57,9 +57,11 @@ interface Usage          { promptTokens: number; completionTokens: number; total
 
 - New shared types (`ToolDefinition`, `ToolCall`, `Usage`) and the message variants
   (assistant-with-tool-calls, `role: 'tool'` result) are **owned here**.
-- The **OpenRouter strategy** implements these using `@openrouter/sdk` primitives — its
-  `tool()` Zod helper for schema conversion, `chat.send` with `tools` for the single
-  turn, and the SDK's `usage.cost` / `costDetails` for real per-call dollar cost.
+- The **OpenRouter strategy** implements these using `@openrouter/sdk` primitives
+  (floor `0.13.x`) — `z.toJSONSchema` for Zod→JSON Schema conversion, `chat.send` with
+  `tools` for the single turn, and the SDK's `usage.cost` for real per-call dollar cost.
+  Not the SDK's `tool()` helper (it builds `callModel`'s argument, rejected below), and
+  not `usage.costDetails` (upstream wholesale cost, not the account charge). See PRD §7.
 
 **Layer 2 — the `AgentRunner` loop, provider-agnostic.** It owns the multi-turn loop
 (tool registry, message accumulation, iteration cap, usage aggregation, stop
@@ -315,7 +317,8 @@ Per the #100 resolution this is a clean write-over (relaunch, no users):
 - **`src/llm`**: extend `LLMStrategy` with `complete` / `completeWithTools` / (reserved)
   `stream`; add the shared `ToolDefinition` / `ToolCall` / `Usage` types and tool/tool-
   result message variants; implement them in the OpenRouter strategy over
-  `@openrouter/sdk`'s `tool()` + `chat.send`; add typed `LLMError{retryable}`.
+  `@openrouter/sdk` (≥ `0.13.x`) using `z.toJSONSchema` + `chat.send`; add typed
+  `LLMError{retryable}`.
 - **New `AgentRunner`** (in `src/agent`) owning the generic loop (§2) and the
   `research` / `generate` surface (§3), plus the research/generation/refine prompts.
 - **`searchWeb` tool** wrapping `src/mark/search.ts` (Tavily); `src/mark` otherwise

--- a/docs/artifact-workflow-prd.md
+++ b/docs/artifact-workflow-prd.md
@@ -637,16 +637,32 @@ interface ToolCall         { id: string; name: string; input: unknown }
 interface Usage { promptTokens: number; completionTokens: number; totalTokens: number; cost: number }
 ```
 
-The OpenRouter strategy implements these over `@openrouter/sdk` — its `tool()` Zod helper
-for schema conversion, `chat.send` with `tools` for the single turn, and `usage.cost` /
-`costDetails` for real per-call dollar cost. Add a typed `LLMError { retryable }`: the
-`src/llm` layer owns retryable classification because it knows provider error semantics
-(429/5xx/network → retryable; 4xx/auth → terminal).
+The OpenRouter strategy implements these over `@openrouter/sdk` (**floor: `0.13.x`** — see
+below), using `chat.send` with `tools` for the single turn, `z.toJSONSchema` to convert a
+`ToolDefinition`'s Zod `parameters` into the JSON Schema that `tools[].function.parameters`
+expects, and `usage.cost` for real per-call dollar cost. Add a typed `LLMError { retryable }`:
+the `src/llm` layer owns retryable classification because it knows provider error semantics
+(429/408/5xx/network → retryable; 4xx/auth → terminal; a client-side abort is terminal,
+since the caller cancelled it).
 
 We deliberately do **not** adopt the SDK's `callModel` orchestrator, which ships an
 automatic multi-turn tool loop — burying the loop inside the vendor SDK defeats the
-provider-swappability the layering exists for. We lean on its lower-level per-turn helpers
-and own the loop.
+provider-swappability the layering exists for. We call `chat.send` directly and own the loop.
+
+**Do not use the SDK's `tool()` helper.** It builds `callModel`'s argument — a tool object
+carrying an `execute` function — not JSON Schema, so `chat.send` will not take it. Reaching
+for `tool()` quietly drags in the orchestrator this section just rejected.
+
+**`usage.cost` is not `usage.costDetails`.** `cost` is what OpenRouter charged the account;
+`costDetails` (`upstreamInferenceCost`, `upstreamInferencePromptCost`,
+`upstreamInferenceCompletionsCost`) is what the upstream provider charged *OpenRouter* —
+wholesale, excluding margin, and different under BYOK. Only `cost` may denominate credits
+(§9). `Usage` therefore carries `cost` alone; `costDetails` is not plumbed through.
+
+**SDK floor.** `usage.cost` does not exist on `@openrouter/sdk` before ~`0.13.x`: the older
+chat usage type has no cost field, the request carries no usage-accounting toggle, and the
+response is parsed through a plain `z.object`, so a `cost` key is stripped before it is read.
+`0.13.x` also nests the request under `chatRequest` and renames `ChatResponse` → `ChatResult`.
 
 ### Layer 2 — `AgentRunner`, provider-agnostic
 
@@ -1462,9 +1478,10 @@ leaves the tree green. `Blocked by` declares hard ordering.
 > **T1 — LLM layer: single-turn primitives + typed errors.**
 > Extend `LLMStrategy` with `complete` / `completeWithTools` / reserved `stream`. Add
 > `ToolDefinition`, `ToolCall`, `Usage`, and the assistant-with-tool-calls and `role:'tool'`
-> message variants. Implement in the OpenRouter strategy over `@openrouter/sdk`'s `tool()` +
-> `chat.send`, surfacing `usage.cost`. Add typed `LLMError { retryable }` (429/5xx/network →
-> retryable; 4xx/auth → terminal). *Blocked by: none.*
+> message variants. Implement in the OpenRouter strategy over `@openrouter/sdk` (≥ `0.13.x`)
+> using `z.toJSONSchema` + `chat.send`, surfacing `usage.cost`. Add typed
+> `LLMError { retryable }` (429/408/5xx/network → retryable; 4xx/auth → terminal).
+> *Blocked by: none.*
 
 > **T2 — `Artifact` schema + the POST arm of the content union.**
 > New `Artifact`/`ArtifactVersion` schema (§4) with `ArtifactType`, `VersionStatus`,

--- a/docs/credit-usage-system-design.md
+++ b/docs/credit-usage-system-design.md
@@ -27,9 +27,14 @@ enforcement points, and the Paddle/tier-config implications**. The engine's hook
   balance guard, and the debit.
 - **#104 §7 emits raw signals, not credits:** each LLM turn → `record({ kind: 'llm',
   amount: usage.cost, detail: { model, totalTokens } })` where `usage.cost` is the
-  **real per-call USD cost** from OpenRouter's `costDetails`; each web search →
+  **real per-call USD cost OpenRouter charged the account**; each web search →
   `record({ kind: 'web_search', amount: 1 })`. Converting those to credits is this
   ticket's job.
+
+  > **Not `usage.costDetails`.** That sibling field reports what the *upstream provider*
+  > charged OpenRouter — wholesale, excluding OpenRouter's margin, and different under
+  > BYOK. Metering on it would systematically under-count real spend, worst where the
+  > margin is widest. `Usage` (PRD §7) carries `cost` alone, by design.
 
 ---
 


### PR DESCRIPTION
Corrects three errors in the LLM-layer spec, found while implementing #112 (merged as #132). All three had already propagated from PRD §7 into the design docs that cite it.

Docs only — no code changes. #112 already ships the corrected behaviour.

## 1. `tool()` is the wrong mechanism

§7 said:

> its `tool()` Zod helper for schema conversion

`chat.send` takes plain JSON Schema at `tools[].function.parameters`. `tool()` returns a `ToolWithExecute` / `ManualTool` — a tool object carrying an `execute` function. That's the argument to `callModel`, the multi-turn orchestrator **the very next paragraph of §7 explicitly rejects**. The two halves of the paragraph contradicted each other, and reaching for `tool()` quietly drags in the orchestrator the layering exists to avoid.

Corrected to `z.toJSONSchema`, plus an explicit "do not use `tool()`" note so the next reader doesn't rediscover this. Also drops the claim that we "lean on its lower-level per-turn helpers" — there are none; `chat.send` is the raw endpoint.

## 2. `usage.cost` is not `usage.costDetails` — this one had teeth

`credit-usage-system-design.md` said:

> `usage.cost` is the **real per-call USD cost** from OpenRouter's `costDetails`

Wrong provenance. They are sibling fields carrying different numbers:

```ts
usage.cost: number                        // what OpenRouter charged the account
usage.costDetails: {
  upstreamInferenceCost?: number          // what the upstream provider charged OpenRouter
  upstreamInferencePromptCost: number
  upstreamInferenceCompletionsCost: number
}
```

`costDetails` is OpenRouter's **cost of goods** — wholesale, excluding their margin, and different again under BYOK.

This matters because #114 denominates credits on cost (`1 credit = $0.001 of raw provider cost`). Anyone taking that line literally and summing the `upstreamInference*` fields would meter every user against OpenRouter's wholesale price rather than what the account was actually charged — a silent, systematic under-count of real spend, worst exactly where the margin is widest.

Fixed in both docs, and PRD §7 now states that only `cost` may denominate credits and that `Usage` deliberately carries no `costDetails`.

## 3. No SDK floor was stated

§7 named `usage.cost`, which does not exist on `@openrouter/sdk` before ~`0.13.x`: the older chat usage type has no cost field, the request carries no usage-accounting toggle, and the response is parsed through a plain `z.object`, so a `cost` key is stripped before it can be read. `package.json` pinned `^0.5.1`, so §7 specified a field the pinned dependency could not return — which is what made #112 unimplementable as written.

The floor is now recorded, along with the two breaking changes `0.13.x` brings (request nests under `chatRequest`; `ChatResponse` → `ChatResult`). The stale `^0.5.1` dependency line in the agent-loop design is refreshed to `^0.13.39`.

## Files

- `docs/artifact-workflow-prd.md` — §7 prose, and the T1 ticket summary at the foot.
- `docs/agent-loop-and-research-agent-design.md` — Layer 1 bullet, dependency line, T1 summary.
- `docs/credit-usage-system-design.md` — the `costDetails` provenance, with a callout.

Every surviving mention of `costDetails` across `docs/` is now a warning against using it.

Part of #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
