### PR TITLE
feat: add carousel schemas, templates, and assets (#120)

### DIFF
--- a/assets/carousel/base.css
+++ b/assets/carousel/base.css
@@ -1,0 +1,147 @@
+/*
+ * Shared frame and layout for every carousel deck. Themes (theme.css) change
+ * only the look — colour, typeface, decoration. Box metrics and the type scale
+ * live here so a field that fits under one theme fits under all four, which is
+ * what makes the schema caps a trustworthy fit contract.
+ */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+/*
+ * The one-slide-one-page invariant. A fixed 1080x1350 box with no scroll:
+ * overflow is clipped so nothing spills onto the next page, and one long token
+ * cannot blow the box out sideways. Puppeteer paginates on `break-after: page`.
+ */
+.slide {
+  box-sizing: border-box; /* theme padding never inflates the box */
+  width: 1080px;
+  height: 1350px;
+  overflow: hidden; /* nothing ever spills onto the next page */
+  overflow-wrap: anywhere; /* one long token can't blow the box sideways */
+  break-after: page;
+  break-inside: avoid;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 100px 96px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+    sans-serif;
+  line-height: 1.3;
+}
+
+/*
+ * Load-bearing, not cosmetic: a break after the final slide emits an empty page
+ * LinkedIn would show as a blank last card.
+ */
+.slide:last-child {
+  break-after: auto;
+}
+
+/* --- Per-role layout (shared across themes) --- */
+
+.slide--cover {
+  justify-content: center;
+}
+
+.slide--content,
+.slide--list {
+  justify-content: flex-start;
+}
+
+.slide--quote,
+.slide--cta {
+  justify-content: center;
+}
+
+/* --- Type scale (shared across themes; themes reface, never resize) --- */
+
+.eyebrow {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 28px;
+}
+
+.title {
+  font-size: 92px;
+  font-weight: 800;
+  line-height: 1.04;
+}
+
+.subtitle {
+  font-size: 38px;
+  font-weight: 400;
+  line-height: 1.35;
+  margin-top: 32px;
+}
+
+.heading {
+  font-size: 62px;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 40px;
+}
+
+.body {
+  font-size: 40px;
+  font-weight: 400;
+  line-height: 1.45;
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.list-item {
+  font-size: 38px;
+  font-weight: 400;
+  line-height: 1.35;
+  padding-left: 44px;
+  position: relative;
+}
+
+.quote {
+  font-size: 60px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.attribution {
+  font-size: 32px;
+  font-weight: 500;
+  margin-top: 44px;
+}
+
+.headline {
+  font-size: 78px;
+  font-weight: 800;
+  line-height: 1.08;
+}
+
+.action {
+  font-size: 46px;
+  font-weight: 600;
+  margin-top: 40px;
+}
+
+.handle {
+  font-size: 32px;
+  font-weight: 500;
+  margin-top: 28px;
+  opacity: 0.85;
+}

--- a/assets/carousel/templates/bold/content.hbs
+++ b/assets/carousel/templates/bold/content.hbs
@@ -1,0 +1,2 @@
+<h2 class="heading">{{heading}}</h2>
+<p class="body">{{body}}</p>

--- a/assets/carousel/templates/bold/cover.hbs
+++ b/assets/carousel/templates/bold/cover.hbs
@@ -1,0 +1,3 @@
+{{#if eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/if}}
+<h1 class="title">{{title}}</h1>
+{{#if subtitle}}<p class="subtitle">{{subtitle}}</p>{{/if}}

--- a/assets/carousel/templates/bold/cta.hbs
+++ b/assets/carousel/templates/bold/cta.hbs
@@ -1,0 +1,3 @@
+<h2 class="headline">{{headline}}</h2>
+<p class="action">{{action}}</p>
+{{#if handle}}<p class="handle">{{handle}}</p>{{/if}}

--- a/assets/carousel/templates/bold/fixture.json
+++ b/assets/carousel/templates/bold/fixture.json
@@ -1,0 +1,134 @@
+{
+  "theme": "bold",
+  "slides": [
+    {
+      "type": "cover",
+      "fields": {
+        "eyebrow": "THE BOLD the quick brown",
+        "title": "Ship a carousel that fits 🚀  the quick brown fox jumps over a remarka",
+        "subtitle": "A cover subtitle stretched to the very last character the quick brown fox jumps over a remarkably lazy sleeping dog agai"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 1 the quick brown fox jumps over a re",
+        "body": "Body copy with an emoji 🔥 pushed to the maximum allowed length so we can prove the fit the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleepin"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 2 the quick brown fox jumps over a re",
+        "body": "Body copy 2 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 3 the quick brown fox jumps over a re",
+        "body": "Body copy 3 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 4 the quick brown fox jumps over a re",
+        "body": "Body copy 4 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 5 the quick brown fox jumps over a re",
+        "body": "Body copy 5 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 1 the quick brown fox jumps over a remar",
+        "items": [
+          "https://example.com/really/long/unbreakable/path/segment/x  the quick brown foxx",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 2 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 1 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 3 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 2 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 1: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 1 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 2: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 2 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 3: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 3 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 4: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 4 the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 1 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 2 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    }
+  ]
+}

--- a/assets/carousel/templates/bold/list.hbs
+++ b/assets/carousel/templates/bold/list.hbs
@@ -1,0 +1,6 @@
+<h2 class="heading">{{heading}}</h2>
+<ul class="list">
+{{#each items}}
+  <li class="list-item">{{this}}</li>
+{{/each}}
+</ul>

--- a/assets/carousel/templates/bold/quote.hbs
+++ b/assets/carousel/templates/bold/quote.hbs
@@ -1,0 +1,2 @@
+<blockquote class="quote">{{quote}}</blockquote>
+{{#if attribution}}<p class="attribution">{{attribution}}</p>{{/if}}

--- a/assets/carousel/templates/bold/theme.css
+++ b/assets/carousel/templates/bold/theme.css
@@ -1,0 +1,83 @@
+/* bold — high-contrast dark deck, heavy type, one electric accent. */
+
+.slide {
+  background: #0b0b0f;
+  color: #f6f6f4;
+}
+
+.slide--cover {
+  background: #0b0b0f;
+}
+
+.eyebrow {
+  color: #ffe14d;
+}
+
+.title {
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+
+/* accent bar under the cover title */
+.slide--cover .title::after {
+  content: '';
+  display: block;
+  width: 180px;
+  height: 14px;
+  margin-top: 36px;
+  background: #ffe14d;
+}
+
+.heading,
+.headline {
+  font-weight: 900;
+  letter-spacing: -0.01em;
+}
+
+.heading {
+  color: #ffffff;
+}
+
+/* square marker for list rows */
+.list-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 18px;
+  width: 20px;
+  height: 20px;
+  background: #ffe14d;
+}
+
+.quote {
+  color: #ffffff;
+}
+
+.slide--quote .quote::before {
+  content: '\201C';
+  display: block;
+  font-size: 140px;
+  line-height: 0.6;
+  color: #ffe14d;
+  margin-bottom: 24px;
+}
+
+.attribution {
+  color: #ffe14d;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.action {
+  display: inline-block;
+  align-self: flex-start;
+  background: #ffe14d;
+  color: #0b0b0f;
+  font-weight: 800;
+  padding: 22px 40px;
+  border-radius: 4px;
+}
+
+.handle {
+  color: #ffe14d;
+}

--- a/assets/carousel/templates/editorial/content.hbs
+++ b/assets/carousel/templates/editorial/content.hbs
@@ -1,0 +1,2 @@
+<h2 class="heading">{{heading}}</h2>
+<p class="body">{{body}}</p>

--- a/assets/carousel/templates/editorial/cover.hbs
+++ b/assets/carousel/templates/editorial/cover.hbs
@@ -1,0 +1,3 @@
+{{#if eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/if}}
+<h1 class="title">{{title}}</h1>
+{{#if subtitle}}<p class="subtitle">{{subtitle}}</p>{{/if}}

--- a/assets/carousel/templates/editorial/cta.hbs
+++ b/assets/carousel/templates/editorial/cta.hbs
@@ -1,0 +1,3 @@
+<h2 class="headline">{{headline}}</h2>
+<p class="action">{{action}}</p>
+{{#if handle}}<p class="handle">{{handle}}</p>{{/if}}

--- a/assets/carousel/templates/editorial/fixture.json
+++ b/assets/carousel/templates/editorial/fixture.json
@@ -1,0 +1,134 @@
+{
+  "theme": "editorial",
+  "slides": [
+    {
+      "type": "cover",
+      "fields": {
+        "eyebrow": "THE EDITORIAL the quickx",
+        "title": "Ship a carousel that fits 🚀  the quick brown fox jumps over a remarka",
+        "subtitle": "A cover subtitle stretched to the very last character the quick brown fox jumps over a remarkably lazy sleeping dog agai"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 1 the quick brown fox jumps over a re",
+        "body": "Body copy with an emoji 🔥 pushed to the maximum allowed length so we can prove the fit the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleepin"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 2 the quick brown fox jumps over a re",
+        "body": "Body copy 2 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 3 the quick brown fox jumps over a re",
+        "body": "Body copy 3 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 4 the quick brown fox jumps over a re",
+        "body": "Body copy 4 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 5 the quick brown fox jumps over a re",
+        "body": "Body copy 5 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 1 the quick brown fox jumps over a remar",
+        "items": [
+          "https://example.com/really/long/unbreakable/path/segment/x  the quick brown foxx",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 2 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 1 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 3 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 2 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 1: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 1 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 2: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 2 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 3: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 3 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 4: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 4 the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 1 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 2 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    }
+  ]
+}

--- a/assets/carousel/templates/editorial/list.hbs
+++ b/assets/carousel/templates/editorial/list.hbs
@@ -1,0 +1,6 @@
+<h2 class="heading">{{heading}}</h2>
+<ul class="list">
+{{#each items}}
+  <li class="list-item">{{this}}</li>
+{{/each}}
+</ul>

--- a/assets/carousel/templates/editorial/quote.hbs
+++ b/assets/carousel/templates/editorial/quote.hbs
@@ -1,0 +1,2 @@
+<blockquote class="quote">{{quote}}</blockquote>
+{{#if attribution}}<p class="attribution">{{attribution}}</p>{{/if}}

--- a/assets/carousel/templates/editorial/theme.css
+++ b/assets/carousel/templates/editorial/theme.css
@@ -1,0 +1,88 @@
+/* editorial — cream stock, serif headings, a single rust accent. Magazine feel. */
+
+.slide {
+  background: #f7f3ea;
+  color: #1f1b16;
+}
+
+.eyebrow {
+  color: #b23a2e;
+}
+
+.title,
+.heading,
+.headline,
+.quote {
+  font-family: Georgia, 'Times New Roman', 'Iowan Old Style', serif;
+}
+
+.title {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.slide--cover .title::after {
+  content: '';
+  display: block;
+  width: 240px;
+  height: 3px;
+  margin-top: 36px;
+  background: #b23a2e;
+}
+
+.subtitle {
+  color: #5c5347;
+  font-style: italic;
+}
+
+.heading {
+  font-weight: 700;
+}
+
+.body {
+  color: #33302a;
+}
+
+/* rust bullet */
+.list-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 20px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #b23a2e;
+}
+
+.slide--quote .quote::before {
+  content: '\201C';
+  display: block;
+  font-family: Georgia, serif;
+  font-size: 160px;
+  line-height: 0.5;
+  color: #b23a2e;
+  margin-bottom: 16px;
+}
+
+.quote {
+  font-style: italic;
+  font-weight: 600;
+}
+
+.attribution {
+  color: #b23a2e;
+  font-style: normal;
+  letter-spacing: 0.04em;
+}
+
+.action {
+  align-self: flex-start;
+  color: #b23a2e;
+  border-bottom: 3px solid #b23a2e;
+  padding-bottom: 8px;
+}
+
+.handle {
+  color: #5c5347;
+}

--- a/assets/carousel/templates/gradient/content.hbs
+++ b/assets/carousel/templates/gradient/content.hbs
@@ -1,0 +1,2 @@
+<h2 class="heading">{{heading}}</h2>
+<p class="body">{{body}}</p>

--- a/assets/carousel/templates/gradient/cover.hbs
+++ b/assets/carousel/templates/gradient/cover.hbs
@@ -1,0 +1,3 @@
+{{#if eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/if}}
+<h1 class="title">{{title}}</h1>
+{{#if subtitle}}<p class="subtitle">{{subtitle}}</p>{{/if}}

--- a/assets/carousel/templates/gradient/cta.hbs
+++ b/assets/carousel/templates/gradient/cta.hbs
@@ -1,0 +1,3 @@
+<h2 class="headline">{{headline}}</h2>
+<p class="action">{{action}}</p>
+{{#if handle}}<p class="handle">{{handle}}</p>{{/if}}

--- a/assets/carousel/templates/gradient/fixture.json
+++ b/assets/carousel/templates/gradient/fixture.json
@@ -1,0 +1,134 @@
+{
+  "theme": "gradient",
+  "slides": [
+    {
+      "type": "cover",
+      "fields": {
+        "eyebrow": "THE GRADIENT the quick b",
+        "title": "Ship a carousel that fits 🚀  the quick brown fox jumps over a remarka",
+        "subtitle": "A cover subtitle stretched to the very last character the quick brown fox jumps over a remarkably lazy sleeping dog agai"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 1 the quick brown fox jumps over a re",
+        "body": "Body copy with an emoji 🔥 pushed to the maximum allowed length so we can prove the fit the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleepin"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 2 the quick brown fox jumps over a re",
+        "body": "Body copy 2 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 3 the quick brown fox jumps over a re",
+        "body": "Body copy 3 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 4 the quick brown fox jumps over a re",
+        "body": "Body copy 4 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 5 the quick brown fox jumps over a re",
+        "body": "Body copy 5 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 1 the quick brown fox jumps over a remar",
+        "items": [
+          "https://example.com/really/long/unbreakable/path/segment/x  the quick brown foxx",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 2 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 1 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 3 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 2 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 1: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 1 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 2: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 2 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 3: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 3 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 4: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 4 the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 1 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 2 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    }
+  ]
+}

--- a/assets/carousel/templates/gradient/list.hbs
+++ b/assets/carousel/templates/gradient/list.hbs
@@ -1,0 +1,6 @@
+<h2 class="heading">{{heading}}</h2>
+<ul class="list">
+{{#each items}}
+  <li class="list-item">{{this}}</li>
+{{/each}}
+</ul>

--- a/assets/carousel/templates/gradient/quote.hbs
+++ b/assets/carousel/templates/gradient/quote.hbs
@@ -1,0 +1,2 @@
+<blockquote class="quote">{{quote}}</blockquote>
+{{#if attribution}}<p class="attribution">{{attribution}}</p>{{/if}}

--- a/assets/carousel/templates/gradient/theme.css
+++ b/assets/carousel/templates/gradient/theme.css
@@ -1,0 +1,78 @@
+/* gradient — saturated diagonal wash, white type, glassy accents. */
+
+.slide {
+  background: linear-gradient(135deg, #6d28d9 0%, #db2777 100%);
+  color: #ffffff;
+}
+
+.eyebrow {
+  color: #ffffff;
+  opacity: 0.85;
+}
+
+.title {
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  text-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
+}
+
+.subtitle {
+  color: #ffffff;
+  opacity: 0.92;
+}
+
+.heading,
+.headline {
+  font-weight: 800;
+  text-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
+}
+
+.body {
+  color: #ffffff;
+  opacity: 0.95;
+}
+
+/* translucent chip marker */
+.list-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 22px;
+  height: 22px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.slide--quote .quote::before {
+  content: '\201C';
+  display: block;
+  font-size: 150px;
+  line-height: 0.55;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 20px;
+}
+
+.quote {
+  font-weight: 600;
+}
+
+.attribution {
+  color: #ffffff;
+  opacity: 0.85;
+  letter-spacing: 0.06em;
+}
+
+.action {
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.95);
+  color: #6d28d9;
+  font-weight: 800;
+  padding: 22px 40px;
+  border-radius: 999px;
+}
+
+.handle {
+  color: #ffffff;
+  opacity: 0.85;
+}

--- a/assets/carousel/templates/minimal/content.hbs
+++ b/assets/carousel/templates/minimal/content.hbs
@@ -1,0 +1,2 @@
+<h2 class="heading">{{heading}}</h2>
+<p class="body">{{body}}</p>

--- a/assets/carousel/templates/minimal/cover.hbs
+++ b/assets/carousel/templates/minimal/cover.hbs
@@ -1,0 +1,3 @@
+{{#if eyebrow}}<p class="eyebrow">{{eyebrow}}</p>{{/if}}
+<h1 class="title">{{title}}</h1>
+{{#if subtitle}}<p class="subtitle">{{subtitle}}</p>{{/if}}

--- a/assets/carousel/templates/minimal/cta.hbs
+++ b/assets/carousel/templates/minimal/cta.hbs
@@ -1,0 +1,3 @@
+<h2 class="headline">{{headline}}</h2>
+<p class="action">{{action}}</p>
+{{#if handle}}<p class="handle">{{handle}}</p>{{/if}}

--- a/assets/carousel/templates/minimal/fixture.json
+++ b/assets/carousel/templates/minimal/fixture.json
@@ -1,0 +1,134 @@
+{
+  "theme": "minimal",
+  "slides": [
+    {
+      "type": "cover",
+      "fields": {
+        "eyebrow": "THE MINIMAL the quick br",
+        "title": "Ship a carousel that fits 🚀  the quick brown fox jumps over a remarka",
+        "subtitle": "A cover subtitle stretched to the very last character the quick brown fox jumps over a remarkably lazy sleeping dog agai"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 1 the quick brown fox jumps over a re",
+        "body": "Body copy with an emoji 🔥 pushed to the maximum allowed length so we can prove the fit the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleepin"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 2 the quick brown fox jumps over a re",
+        "body": "Body copy 2 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 3 the quick brown fox jumps over a re",
+        "body": "Body copy 3 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 4 the quick brown fox jumps over a re",
+        "body": "Body copy 4 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "content",
+      "fields": {
+        "heading": "Content heading number 5 the quick brown fox jumps over a re",
+        "body": "Body copy 5 pushed to the maximum allowed length to prove the fixed slide clamps rather than spills the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkably lazy sleeping dog again the quick brown fox jumps over a remarkablyx"
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 1 the quick brown fox jumps over a remar",
+        "items": [
+          "https://example.com/really/long/unbreakable/path/segment/x  the quick brown foxx",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 2 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 1 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "list",
+      "fields": {
+        "heading": "List heading number 3 the quick brown fox jumps over a remar",
+        "items": [
+          "List item one for deck 2 the quick brown fox jumps over a remarkably lazy sleepi",
+          "List item two with an emoji ✅ at full width the quick brown fox jumps over a rem",
+          "List item three at the maximum allowed width for a single row the quick brown fo",
+          "List item four kept at the eighty character ceiling exactly the quick brown foxx",
+          "List item five also stretched to the eighty character ceiling the quick brown fo",
+          "List item six the sixth and final item at full width the quick brown fox jumps o"
+        ]
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 1: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 1 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 2: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 2 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 3: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 3 the quick brow"
+      }
+    },
+    {
+      "type": "quote",
+      "fields": {
+        "quote": "Quote 4: a pull quote stretched to the two hundred character ceiling so the largest type on the deck is proven to fit inside the fixed slide the quick brown fox jumps over a remarkably lazy sleeping d",
+        "attribution": "Jane Q. Author, Head of Content 4 the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 1 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    },
+    {
+      "type": "cta",
+      "fields": {
+        "headline": "Follow for more like this deck 2 the quick brown fox jumps over a rema",
+        "action": "Tap the bell and share the quick brown f",
+        "handle": "@marquill.official.handle the quick brow"
+      }
+    }
+  ]
+}

--- a/assets/carousel/templates/minimal/list.hbs
+++ b/assets/carousel/templates/minimal/list.hbs
@@ -1,0 +1,6 @@
+<h2 class="heading">{{heading}}</h2>
+<ul class="list">
+{{#each items}}
+  <li class="list-item">{{this}}</li>
+{{/each}}
+</ul>

--- a/assets/carousel/templates/minimal/quote.hbs
+++ b/assets/carousel/templates/minimal/quote.hbs
@@ -1,0 +1,2 @@
+<blockquote class="quote">{{quote}}</blockquote>
+{{#if attribution}}<p class="attribution">{{attribution}}</p>{{/if}}

--- a/assets/carousel/templates/minimal/theme.css
+++ b/assets/carousel/templates/minimal/theme.css
@@ -1,0 +1,67 @@
+/* minimal — white ground, monochrome, hairline rules, restrained weights. */
+
+.slide {
+  background: #ffffff;
+  color: #111114;
+}
+
+.eyebrow {
+  color: #8a8a90;
+  font-weight: 600;
+}
+
+.title {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: #55555c;
+}
+
+.heading {
+  font-weight: 600;
+  padding-bottom: 28px;
+  border-bottom: 2px solid #111114;
+}
+
+.headline {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.body {
+  color: #34343a;
+}
+
+/* thin dash marker */
+.list-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 24px;
+  width: 24px;
+  height: 2px;
+  background: #111114;
+}
+
+.quote {
+  font-weight: 500;
+  border-left: 4px solid #111114;
+  padding-left: 44px;
+}
+
+.attribution {
+  color: #8a8a90;
+}
+
+.action {
+  align-self: flex-start;
+  font-weight: 600;
+  padding-bottom: 10px;
+  border-bottom: 3px solid #111114;
+}
+
+.handle {
+  color: #8a8a90;
+}

--- a/src/carousel/carousel-templates.service.spec.ts
+++ b/src/carousel/carousel-templates.service.spec.ts
@@ -1,0 +1,46 @@
+import { CarouselTemplatesService } from './carousel-templates.service';
+import { Slide } from './schemas';
+
+const makeService = () => {
+  const service = new CarouselTemplatesService();
+  const fixtures = {
+    slides: [
+      { type: 'cover', fields: { title: 'A hook' } },
+      { type: 'content', fields: { heading: 'H', body: 'B' } },
+    ] as Slide[],
+  };
+  return { service, fixtures };
+};
+
+describe('CarouselTemplatesService', () => {
+  let service: CarouselTemplatesService;
+  let fixtures: ReturnType<typeof makeService>['fixtures'];
+
+  beforeEach(() => {
+    ({ service, fixtures } = makeService());
+  });
+
+  describe('onModuleInit', () => {
+    it('should compile the real template set without throwing', () => {
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+  });
+
+  describe('assembleHtml', () => {
+    it('should assemble a document once templates are loaded', () => {
+      service.onModuleInit();
+
+      const html = service.assembleHtml('bold', fixtures.slides);
+
+      expect(html.startsWith('<!doctype html>')).toBe(true);
+      expect(html).toContain('<section class="slide slide--cover">');
+      expect(html).toContain('<section class="slide slide--content">');
+    });
+
+    it('should throw when called before templates are loaded', () => {
+      expect(() => service.assembleHtml('bold', fixtures.slides)).toThrow(
+        /not been loaded/i,
+      );
+    });
+  });
+});

--- a/src/carousel/carousel-templates.service.ts
+++ b/src/carousel/carousel-templates.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Slide } from './schemas';
+import {
+  CarouselThemeId,
+  CompiledCarouselTemplates,
+  loadCarouselTemplates,
+} from './templates';
+
+/**
+ * Owns the compiled carousel templates. Compilation runs once at module init
+ * and **fails the boot loudly** if any template is missing, fails to compile,
+ * or contains banned unescaped-output syntax — turning the security rule into a
+ * boot invariant rather than a review checkpoint. `T10`'s renderer injects this
+ * for the pure `assembleHtml` half of its pipeline.
+ */
+@Injectable()
+export class CarouselTemplatesService implements OnModuleInit {
+  private readonly logger = new Logger(CarouselTemplatesService.name);
+  private templates?: CompiledCarouselTemplates;
+
+  onModuleInit(): void {
+    this.templates = loadCarouselTemplates();
+    this.logger.log('Carousel templates compiled');
+  }
+
+  assembleHtml(theme: CarouselThemeId, slides: Slide[]): string {
+    if (!this.templates) {
+      throw new Error('Carousel templates have not been loaded');
+    }
+    return this.templates.assembleHtml(theme, slides);
+  }
+}

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CarouselTemplatesService } from './carousel-templates.service';
+
+@Module({
+  providers: [CarouselTemplatesService],
+  exports: [CarouselTemplatesService],
+})
+export class CarouselModule {}

--- a/src/carousel/index.ts
+++ b/src/carousel/index.ts
@@ -1,0 +1,4 @@
+export * from './schemas';
+export * from './templates';
+export * from './carousel-templates.service';
+export * from './carousel.module';

--- a/src/carousel/schemas.spec.ts
+++ b/src/carousel/schemas.spec.ts
@@ -1,0 +1,145 @@
+import { slideFieldSchemas, slideSchema, slidesSchema } from './schemas';
+
+describe('carousel schemas', () => {
+  describe('slideFieldSchemas.cover', () => {
+    it('should accept a title-only cover with the optional fields absent', () => {
+      expect(slideFieldSchemas.cover.safeParse({ title: 'Hook' }).success).toBe(
+        true,
+      );
+    });
+
+    it('should reject a cover with no title', () => {
+      expect(slideFieldSchemas.cover.safeParse({}).success).toBe(false);
+    });
+
+    it('should reject a title over the 70-character cap', () => {
+      expect(
+        slideFieldSchemas.cover.safeParse({ title: 'a'.repeat(71) }).success,
+      ).toBe(false);
+    });
+
+    it('should accept a title at exactly the 70-character cap', () => {
+      expect(
+        slideFieldSchemas.cover.safeParse({ title: 'a'.repeat(70) }).success,
+      ).toBe(true);
+    });
+
+    it('should reject a whitespace-only title (trim then min 1)', () => {
+      expect(slideFieldSchemas.cover.safeParse({ title: '   ' }).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('slideFieldSchemas.content', () => {
+    it('should reject a body over the 280-character cap', () => {
+      expect(
+        slideFieldSchemas.content.safeParse({
+          heading: 'Heading',
+          body: 'a'.repeat(281),
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe('slideFieldSchemas.list', () => {
+    it('should reject fewer than 2 items', () => {
+      expect(
+        slideFieldSchemas.list.safeParse({ heading: 'H', items: ['one'] })
+          .success,
+      ).toBe(false);
+    });
+
+    it('should reject more than 6 items', () => {
+      expect(
+        slideFieldSchemas.list.safeParse({
+          heading: 'H',
+          items: ['1', '2', '3', '4', '5', '6', '7'],
+        }).success,
+      ).toBe(false);
+    });
+
+    it('should reject an item over the 80-character cap', () => {
+      expect(
+        slideFieldSchemas.list.safeParse({
+          heading: 'H',
+          items: ['ok', 'a'.repeat(81)],
+        }).success,
+      ).toBe(false);
+    });
+
+    it('should accept 2-6 items each within the cap', () => {
+      expect(
+        slideFieldSchemas.list.safeParse({
+          heading: 'H',
+          items: ['one', 'two', 'three'],
+        }).success,
+      ).toBe(true);
+    });
+  });
+
+  describe('slideFieldSchemas.quote', () => {
+    it('should reject a quote over the 200-character cap', () => {
+      expect(
+        slideFieldSchemas.quote.safeParse({ quote: 'a'.repeat(201) }).success,
+      ).toBe(false);
+    });
+
+    it('should accept a quote with no attribution', () => {
+      expect(
+        slideFieldSchemas.quote.safeParse({ quote: 'Words' }).success,
+      ).toBe(true);
+    });
+  });
+
+  describe('slideFieldSchemas.cta', () => {
+    it('should require headline and action', () => {
+      expect(
+        slideFieldSchemas.cta.safeParse({ headline: 'Follow' }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe('slideSchema', () => {
+    it('should narrow fields to the arm named by type', () => {
+      const parsed = slideSchema.parse({
+        type: 'quote',
+        fields: { quote: 'A pull quote' },
+      });
+      expect(parsed.type).toBe('quote');
+    });
+
+    it('should reject an unknown slide type', () => {
+      expect(slideSchema.safeParse({ type: 'image', fields: {} }).success).toBe(
+        false,
+      );
+    });
+
+    it("should reject a cover carrying another arm's fields", () => {
+      expect(
+        slideSchema.safeParse({ type: 'cover', fields: { quote: 'x' } })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  describe('slidesSchema', () => {
+    const slide = { type: 'content', fields: { heading: 'H', body: 'B' } };
+
+    it('should reject a single-slide deck', () => {
+      expect(slidesSchema.safeParse([slide]).success).toBe(false);
+    });
+
+    it('should reject a deck over 15 slides', () => {
+      expect(
+        slidesSchema.safeParse(Array.from({ length: 16 }, () => slide)).success,
+      ).toBe(false);
+    });
+
+    it('should accept a deck of 2-15 slides', () => {
+      expect(
+        slidesSchema.safeParse(Array.from({ length: 15 }, () => slide)).success,
+      ).toBe(true);
+    });
+  });
+});

--- a/src/carousel/schemas.ts
+++ b/src/carousel/schemas.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+/**
+ * A carousel slide's *role* on the deck. Distinct from the deck-level
+ * `CarouselTheme` (its look, in `src/database/schemas`): a real carousel is a
+ * cover (the hook), body slides, and a call to action — visually different
+ * roles — all rendered in one consistent theme.
+ */
+export const slideTypes = ['cover', 'content', 'list', 'quote', 'cta'] as const;
+
+export type SlideType = (typeof slideTypes)[number];
+
+/**
+ * A trimmed, non-empty string capped at `n` characters. The cap is a *fit*
+ * contract: a 1080x1350 slide has no scroll, so `n` is sized to the tightest
+ * theme. It is only a proxy for rendered width, hence enforced three ways
+ * (prompt, this Zod cap, and the template frame's `overflow: hidden`).
+ */
+const cap = (n: number) => z.string().trim().min(1).max(n);
+
+/**
+ * Field schemas attach to the slide *type*, not the theme: every theme renders
+ * the same five typed shapes and differs only in look. This is the single Zod
+ * contract that serves the artifact content union, the agent's generation
+ * contract, and all four themes at once — so it must stay uniform.
+ */
+export const slideFieldSchemas = {
+  cover: z.object({
+    eyebrow: cap(24).optional(),
+    title: cap(70),
+    subtitle: cap(120).optional(),
+  }),
+  content: z.object({
+    heading: cap(60),
+    body: cap(280),
+  }),
+  list: z.object({
+    heading: cap(60),
+    items: z.array(cap(80)).min(2).max(6),
+  }),
+  quote: z.object({
+    quote: cap(200),
+    attribution: cap(48).optional(),
+  }),
+  cta: z.object({
+    headline: cap(70),
+    action: cap(40),
+    handle: cap(40).optional(),
+  }),
+} as const;
+
+/**
+ * Discriminated on `type` so a future `image` arm touches no existing one, and
+ * so a slide's fields are narrowed to exactly its role's shape.
+ */
+export const slideSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('cover'), fields: slideFieldSchemas.cover }),
+  z.object({ type: z.literal('content'), fields: slideFieldSchemas.content }),
+  z.object({ type: z.literal('list'), fields: slideFieldSchemas.list }),
+  z.object({ type: z.literal('quote'), fields: slideFieldSchemas.quote }),
+  z.object({ type: z.literal('cta'), fields: slideFieldSchemas.cta }),
+]);
+
+export type Slide = z.infer<typeof slideSchema>;
+
+/** A deck is 2-15 slides; one HTML document, one page per slide. */
+export const slidesSchema = z.array(slideSchema).min(2).max(15);
+
+export type Slides = z.infer<typeof slidesSchema>;

--- a/src/carousel/templates.spec.ts
+++ b/src/carousel/templates.spec.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { slidesSchema, Slide } from './schemas';
+import {
+  CarouselThemeId,
+  carouselThemes,
+  carouselTemplateRegistry,
+  loadCarouselTemplates,
+} from './templates';
+
+const ASSETS_ROOT = join(process.cwd(), 'assets/carousel');
+
+function loadFixture(theme: string): Slide[] {
+  const raw = readFileSync(
+    join(ASSETS_ROOT, 'templates', theme, 'fixture.json'),
+    'utf-8',
+  );
+  const parsed = JSON.parse(raw) as { theme: string; slides: unknown };
+  // The fixture is only trustworthy as a fit proof if it satisfies the caps.
+  return slidesSchema.parse(parsed.slides);
+}
+
+describe('carouselTemplateRegistry', () => {
+  it('maps every theme x slide type to a .hbs file', () => {
+    for (const theme of carouselThemes) {
+      const set = carouselTemplateRegistry[theme];
+      for (const file of Object.values(set)) {
+        expect(file.endsWith('.hbs')).toBe(true);
+      }
+    }
+    // 4 themes x 5 slide types
+    expect(carouselThemes.length).toBe(4);
+  });
+});
+
+describe('loadCarouselTemplates', () => {
+  // A minimal asset root the loader reaches `bold/cover.hbs` in — enough to
+  // exercise each fail-fast branch on a single crafted template.
+  const makeRootWithCover = (label: string, coverSource?: string): string => {
+    const root = mkdtempSync(join(tmpdir(), `carousel-${label}-`));
+    writeFileSync(join(root, 'base.css'), '.slide{}');
+    mkdirSync(join(root, 'templates', 'bold'), { recursive: true });
+    writeFileSync(join(root, 'templates', 'bold', 'theme.css'), '');
+    if (coverSource !== undefined) {
+      writeFileSync(join(root, 'templates', 'bold', 'cover.hbs'), coverSource);
+    }
+    return root;
+  };
+
+  it('compiles the real asset set without throwing', () => {
+    expect(() => loadCarouselTemplates()).not.toThrow();
+  });
+
+  it('throws when the assets root is missing', () => {
+    expect(() =>
+      loadCarouselTemplates('/definitely/not/a/real/carousel/root'),
+    ).toThrow(/missing or unreadable/i);
+  });
+
+  it('throws when a template file is missing', () => {
+    // cover.hbs absent — the first template the loader reaches
+    const root = makeRootWithCover('missing');
+    expect(() => loadCarouselTemplates(root)).toThrow(/missing or unreadable/i);
+  });
+
+  it('throws when a template contains a banned triple-stache', () => {
+    const root = makeRootWithCover('triple', '<h1>{{{title}}}</h1>');
+    expect(() => loadCarouselTemplates(root)).toThrow(/unescaped-output/i);
+  });
+
+  it('throws when a template contains the {{& }} unescaped form', () => {
+    const root = makeRootWithCover('amp', '<h1>{{& title}}</h1>');
+    expect(() => loadCarouselTemplates(root)).toThrow(/unescaped-output/i);
+  });
+
+  it('throws when a template fails to compile', () => {
+    const root = makeRootWithCover('badhbs', '{{#if title}}unterminated');
+    expect(() => loadCarouselTemplates(root)).toThrow(/failed to compile/i);
+  });
+});
+
+describe('assembleHtml', () => {
+  const templates = loadCarouselTemplates();
+
+  it.each(carouselThemes)(
+    'assembles the %s fixture deck cleanly',
+    (theme: CarouselThemeId) => {
+      const slides = loadFixture(theme);
+      const html = templates.assembleHtml(theme, slides);
+
+      // one <section> per slide, in order
+      const sections = html.match(/<section class="slide slide--/g) ?? [];
+      expect(sections.length).toBe(slides.length);
+      expect(slides.length).toBe(15);
+
+      // a complete, single document
+      expect(html.startsWith('<!doctype html>')).toBe(true);
+      expect(html.trimEnd().endsWith('</html>')).toBe(true);
+
+      // every template placeholder was applied — no stray handlebars left
+      expect(html).not.toMatch(/\{\{/);
+
+      // the load-bearing frame and last-child override are inlined
+      expect(html).toContain('break-after: page');
+      expect(html).toContain('.slide:last-child');
+
+      // self-contained: nothing to fetch over the network
+      expect(html).not.toMatch(/\bsrc=/);
+      expect(html).not.toMatch(/<link\b/);
+      expect(html).not.toMatch(/@import/);
+    },
+  );
+
+  it('HTML-escapes untrusted field content', () => {
+    const slides: Slide[] = [
+      {
+        type: 'content',
+        fields: { heading: 'Safe', body: '<script>alert(1)</script> & "x"' },
+      },
+      { type: 'content', fields: { heading: 'H2', body: 'B2' } },
+    ];
+    const html = loadCarouselTemplates().assembleHtml('bold', slides);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&amp;');
+  });
+
+  it('throws on an unknown slide type', () => {
+    const slides = [{ type: 'image', fields: {} }] as unknown as Slide[];
+    expect(() => loadCarouselTemplates().assembleHtml('bold', slides)).toThrow(
+      /No carousel template/i,
+    );
+  });
+
+  it('throws on an unknown theme', () => {
+    expect(() =>
+      loadCarouselTemplates().assembleHtml('neon' as CarouselThemeId, []),
+    ).toThrow(/Unknown carousel theme/i);
+  });
+});

--- a/src/carousel/templates.ts
+++ b/src/carousel/templates.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Handlebars from 'handlebars';
+import type { CarouselTheme } from '../database/schemas';
+import { Slide, SlideType, slideTypes } from './schemas';
+
+/**
+ * A deck theme as its string value. Typed off the DB `CarouselTheme` enum but
+ * as a **type-only** reference, so this pure, browserless-free module never
+ * pulls the mongoose layer into its runtime (or its tests). A string-enum
+ * member is assignable to its value, so callers holding the DB enum pass
+ * straight through.
+ */
+export type CarouselThemeId = `${CarouselTheme}`;
+
+/** Every carousel theme. The compile-time check below fails if this drifts
+ *  from the DB enum — add a theme in both places or neither. */
+export const carouselThemes = [
+  'bold',
+  'minimal',
+  'editorial',
+  'gradient',
+] as const satisfies readonly CarouselThemeId[];
+
+type AssertEqual<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false;
+// Compile error if `carouselThemes` and the DB `CarouselTheme` enum diverge.
+const _themesMatchEnum: AssertEqual<
+  (typeof carouselThemes)[number],
+  CarouselThemeId
+> = true;
+void _themesMatchEnum;
+
+/**
+ * Typed registry mapping (theme x slide type) -> template filename, relative to
+ * `assets/carousel/`. The registry deliberately carries no schemas — keying
+ * those by theme would invite per-theme divergence of a contract that must stay
+ * uniform. Adding a theme later is a new folder plus these entries.
+ */
+export type CarouselTemplateRegistry = Record<
+  CarouselThemeId,
+  Record<SlideType, `${string}.hbs`>
+>;
+
+export const carouselTemplateRegistry: CarouselTemplateRegistry =
+  carouselThemes.reduce((registry, theme) => {
+    registry[theme] = slideTypes.reduce(
+      (set, type) => {
+        set[type] = `templates/${theme}/${type}.hbs`;
+        return set;
+      },
+      {} as Record<SlideType, `${string}.hbs`>,
+    );
+    return registry;
+  }, {} as CarouselTemplateRegistry);
+
+/**
+ * Unescaped-output syntax is banned outright: triple-stache `{{{ }}}` and the
+ * `{{& }}` ampersand form both bypass HTML escaping, and every slide field is
+ * untrusted LLM text. Enforced at boot so the rule cannot erode as templates
+ * are added.
+ */
+const UNESCAPED_OUTPUT = /\{\{(\{|\s*&)/;
+
+const DEFAULT_ASSETS_ROOT = join(process.cwd(), 'assets/carousel');
+
+const key = (theme: CarouselThemeId, type: SlideType) => `${theme}:${type}`;
+
+export interface CompiledCarouselTemplates {
+  /**
+   * Pure, no I/O: apply each precompiled template to `slide.fields`, wrap in a
+   * `.slide` section, and concatenate in order inside one self-contained
+   * document whose `<head>` inlines `base.css` + the theme's `theme.css`.
+   * Resolves zero network requests so Browserless has nothing to fetch.
+   */
+  assembleHtml(theme: CarouselThemeId, slides: Slide[]): string;
+}
+
+function readAsset(root: string, relativePath: string, label: string): string {
+  try {
+    return readFileSync(join(root, relativePath), 'utf-8');
+  } catch (error) {
+    throw new Error(
+      `Carousel asset missing or unreadable: ${label} (${relativePath}) — ${(error as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Load and compile every `(theme, slide type)` template once, failing fast if
+ * any file is missing, fails to compile, or contains unescaped-output syntax.
+ * An isolated Handlebars environment is used so no globally registered helper
+ * can leak a `SafeString` into a slide.
+ */
+export function loadCarouselTemplates(
+  assetsRoot: string = DEFAULT_ASSETS_ROOT,
+): CompiledCarouselTemplates {
+  const handlebars = Handlebars.create();
+
+  const baseCss = readAsset(assetsRoot, 'base.css', 'base.css');
+  const themeCss = new Map<CarouselThemeId, string>();
+  const compiled = new Map<string, Handlebars.TemplateDelegate>();
+
+  for (const theme of carouselThemes) {
+    themeCss.set(
+      theme,
+      readAsset(
+        assetsRoot,
+        `templates/${theme}/theme.css`,
+        `${theme}/theme.css`,
+      ),
+    );
+
+    for (const type of slideTypes) {
+      const relativePath = carouselTemplateRegistry[theme][type];
+      const label = `${theme}/${type}.hbs`;
+      const source = readAsset(assetsRoot, relativePath, label);
+
+      if (UNESCAPED_OUTPUT.test(source)) {
+        throw new Error(
+          `Carousel template ${label} uses banned unescaped-output syntax ({{{ }}} or {{& }}); slide fields are untrusted LLM text and must be HTML-escaped`,
+        );
+      }
+
+      try {
+        // Force a parse now so a syntax error surfaces at boot, not first render.
+        handlebars.precompile(source);
+        compiled.set(key(theme, type), handlebars.compile(source));
+      } catch (error) {
+        throw new Error(
+          `Carousel template ${label} failed to compile: ${(error as Error).message}`,
+        );
+      }
+    }
+  }
+
+  return {
+    assembleHtml(theme, slides) {
+      if (!themeCss.has(theme)) {
+        throw new Error(`Unknown carousel theme: ${theme}`);
+      }
+
+      const sections = slides.map((slide) => {
+        const template = compiled.get(key(theme, slide.type));
+        if (!template) {
+          throw new Error(`No carousel template for ${theme}/${slide.type}`);
+        }
+        // `slide.type` is a controlled enum value — safe in the class name.
+        return `<section class="slide slide--${slide.type}">${template(
+          slide.fields,
+        )}</section>`;
+      });
+
+      const css = `${baseCss}\n${themeCss.get(theme) ?? ''}`;
+
+      return [
+        '<!doctype html>',
+        '<html lang="en">',
+        '<head>',
+        '<meta charset="utf-8">',
+        `<style>${css}</style>`,
+        '</head>',
+        `<body>${sections.join('')}</body>`,
+        '</html>',
+      ].join('');
+    },
+  };
+}


### PR DESCRIPTION
T9 — the carousel template system. New `src/carousel/` module and
`assets/carousel/` asset tree, mirroring the mail-template idiom.

- **`schemas.ts`** — single Zod source of truth: `slideFieldSchemas`
  (cover/content/list/quote/cta with the PRD §8 caps), `slideSchema`
  (discriminated union on `type`), `slidesSchema` (2–15 slides).
- **`templates.ts`** — typed theme×slide-type registry + `loadCarouselTemplates`,
  a boot-time Handlebars compile that **fails fast** on a missing file, a compile
  error, or any unescaped-output syntax (`{{{…}}}` and the `{{&…}}` form), plus a
  pure `assembleHtml` that inlines `base.css` + the theme's `theme.css` into one
  self-contained, zero-network document.
- **`carousel-templates.service.ts` / `carousel.module.ts` / `index.ts`** — the
  injectable runs the fail-fast compile at `onModuleInit`.
- **Assets** — `base.css` with the load-bearing `.slide` frame and
  `:last-child { break-after: auto }`; 4 themes × 5 slide types = 20 `.hbs`
  + 4 `theme.css` + 4 `fixture.json`, each 15 slides at max field lengths with a
  6-item list, an emoji, and a long unbroken token (the fit proof).

The pure module keeps mongoose out of its runtime: `CarouselTheme` is referenced
type-only, with a local runtime tuple guarded by a compile-time equality
assertion against the enum.

Verified: 36 carousel tests pass, full suite green, `nest build` and eslint clean.
Two-axis code review (Standards + Spec) run and findings addressed. The PDF render
(`RENDER_PDF`, `CarouselRendererService`, `CarouselModule` wiring) is T10, out of
scope here.

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)