### PR TITLE
feat: complete DOCUMENT artifacts end to end (#122)

### DIFF
--- a/src/agent/agent-runner.service.spec.ts
+++ b/src/agent/agent-runner.service.spec.ts
@@ -7,7 +7,12 @@ jest.mock(
   'src/database/schemas',
   () => ({
     ArtifactType: { POST: 'POST', POLL: 'POLL', DOCUMENT: 'DOCUMENT' },
-    CarouselTheme: { MINIMAL: 'minimal' },
+    CarouselTheme: {
+      BOLD: 'bold',
+      MINIMAL: 'minimal',
+      EDITORIAL: 'editorial',
+      GRADIENT: 'gradient',
+    },
   }),
   { virtual: true },
 );
@@ -322,15 +327,75 @@ describe('AgentRunnerService', () => {
       );
     });
 
-    it('should throw when no generation prompt exists for the artifact type', async () => {
-      await expect(
-        service.generate({
-          ...fixtures.input,
-          type: ArtifactType.DOCUMENT,
+    describe('DOCUMENT generation', () => {
+      // A valid slides-only deck the model returns; templateId varies per test.
+      const deckJson = (templateId: string) =>
+        JSON.stringify({
+          document: {
+            templateId,
+            slides: [
+              { type: 'cover', fields: { title: 'A carousel' } },
+              { type: 'content', fields: { heading: 'One', body: 'A point' } },
+            ],
+          },
+        });
+
+      const documentInput: GenerateInput = {
+        type: ArtifactType.DOCUMENT,
+        prompt: 'A carousel on staff engineering',
+      };
+
+      it('should parse and return the document deck the model produces', async () => {
+        mocks.llmService.complete.mockResolvedValue(
+          completion(deckJson('editorial')),
+        );
+
+        const content = await service.generate(documentInput);
+
+        expect(content).toMatchObject({
+          document: { templateId: 'editorial' },
+        });
+        expect(mocks.llmService.complete).toHaveBeenCalledTimes(1);
+      });
+
+      it('should keep the model-chosen theme when the user supplied none', async () => {
+        mocks.llmService.complete.mockResolvedValue(
+          completion(deckJson('gradient')),
+        );
+
+        const content = await service.generate(documentInput);
+
+        expect(content).toMatchObject({ document: { templateId: 'gradient' } });
+      });
+
+      it('should stamp the user-supplied theme over a different one the model picked', async () => {
+        // The model tries to pick "bold"; the user asked for "minimal".
+        mocks.llmService.complete.mockResolvedValue(
+          completion(deckJson('bold')),
+        );
+
+        const content = await service.generate({
+          ...documentInput,
           theme: CarouselTheme.MINIMAL,
-        }),
-      ).rejects.toThrow('DOCUMENT');
-      expect(mocks.llmService.complete).not.toHaveBeenCalled();
+        });
+
+        expect(content).toMatchObject({ document: { templateId: 'minimal' } });
+      });
+
+      it('should instruct the model to use the stamped theme in the user prompt', async () => {
+        mocks.llmService.complete.mockResolvedValue(
+          completion(deckJson('minimal')),
+        );
+
+        await service.generate({
+          ...documentInput,
+          theme: CarouselTheme.MINIMAL,
+        });
+
+        const [, user] = messagesOfCall(1);
+        expect(user.content).toContain('THEME:');
+        expect(user.content).toContain('minimal');
+      });
     });
   });
 

--- a/src/agent/agent-runner.service.ts
+++ b/src/agent/agent-runner.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ArtifactType } from 'src/database/schemas';
 import { ArtifactContent, contentSchemaFor } from '../artifact/schemas';
 import { LLMProvider, MessageRole } from '../llm/interfaces';
 import type {
@@ -236,7 +237,7 @@ export class AgentRunnerService implements AgentRunner {
 
     let validationError: unknown;
     try {
-      return this.parser.parseWithSchema(draft, schema);
+      return this.stampTheme(this.parser.parseWithSchema(draft, schema), input);
     } catch (error: unknown) {
       validationError = error;
     }
@@ -258,13 +259,40 @@ export class AgentRunnerService implements AgentRunner {
     );
 
     try {
-      return this.parser.parseWithSchema(repaired, schema);
+      return this.stampTheme(
+        this.parser.parseWithSchema(repaired, schema),
+        input,
+      );
     } catch (error: unknown) {
       throw new ContentValidationError(
         `Generated ${input.type} content failed validation after one repair retry: ${describeError(error)}`,
         { cause: error },
       );
     }
+  }
+
+  /**
+   * A user-supplied `theme` is authoritative: it overrides whatever templateId
+   * the model chose, so a document keeps the user's chosen look across the
+   * initial run and every later refine (R4). Applied after validation, so it is
+   * a stamp over already-valid content — not a chance to sneak a bad theme past
+   * Zod. With no theme, the model's own validated pick stands.
+   */
+  private stampTheme(
+    content: ArtifactContent,
+    input: GenerateInput,
+  ): ArtifactContent {
+    if (
+      input.type !== ArtifactType.DOCUMENT ||
+      !input.theme ||
+      !('document' in content)
+    ) {
+      return content;
+    }
+    return {
+      ...content,
+      document: { ...content.document, templateId: input.theme },
+    };
   }
 
   /**

--- a/src/agent/prompts/artifact-generation.prompts.ts
+++ b/src/agent/prompts/artifact-generation.prompts.ts
@@ -68,12 +68,61 @@ CONSTRAINTS:
 - Avoid hype, clickbait, and leading questions. Prefer clarity over cleverness.
 - Do not mention the brief, the research, or that you are an AI.`;
 
+export const GENERATE_DOCUMENT_SYSTEM_PROMPT = `ROLE:
+You are a professional LinkedIn carousel designer. You produce a swipeable
+document (a deck of slides) that teaches one idea with clarity and momentum.
+
+TASK:
+Design one LinkedIn carousel from the brief the user supplies: an ordered deck of
+slides plus optional commentary that introduces the post.
+
+OUTPUT:
+Return ONLY a JSON object matching this shape, with no prose, commentary, or
+markdown fences around it:
+
+{ "commentary": "optional intro text", "document": { "templateId": "minimal", "slides": [ { "type": "cover", "fields": { "title": "..." } } ] } }
+
+"commentary" is optional — omit the key entirely if the post needs no intro.
+Newlines inside any string must be escaped as \\n, and the whole object must be
+valid JSON.
+
+DECK:
+- "slides" must hold 2 to 15 slides. One slide is one page — never pack two ideas
+  onto one slide to fit the count.
+- Open with a "cover" slide (the hook) and close with a "cta" slide (the ask).
+- Each slide is { "type": <role>, "fields": {...} }. The role fixes which fields
+  are allowed. Every character cap below is a hard fit limit — a slide does not
+  scroll, so exceeding it is a rejection, not a truncation.
+
+SLIDE ROLES AND FIELDS:
+- "cover":   { "title": <=70; "eyebrow"?: <=24; "subtitle"?: <=120 }
+- "content": { "heading": <=60; "body": <=280 }
+- "list":    { "heading": <=60; "items": 2-6 strings, each <=80 }
+- "quote":   { "quote": <=200; "attribution"?: <=48 }
+- "cta":     { "headline": <=70; "action": <=40; "handle"?: <=40 }
+
+THEME:
+- "templateId" is the deck's visual theme, one of exactly: "bold", "minimal",
+  "editorial", "gradient". If the brief stamps a THEME, use that value exactly
+  and do not substitute another. Otherwise choose the one that best fits the
+  topic and tone.
+- The theme is only the look. A VOICE instruction, if supplied, shapes the words
+  independently — follow it as the highest-priority guidance for tone.
+
+CONSTRAINTS:
+- If RESEARCH FINDINGS are supplied, ground every factual claim in them and
+  introduce no facts they do not support. If absent, rely on the brief and
+  general domain reasoning, and make no unsupported claims.
+- Do NOT use emojis anywhere in the slides — the rendered PDF cannot be trusted
+  to carry a color emoji font. Commentary may use them sparingly.
+- Do not include "pdfKey" or "pageCount" — those are added after rendering.
+- Avoid hype and filler. Prefer clarity over cleverness.
+- Do not mention the brief, the research, or that you are an AI.`;
+
 /**
  * A switch rather than a module-scope lookup table: the enum is read when a
  * prompt is asked for, not when this module loads, so importing it never
  * depends on the schema barrel having been fully evaluated.
- *
- * DOCUMENT arrives with its own slice.
  */
 export function generationSystemPrompt(type: ArtifactType): string {
   switch (type) {
@@ -81,9 +130,13 @@ export function generationSystemPrompt(type: ArtifactType): string {
       return GENERATE_POST_SYSTEM_PROMPT;
     case ArtifactType.POLL:
       return GENERATE_POLL_SYSTEM_PROMPT;
+    case ArtifactType.DOCUMENT:
+      return GENERATE_DOCUMENT_SYSTEM_PROMPT;
     default:
+      // Exhaustive today; kept as a runtime net for a future ArtifactType. The
+      // cast placates the type-narrowed-to-never template check.
       throw new Error(
-        `No generation prompt implemented for artifact type ${type}`,
+        `No generation prompt implemented for artifact type ${String(type)}`,
       );
   }
 }
@@ -98,6 +151,14 @@ export function buildGenerationUserPrompt(input: GenerateInput): string {
   const voice = resolveStylePresetInstruction(input.stylePreset);
   if (voice) sections.push(`VOICE:\n${voice}`);
 
+  // A user-stamped deck theme is authoritative — the model is told to use it
+  // verbatim (and GENERATE re-stamps it after validation as the real guarantee).
+  if (input.theme) {
+    sections.push(
+      `THEME:\nUse exactly this deck theme (templateId): "${input.theme}". Do not choose a different one.`,
+    );
+  }
+
   if (input.research) {
     sections.push(`RESEARCH FINDINGS:\n${input.research.findings}`);
     if (input.research.sources.length > 0) {
@@ -111,7 +172,7 @@ export function buildGenerationUserPrompt(input: GenerateInput): string {
   if (input.refine) {
     sections.push(
       `PREVIOUS VERSION:\n${JSON.stringify(input.refine.priorContent)}`,
-      `REVISION FEEDBACK:\n${input.refine.feedback}\n\nRewrite the post to address the feedback. Keep what the feedback does not ask you to change.`,
+      `REVISION FEEDBACK:\n${input.refine.feedback}\n\nRewrite it to address the feedback. Keep what the feedback does not ask you to change.`,
     );
   }
 

--- a/src/artifact/artifact.service.spec.ts
+++ b/src/artifact/artifact.service.spec.ts
@@ -19,8 +19,13 @@ jest.mock(
 );
 
 import { Types } from 'mongoose';
-import { ArtifactType, VersionStatus } from 'src/database/schemas';
+import {
+  ArtifactType,
+  CarouselTheme,
+  VersionStatus,
+} from 'src/database/schemas';
 import { StylePreset } from '../agent/style-presets.config';
+import type { ArtifactContent } from './schemas';
 import { ArtifactService } from './artifact.service';
 
 const makeService = () => {
@@ -103,6 +108,23 @@ describe('ArtifactService', () => {
       versions: [{ version: 1, status: VersionStatus.GENERATING, content: {} }],
     });
 
+    const generatingDocument = () => ({
+      _id: fixtures.artifactId,
+      type: ArtifactType.DOCUMENT,
+      versions: [{ version: 1, status: VersionStatus.GENERATING, content: {} }],
+    });
+
+    // The slides-only shape GENERATE writes into state.content — no pdfKey yet.
+    const slidesOnlyDocument = (): ArtifactContent => ({
+      document: {
+        templateId: CarouselTheme.MINIMAL,
+        slides: [
+          { type: 'cover', fields: { title: 'A carousel' } },
+          { type: 'content', fields: { heading: 'One', body: 'A point' } },
+        ],
+      },
+    });
+
     it('should validate the content and flip the version to READY when the version exists', async () => {
       mocks.artifactModel.findById.mockResolvedValue(generatingArtifact());
 
@@ -151,6 +173,51 @@ describe('ArtifactService', () => {
           },
         },
       );
+    });
+
+    it('should fold the render pdfKey and pageCount into the document before flipping READY', async () => {
+      mocks.artifactModel.findById.mockResolvedValue(generatingDocument());
+
+      await service.setVersionContent(
+        fixtures.artifactId,
+        1,
+        slidesOnlyDocument(),
+        { pdfKey: 'artifacts/abc/1/document.pdf', pageCount: 2 },
+      );
+
+      expect(mocks.artifactModel.updateOne).toHaveBeenCalledWith(
+        { _id: fixtures.artifactId, 'versions.version': 1 },
+        {
+          $set: {
+            'versions.$.content': {
+              document: {
+                templateId: 'minimal',
+                slides: [
+                  { type: 'cover', fields: { title: 'A carousel' } },
+                  {
+                    type: 'content',
+                    fields: { heading: 'One', body: 'A point' },
+                  },
+                ],
+                pdfKey: 'artifacts/abc/1/document.pdf',
+                pageCount: 2,
+              },
+            },
+            'versions.$.status': VersionStatus.READY,
+          },
+        },
+      );
+    });
+
+    it('should refuse to flip a document READY when no render pdfKey has been produced', async () => {
+      mocks.artifactModel.findById.mockResolvedValue(generatingDocument());
+
+      // RENDER_PDF gates READY for documents; reaching PERSIST_VERSION without a
+      // render is a wiring bug, never a healthy state to persist.
+      await expect(
+        service.setVersionContent(fixtures.artifactId, 1, slidesOnlyDocument()),
+      ).rejects.toThrow(/pdfKey/i);
+      expect(mocks.artifactModel.updateOne).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException when the artifact does not exist', async () => {

--- a/src/artifact/artifact.service.ts
+++ b/src/artifact/artifact.service.ts
@@ -13,7 +13,11 @@ import {
   CurrentVersionRead,
   VersionRender,
 } from './artifact-writer.interface';
-import { ArtifactContent, parseArtifactContent } from './schemas';
+import {
+  ArtifactContent,
+  DocumentContent,
+  parseArtifactContent,
+} from './schemas';
 
 export interface CreateArtifactInput {
   type: ArtifactType;
@@ -60,10 +64,21 @@ export class ArtifactService implements ArtifactWriter {
       );
     }
 
-    // Folding render.pdfKey/pageCount into content.document arrives with the
-    // DOCUMENT arm (#122); the POST arm has no document object to fold into.
-    void render;
-    const parsed = parseArtifactContent(artifact.type, content);
+    // For a DOCUMENT, fold RENDER_PDF's derived output onto the slides-only
+    // content GENERATE produced; POST/POLL carry no document to fold into.
+    const folded = this.foldRender(artifact.type, content, render);
+    const parsed = parseArtifactContent(artifact.type, folded);
+
+    // RENDER_PDF is what gates READY for a document: without a rendered pdfKey the
+    // deck has no preview, so this flip would publish a half-built version.
+    if (
+      artifact.type === ArtifactType.DOCUMENT &&
+      !(parsed as DocumentContent).document.pdfKey
+    ) {
+      throw new Error(
+        `Cannot mark document ${artifactId} v${version} READY without a rendered pdfKey`,
+      );
+    }
 
     // The write targets the fixed (artifactId, version), so a whole-job retry
     // overwrites rather than appends.
@@ -120,6 +135,29 @@ export class ArtifactService implements ArtifactWriter {
       type: artifact.type,
       version: current.version,
       content: current.content as ArtifactContent,
+    };
+  }
+
+  /**
+   * Folds RENDER_PDF's `pdfKey`/`pageCount` onto a document's slides-only
+   * content. A no-op for POST/POLL (no document object) and for a document
+   * reached without a render (the gate below rejects that separately).
+   */
+  private foldRender(
+    type: ArtifactType,
+    content: ArtifactContent,
+    render?: VersionRender,
+  ): ArtifactContent {
+    if (type !== ArtifactType.DOCUMENT || !render || !('document' in content)) {
+      return content;
+    }
+    return {
+      ...content,
+      document: {
+        ...content.document,
+        pdfKey: render.pdfKey,
+        pageCount: render.pageCount,
+      },
     };
   }
 

--- a/src/artifact/schemas/artifact-content.schema.spec.ts
+++ b/src/artifact/schemas/artifact-content.schema.spec.ts
@@ -2,6 +2,12 @@ jest.mock(
   'src/database/schemas',
   () => ({
     ArtifactType: { POST: 'POST', POLL: 'POLL', DOCUMENT: 'DOCUMENT' },
+    CarouselTheme: {
+      BOLD: 'bold',
+      MINIMAL: 'minimal',
+      EDITORIAL: 'editorial',
+      GRADIENT: 'gradient',
+    },
   }),
   { virtual: true },
 );
@@ -308,11 +314,84 @@ describe('parseArtifactContent', () => {
     });
   });
 
-  describe('unimplemented arms', () => {
-    it('should throw when no content schema exists for the artifact type', () => {
+  describe('DOCUMENT arm', () => {
+    // The slides-only shape GENERATE emits: templateId + a valid deck, with no
+    // pdfKey/pageCount yet (those are RENDER_PDF's derived output).
+    const slidesOnlyDocument = () => ({
+      document: {
+        templateId: 'minimal',
+        slides: [
+          { type: 'cover', fields: { title: 'A carousel' } },
+          { type: 'content', fields: { heading: 'One', body: 'A point' } },
+        ],
+      },
+    });
+
+    it('should accept the slides-only document GENERATE emits', () => {
+      const content = slidesOnlyDocument();
+      expect(parseArtifactContent(ArtifactType.DOCUMENT, content)).toEqual(
+        content,
+      );
+    });
+
+    it('should accept optional framing commentary alongside the deck', () => {
+      const content = { commentary: 'A thread 🧵', ...slidesOnlyDocument() };
+      expect(parseArtifactContent(ArtifactType.DOCUMENT, content)).toEqual(
+        content,
+      );
+    });
+
+    it('should accept the folded form carrying pdfKey and pageCount', () => {
+      const base = slidesOnlyDocument();
+      const folded = {
+        document: {
+          ...base.document,
+          pdfKey: 'artifacts/abc/1/document.pdf',
+          pageCount: 2,
+        },
+      };
+      expect(parseArtifactContent(ArtifactType.DOCUMENT, folded)).toEqual(
+        folded,
+      );
+    });
+
+    it('should reject a templateId that is not a real CarouselTheme', () => {
+      const content = slidesOnlyDocument();
+      content.document.templateId = 'neon';
       expect(() =>
-        parseArtifactContent(ArtifactType.DOCUMENT, { commentary: 'x' }),
-      ).toThrow('No content schema implemented for artifact type DOCUMENT');
+        parseArtifactContent(ArtifactType.DOCUMENT, content),
+      ).toThrow(ZodError);
+    });
+
+    it('should reject a deck with fewer than two slides', () => {
+      const content = slidesOnlyDocument();
+      content.document.slides = [content.document.slides[0]];
+      expect(() =>
+        parseArtifactContent(ArtifactType.DOCUMENT, content),
+      ).toThrow(ZodError);
+    });
+
+    it('should reject a slide whose type is not a known slide role', () => {
+      const content = {
+        document: {
+          templateId: 'minimal',
+          slides: [
+            { type: 'cover', fields: { title: 'A carousel' } },
+            { type: 'banner', fields: { heading: 'One', body: 'A point' } },
+          ],
+        },
+      };
+      expect(() =>
+        parseArtifactContent(ArtifactType.DOCUMENT, content),
+      ).toThrow(ZodError);
+    });
+
+    it('should reject content that has no document object', () => {
+      expect(() =>
+        parseArtifactContent(ArtifactType.DOCUMENT, {
+          commentary: 'just text',
+        }),
+      ).toThrow(ZodError);
     });
   });
 });

--- a/src/artifact/schemas/artifact-content.schema.ts
+++ b/src/artifact/schemas/artifact-content.schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { ArtifactType } from 'src/database/schemas';
+import { ArtifactType, CarouselTheme } from 'src/database/schemas';
+import { slidesSchema } from '../../carousel/schemas';
 import { linkedInCharCount } from '../utils/linkedin-char-count.util';
 
 export const LINKEDIN_MAX_POST_CHARS = 3000;
@@ -73,15 +74,36 @@ export const pollContentSchema = z.object({
 
 export type PollContent = z.infer<typeof pollContentSchema>;
 
-// Discriminated on the artifact's family-level `type`; grows a DOCUMENT arm in a
-// later slice (#122).
-export type ArtifactContent = PostContent | PollContent;
+// DOCUMENT — a carousel deck, optionally introduced by commentary. `slides` is
+// the editable source of truth authored by GENERATE; the PDF is the disposable
+// derived output. `pdfKey`/`pageCount` are therefore optional here: GENERATE
+// emits the slides-only shape, and PERSIST_VERSION folds RENDER_PDF's output in.
+// `templateId` reuses the deck-level `CarouselTheme` (its look), distinct from
+// `stylePreset` (voice) which shapes the slide copy (R4). `slides` reuses the one
+// carousel Zod contract, so the union, the generation contract, and the four
+// themes validate the same shape.
+export const documentContentSchema = z.object({
+  commentary: commentarySchema.optional(),
+  document: z.object({
+    templateId: z.enum(CarouselTheme),
+    slides: slidesSchema,
+    pdfKey: z.string().min(1).optional(),
+    pageCount: z.number().int().positive().optional(),
+  }),
+});
+
+export type DocumentContent = z.infer<typeof documentContentSchema>;
+
+// Discriminated on the artifact's family-level `type`. POST/POLL carry text
+// only; DOCUMENT adds the derived-PDF-backed carousel deck.
+export type ArtifactContent = PostContent | PollContent | DocumentContent;
 
 const contentSchemaByType: Partial<
   Record<ArtifactType, z.ZodType<ArtifactContent>>
 > = {
   [ArtifactType.POST]: postContentSchema,
   [ArtifactType.POLL]: pollContentSchema,
+  [ArtifactType.DOCUMENT]: documentContentSchema,
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds the third artifact type: **DOCUMENT = POST/POLL + `RENDER_PDF`**. This wires the DOCUMENT arm through every remaining layer (T8 + T10 already landed the agent loop and `CarouselRendererService`/`RENDER_PDF`; the builder already inserted `RENDER_PDF` for `type === DOCUMENT`).

## What changed

- **`ArtifactContent` Zod union** gains a DOCUMENT arm: `{ commentary?, document: { templateId: z.enum(CarouselTheme), slides, pdfKey?, pageCount? } }`. `slides` reuses the single carousel Zod contract and is the editable source of truth; `pdfKey`/`pageCount` are optional because GENERATE emits the slides-only shape and RENDER_PDF's output is folded in later.
- **`generate()`** dispatches on DOCUMENT via a new system prompt and stamps a user-supplied `theme` **authoritatively onto `document.templateId` after validation** (both first-pass and repair paths), so a model that picks a different theme cannot win (R4 — reads `theme`, not `stylePreset`; voice still shapes slide copy independently). A test proves a user `minimal` overrides a model-picked `bold`.
- **`setVersionContent`** folds `render.pdfKey` + `pageCount` into `content.document`, and gates the READY flip on a document actually carrying a rendered `pdfKey` (POST/POLL still reach READY at PERSIST_VERSION with no render).
- **DOCUMENT generation prompt**: the slides contract, the four themes, and an emoji ban (the Browserless image's color-emoji font is unverified — a conservative pre-QA default).

## Testing

- Typecheck clean (only the two known pre-existing auth spec errors remain).
- Lint clean (one pre-existing `as any` warning).
- Full unit suite **628/628** (+11 new).
- Two-axis `/code-review` since the epic base: passed with no blockers.

## Notes

- The **Manual QA gate** in the ticket (render the four fixture decks; verify 15-page pagination + emoji rendering) is a human task, not code.
- "A refine keeps the theme" currently rests on persistence + the prior-content prompt echo; there is no REFINE **launch** path in the repo yet (only `launchInitialRun`) — a separate slice, outside #122.

Closes #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)