### PR TITLE
feat: add artifact refine runs (#123)

### DIFF
--- a/src/artifact/artifact-generation.service.spec.ts
+++ b/src/artifact/artifact-generation.service.spec.ts
@@ -42,6 +42,12 @@ describe('ArtifactGenerationService', () => {
   const makeService = () => {
     const artifactService = {
       createArtifact: jest.fn().mockResolvedValue({ _id: 'artifact123' }),
+      appendRefineVersion: jest.fn().mockResolvedValue({
+        version: 2,
+        type: 'POST',
+        prompt: 'why staff engineers write',
+        withResearch: true,
+      }),
     };
     const workflowRunService = {
       createRun: jest.fn().mockResolvedValue({ _id: 'run123' }),
@@ -175,6 +181,109 @@ describe('ArtifactGenerationService', () => {
         'run123',
         storedInput,
       );
+    });
+  });
+
+  describe('launchRefineRun', () => {
+    it('should return the artifactId, new version, and runId when the refine run is launched', async () => {
+      await expect(
+        service.launchRefineRun(
+          'user123',
+          'artifact123',
+          'Make the hook sharper',
+        ),
+      ).resolves.toEqual({
+        artifactId: 'artifact123',
+        version: 2,
+        runId: 'run123',
+      });
+    });
+
+    it('should assert balance before appending the new version when launching a refine', async () => {
+      const order: string[] = [];
+      mocks.creditMeter.assertBalance.mockImplementation(() => {
+        order.push('assertBalance');
+        return Promise.resolve();
+      });
+      mocks.artifactService.appendRefineVersion.mockImplementation(() => {
+        order.push('appendRefineVersion');
+        return Promise.resolve({
+          version: 2,
+          type: ArtifactType.POST,
+          prompt: 'why staff engineers write',
+          withResearch: true,
+        });
+      });
+
+      await service.launchRefineRun(
+        'user123',
+        'artifact123',
+        'Make the hook sharper',
+      );
+
+      expect(order).toEqual(['assertBalance', 'appendRefineVersion']);
+      expect(mocks.creditMeter.assertBalance).toHaveBeenCalledWith('user123');
+      expect(mocks.artifactService.appendRefineVersion).toHaveBeenCalledWith(
+        'user123',
+        'artifact123',
+        'Make the hook sharper',
+      );
+    });
+
+    it('should persist and enqueue a REFINE run when the version is appended', async () => {
+      mocks.artifactService.appendRefineVersion.mockResolvedValue({
+        version: 3,
+        type: ArtifactType.DOCUMENT,
+        prompt: 'deep modules',
+        withResearch: true,
+        stylePreset: 'educational',
+        theme: 'minimal',
+      });
+
+      await service.launchRefineRun(
+        'user123',
+        'artifact123',
+        'Use a more concrete example',
+      );
+
+      expect(mocks.workflowRunService.createRun).toHaveBeenCalledWith({
+        userId: 'user123',
+        artifactId: 'artifact123',
+        targetVersion: 3,
+        kind: RunKind.REFINE,
+        input: {
+          type: ArtifactType.DOCUMENT,
+          prompt: 'deep modules',
+          withResearch: true,
+          stylePreset: 'educational',
+          theme: 'minimal',
+          kind: RunKind.REFINE,
+          userId: 'user123',
+          artifactId: 'artifact123',
+          version: 3,
+        },
+      });
+
+      const storedInput =
+        mocks.workflowRunService.createRun.mock.calls[0][0].input;
+      expect(mocks.workflowQueue.addArtifactRunJob).toHaveBeenCalledWith(
+        'run123',
+        storedInput,
+      );
+    });
+
+    it('should not append or enqueue when the balance check fails for a refine', async () => {
+      mocks.creditMeter.assertBalance.mockRejectedValue(
+        new Error('FEATURE_LIMIT_EXCEEDED'),
+      );
+
+      await expect(
+        service.launchRefineRun('user123', 'artifact123', 'Try again'),
+      ).rejects.toThrow('FEATURE_LIMIT_EXCEEDED');
+
+      expect(mocks.artifactService.appendRefineVersion).not.toHaveBeenCalled();
+      expect(mocks.workflowRunService.createRun).not.toHaveBeenCalled();
+      expect(mocks.workflowQueue.addArtifactRunJob).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/artifact/artifact-generation.service.ts
+++ b/src/artifact/artifact-generation.service.ts
@@ -11,6 +11,10 @@ export interface LaunchResult {
   runId: string;
 }
 
+export interface RefineLaunchResult extends LaunchResult {
+  version: number;
+}
+
 /**
  * Orchestrates artifact creation over HTTP: a fast balance pre-check, then the
  * `Artifact` → `WorkflowRun` → BullMQ-job chain that a single 202 hands to the
@@ -53,17 +57,65 @@ export class ArtifactGenerationService {
       version: 1,
     };
 
+    const runId = await this.persistAndEnqueueRun(
+      userId,
+      artifactId,
+      buildInput,
+    );
+
+    return { artifactId, runId };
+  }
+
+  async launchRefineRun(
+    userId: string,
+    artifactId: string,
+    feedback: string,
+  ): Promise<RefineLaunchResult> {
+    await this.creditMeter.assertBalance(userId);
+
+    const refinement = await this.artifactService.appendRefineVersion(
+      userId,
+      artifactId,
+      feedback,
+    );
+
+    const buildInput: BuildInput = {
+      type: refinement.type,
+      prompt: refinement.prompt,
+      withResearch: refinement.withResearch,
+      stylePreset: refinement.stylePreset,
+      theme: refinement.theme,
+      kind: RunKind.REFINE,
+      userId,
+      artifactId,
+      version: refinement.version,
+    };
+
+    const runId = await this.persistAndEnqueueRun(
+      userId,
+      artifactId,
+      buildInput,
+    );
+
+    return { artifactId, version: refinement.version, runId };
+  }
+
+  private async persistAndEnqueueRun(
+    userId: string,
+    artifactId: string,
+    input: BuildInput,
+  ): Promise<string> {
     const run = await this.workflowRunService.createRun({
       userId,
       artifactId,
-      targetVersion: 1,
-      kind: RunKind.INITIAL,
-      input: buildInput,
+      targetVersion: input.version,
+      kind: input.kind,
+      input,
     });
     const runId = run._id.toString();
 
-    await this.workflowQueue.addArtifactRunJob(runId, buildInput);
+    await this.workflowQueue.addArtifactRunJob(runId, input);
 
-    return { artifactId, runId };
+    return runId;
   }
 }

--- a/src/artifact/artifact-writer.interface.ts
+++ b/src/artifact/artifact-writer.interface.ts
@@ -14,6 +14,11 @@ export interface CurrentVersionRead {
   content: ArtifactContent;
 }
 
+export interface RefineContext {
+  priorContent: ArtifactContent;
+  feedback: string;
+}
+
 // Narrow role interface consumed by the workflow engine's StepContext (#115):
 // steps depend on this, not on the full ArtifactService surface.
 export interface ArtifactWriter {
@@ -24,6 +29,7 @@ export interface ArtifactWriter {
     render?: VersionRender,
   ): Promise<void>;
   readCurrent(artifactId: string): Promise<CurrentVersionRead>;
+  readRefineInput(artifactId: string, version: number): Promise<RefineContext>;
   // Called only by the engine's terminal-failure handler (#115). FAILED
   // versions stay visible in the library, so the user can refine from one.
   failVersion(

--- a/src/artifact/artifact.controller.spec.ts
+++ b/src/artifact/artifact.controller.spec.ts
@@ -1,0 +1,62 @@
+jest.mock(
+  '../auth/clerk/clerk-auth.guard',
+  () => ({
+    ClerkAuthGuard: class ClerkAuthGuard {},
+  }),
+  { virtual: true },
+);
+jest.mock('../common/decorators', () => ({ GetUser: () => () => undefined }), {
+  virtual: true,
+});
+jest.mock('../database/schemas', () => ({ User: class User {} }), {
+  virtual: true,
+});
+jest.mock(
+  './artifact-generation.service',
+  () => ({
+    ArtifactGenerationService: class ArtifactGenerationService {},
+  }),
+  { virtual: true },
+);
+jest.mock(
+  './dto',
+  () => ({
+    CreateArtifactDto: class CreateArtifactDto {},
+    RefineArtifactDto: class RefineArtifactDto {},
+  }),
+  { virtual: true },
+);
+
+import { ArtifactController } from './artifact.controller';
+
+describe('ArtifactController', () => {
+  describe('refine', () => {
+    it('should delegate the owner, artifact, and feedback when refining', async () => {
+      const generation = {
+        launchRefineRun: jest.fn().mockResolvedValue({
+          artifactId: 'artifact-1',
+          version: 2,
+          runId: 'run-2',
+        }),
+      };
+      const controller = new ArtifactController(generation as any);
+      const user = { _id: { toString: () => 'user-1' } };
+
+      await expect(
+        controller.refine(user as any, 'artifact-1', {
+          feedback: 'Make the hook sharper',
+        }),
+      ).resolves.toEqual({
+        artifactId: 'artifact-1',
+        version: 2,
+        runId: 'run-2',
+      });
+
+      expect(generation.launchRefineRun).toHaveBeenCalledWith(
+        'user-1',
+        'artifact-1',
+        'Make the hook sharper',
+      );
+    });
+  });
+});

--- a/src/artifact/artifact.controller.ts
+++ b/src/artifact/artifact.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -14,8 +15,9 @@ import { User } from '../database/schemas';
 import {
   ArtifactGenerationService,
   LaunchResult,
+  RefineLaunchResult,
 } from './artifact-generation.service';
-import { CreateArtifactDto } from './dto';
+import { CreateArtifactDto, RefineArtifactDto } from './dto';
 
 @UseGuards(ClerkAuthGuard)
 @Controller('artifacts')
@@ -34,5 +36,19 @@ export class ArtifactController {
     @Body() dto: CreateArtifactDto,
   ): Promise<LaunchResult> {
     return this.generation.launchInitialRun(user._id.toString(), dto);
+  }
+
+  @HttpCode(HttpStatus.ACCEPTED)
+  @Post(':id/refine')
+  refine(
+    @GetUser() user: User,
+    @Param('id') artifactId: string,
+    @Body() dto: RefineArtifactDto,
+  ): Promise<RefineLaunchResult> {
+    return this.generation.launchRefineRun(
+      user._id.toString(),
+      artifactId,
+      dto.feedback,
+    );
   }
 }

--- a/src/artifact/artifact.service.spec.ts
+++ b/src/artifact/artifact.service.spec.ts
@@ -31,6 +31,7 @@ import { ArtifactService } from './artifact.service';
 const makeService = () => {
   const artifactModel = {
     create: jest.fn(),
+    findOne: jest.fn(),
     findById: jest.fn(),
     updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
   };
@@ -98,6 +99,272 @@ describe('ArtifactService', () => {
           },
         }),
       );
+    });
+  });
+
+  describe('appendRefineVersion', () => {
+    const readyArtifact = () => ({
+      _id: fixtures.artifactId,
+      type: ArtifactType.POST,
+      currentVersion: 1,
+      source: {
+        prompt: 'Write about TDD',
+        withResearch: true,
+        stylePreset: StylePreset.EDUCATIONAL,
+      },
+      versions: [
+        {
+          version: 1,
+          status: VersionStatus.READY,
+          content: { commentary: 'The original post.' },
+        },
+      ],
+    });
+
+    it('should append a GENERATING version and move the head forward when refining a ready artifact', async () => {
+      mocks.artifactModel.findOne.mockResolvedValue(readyArtifact());
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Make the hook sharper',
+        ),
+      ).resolves.toEqual({
+        version: 2,
+        type: ArtifactType.POST,
+        prompt: 'Write about TDD',
+        withResearch: true,
+        stylePreset: StylePreset.EDUCATIONAL,
+      });
+
+      expect(mocks.artifactModel.findOne).toHaveBeenCalledWith({
+        _id: fixtures.artifactId,
+        user: expect.any(Types.ObjectId),
+      });
+      expect(mocks.artifactModel.updateOne).toHaveBeenCalledWith(
+        {
+          _id: fixtures.artifactId,
+          user: expect.any(Types.ObjectId),
+          currentVersion: 1,
+        },
+        {
+          $set: { currentVersion: 2 },
+          $push: {
+            versions: {
+              version: 2,
+              status: VersionStatus.GENERATING,
+              content: {},
+              refineFeedback: 'Make the hook sharper',
+            },
+          },
+        },
+      );
+    });
+
+    it('should carry the document theme into the refine input when the user supplied one', async () => {
+      mocks.artifactModel.findOne.mockResolvedValue({
+        ...readyArtifact(),
+        type: ArtifactType.DOCUMENT,
+        source: {
+          prompt: 'Build a carousel',
+          withResearch: false,
+          theme: CarouselTheme.MINIMAL,
+        },
+      });
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Use fewer words',
+        ),
+      ).resolves.toMatchObject({
+        type: ArtifactType.DOCUMENT,
+        prompt: 'Build a carousel',
+        withResearch: false,
+        theme: CarouselTheme.MINIMAL,
+      });
+    });
+
+    it('should carry a model-selected document theme into the refine input when the source has none', async () => {
+      mocks.artifactModel.findOne.mockResolvedValue({
+        ...readyArtifact(),
+        type: ArtifactType.DOCUMENT,
+        source: {
+          prompt: 'Build a carousel',
+          withResearch: false,
+        },
+        versions: [
+          {
+            version: 1,
+            status: VersionStatus.READY,
+            content: {
+              document: {
+                templateId: CarouselTheme.GRADIENT,
+                slides: [
+                  { type: 'cover', fields: { title: 'A carousel' } },
+                  { type: 'content', fields: { heading: 'A', body: 'B' } },
+                ],
+              },
+            },
+          },
+        ],
+      });
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Use fewer words',
+        ),
+      ).resolves.toMatchObject({ theme: CarouselTheme.GRADIENT });
+    });
+
+    it('should reject an unknown or soft-deleted artifact when appending a version', async () => {
+      mocks.artifactModel.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Try again',
+        ),
+      ).rejects.toMatchObject({ name: 'NotFoundException' });
+
+      mocks.artifactModel.findOne.mockResolvedValue({
+        ...readyArtifact(),
+        deletedAt: new Date(),
+      });
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Try again',
+        ),
+      ).rejects.toMatchObject({ name: 'NotFoundException' });
+      expect(mocks.artifactModel.updateOne).not.toHaveBeenCalled();
+    });
+
+    it('should reject a concurrent head change when appending a version', async () => {
+      mocks.artifactModel.findOne.mockResolvedValue(readyArtifact());
+      mocks.artifactModel.updateOne.mockResolvedValue({ matchedCount: 0 });
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Try again',
+        ),
+      ).rejects.toMatchObject({ name: 'ConflictException' });
+    });
+
+    it('should reject a refine when the current version is still generating', async () => {
+      mocks.artifactModel.findOne.mockResolvedValue({
+        ...readyArtifact(),
+        versions: [
+          {
+            version: 1,
+            status: VersionStatus.GENERATING,
+            content: {},
+          },
+        ],
+      });
+
+      await expect(
+        service.appendRefineVersion(
+          fixtures.userId,
+          fixtures.artifactId,
+          'Try again',
+        ),
+      ).rejects.toMatchObject({ name: 'ConflictException' });
+      expect(mocks.artifactModel.updateOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('readRefineInput', () => {
+    it('should return the prior version content and feedback when the target version is refining', async () => {
+      mocks.artifactModel.findById.mockResolvedValue({
+        _id: fixtures.artifactId,
+        type: ArtifactType.POST,
+        currentVersion: 2,
+        versions: [
+          {
+            version: 1,
+            status: VersionStatus.READY,
+            content: { commentary: 'The original post.' },
+          },
+          {
+            version: 2,
+            status: VersionStatus.GENERATING,
+            content: {},
+            refineFeedback: 'Make the hook sharper',
+          },
+        ],
+      });
+
+      await expect(
+        service.readRefineInput(fixtures.artifactId, 2),
+      ).resolves.toEqual({
+        priorContent: { commentary: 'The original post.' },
+        feedback: 'Make the hook sharper',
+      });
+    });
+
+    it('should reject when the target has no usable prior version for refinement', async () => {
+      mocks.artifactModel.findById.mockResolvedValue({
+        _id: fixtures.artifactId,
+        type: ArtifactType.POST,
+        currentVersion: 2,
+        versions: [
+          {
+            version: 2,
+            status: VersionStatus.GENERATING,
+            content: {},
+            refineFeedback: 'Try again',
+          },
+        ],
+      });
+
+      await expect(
+        service.readRefineInput(fixtures.artifactId, 2),
+      ).rejects.toMatchObject({ name: 'NotFoundException' });
+    });
+
+    it('should skip failed versions when finding the latest earlier usable content', async () => {
+      mocks.artifactModel.findById.mockResolvedValue({
+        _id: fixtures.artifactId,
+        type: ArtifactType.POST,
+        currentVersion: 3,
+        versions: [
+          {
+            version: 1,
+            status: VersionStatus.READY,
+            content: { commentary: 'The original post.' },
+          },
+          {
+            version: 2,
+            status: VersionStatus.FAILED,
+            content: {},
+            failureReason: 'generation failed',
+            refineFeedback: 'Make the hook sharper',
+          },
+          {
+            version: 3,
+            status: VersionStatus.GENERATING,
+            content: {},
+            refineFeedback: 'Try a more direct opening',
+          },
+        ],
+      });
+
+      await expect(
+        service.readRefineInput(fixtures.artifactId, 3),
+      ).resolves.toEqual({
+        priorContent: { commentary: 'The original post.' },
+        feedback: 'Try a more direct opening',
+      });
     });
   });
 

--- a/src/artifact/artifact.service.ts
+++ b/src/artifact/artifact.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import {
@@ -11,6 +15,7 @@ import type { StylePreset } from 'src/agent/style-presets.config';
 import {
   ArtifactWriter,
   CurrentVersionRead,
+  RefineContext,
   VersionRender,
 } from './artifact-writer.interface';
 import {
@@ -19,12 +24,20 @@ import {
   parseArtifactContent,
 } from './schemas';
 
-export interface CreateArtifactInput {
-  type: ArtifactType;
+export interface ArtifactSourceInput {
   prompt: string;
   withResearch: boolean;
   stylePreset?: StylePreset;
   theme?: CarouselTheme;
+}
+
+export interface CreateArtifactInput extends ArtifactSourceInput {
+  type: ArtifactType;
+}
+
+export interface RefineArtifactInput extends ArtifactSourceInput {
+  version: number;
+  type: ArtifactType;
 }
 
 @Injectable()
@@ -49,6 +62,99 @@ export class ArtifactService implements ArtifactWriter {
       currentVersion: 1,
       versions: [{ version: 1, status: VersionStatus.GENERATING, content: {} }],
     });
+  }
+
+  async appendRefineVersion(
+    userId: string,
+    artifactId: string,
+    feedback: string,
+  ): Promise<RefineArtifactInput> {
+    const user = new Types.ObjectId(userId);
+    const artifact = await this.artifactModel.findOne({
+      _id: artifactId,
+      user,
+    });
+
+    if (!artifact || artifact.deletedAt) {
+      throw new NotFoundException(`Artifact ${artifactId} not found`);
+    }
+
+    const current = artifact.versions.find(
+      (item) => item.version === artifact.currentVersion,
+    );
+    if (!current || current.status === VersionStatus.GENERATING) {
+      throw new ConflictException(
+        `Artifact ${artifactId} is still generating and cannot be refined`,
+      );
+    }
+
+    const priorContent = this.findLatestUsableContent(
+      artifact,
+      artifact.currentVersion + 1,
+    );
+    let theme = artifact.source.theme;
+    if (
+      !theme &&
+      artifact.type === ArtifactType.DOCUMENT &&
+      priorContent &&
+      'document' in priorContent
+    ) {
+      theme = priorContent.document.templateId;
+    }
+
+    const nextVersion = artifact.currentVersion + 1;
+    const result = await this.artifactModel.updateOne(
+      {
+        _id: artifact._id,
+        user,
+        currentVersion: artifact.currentVersion,
+      },
+      {
+        $set: { currentVersion: nextVersion },
+        $push: {
+          versions: {
+            version: nextVersion,
+            status: VersionStatus.GENERATING,
+            content: {},
+            refineFeedback: feedback,
+          },
+        },
+      },
+    );
+
+    if (result.matchedCount !== 1) {
+      throw new ConflictException(
+        `Artifact ${artifactId} changed while a refine was being started`,
+      );
+    }
+
+    return {
+      version: nextVersion,
+      type: artifact.type,
+      prompt: artifact.source.prompt,
+      withResearch: artifact.source.withResearch,
+      ...(artifact.source.stylePreset
+        ? { stylePreset: artifact.source.stylePreset }
+        : {}),
+      ...(theme ? { theme } : {}),
+    };
+  }
+
+  async readRefineInput(
+    artifactId: string,
+    version: number,
+  ): Promise<RefineContext> {
+    const artifact = await this.getLiveArtifact(artifactId);
+    const target = artifact.versions.find((item) => item.version === version);
+    const priorContent = this.findLatestUsableContent(artifact, version);
+
+    if (!target || target.refineFeedback == null || !priorContent) {
+      throw new NotFoundException(
+        `Refine input for artifact ${artifactId} v${version} not found`,
+      );
+    }
+
+    return { priorContent, feedback: target.refineFeedback };
   }
 
   async setVersionContent(
@@ -159,6 +265,26 @@ export class ArtifactService implements ArtifactWriter {
         pageCount: render.pageCount,
       },
     };
+  }
+
+  private findLatestUsableContent(
+    artifact: Artifact,
+    beforeVersion: number,
+  ): ArtifactContent | undefined {
+    const versions = [...artifact.versions]
+      .filter((version) => version.version < beforeVersion)
+      .sort((a, b) => b.version - a.version);
+
+    for (const version of versions) {
+      try {
+        return parseArtifactContent(artifact.type, version.content);
+      } catch {
+        // Failed versions can retain an empty content object. Keep walking back
+        // so a later refine can still revise the last usable version.
+      }
+    }
+
+    return undefined;
   }
 
   private async getLiveArtifact(artifactId: string): Promise<Artifact> {

--- a/src/artifact/dto/index.ts
+++ b/src/artifact/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './create-artifact.dto';
+export * from './refine-artifact.dto';

--- a/src/artifact/dto/refine-artifact.dto.ts
+++ b/src/artifact/dto/refine-artifact.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class RefineArtifactDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  feedback: string;
+}

--- a/src/workflow/engine/workflow.types.ts
+++ b/src/workflow/engine/workflow.types.ts
@@ -7,6 +7,7 @@ import type {
 import type { ArtifactContent } from '../../artifact/schemas';
 import type {
   ArtifactWriter,
+  RefineContext,
   VersionRender,
 } from '../../artifact/artifact-writer.interface';
 import type {
@@ -48,7 +49,7 @@ export interface BuildInput extends BuildSpec {
 export interface RunState {
   input: BuildInput;
   research?: ResearchResult;
-  refine?: { priorContent: ArtifactContent; feedback: string };
+  refine?: RefineContext;
   content?: ArtifactContent;
   render?: VersionRender;
 }
@@ -100,6 +101,9 @@ export interface RunRecordHandle {
   readonly runId: string;
   setCurrentStep(step: WorkflowStep): Promise<void>;
   saveResearchContext(research: ResearchResult): Promise<void>;
+  getLatestCompletedResearch(
+    artifactId: string,
+  ): Promise<ResearchResult | undefined>;
   complete(creditsUsed: number): Promise<void>;
   fail(failureReason: string): Promise<void>;
 }

--- a/src/workflow/steps/resolve-input.step.spec.ts
+++ b/src/workflow/steps/resolve-input.step.spec.ts
@@ -1,17 +1,28 @@
 import { NotFoundException } from '@nestjs/common';
+
+jest.mock(
+  '../../database/schemas',
+  () => ({ RunKind: { INITIAL: 'INITIAL', REFINE: 'REFINE' } }),
+  { virtual: true },
+);
+
 import { WorkflowError } from '../engine/workflow.error';
 import type { RunState, StepContext } from '../engine/workflow.types';
 import { resolveInputStep } from './resolve-input.step';
 
 const makeStep = () => {
-  const artifacts = { readCurrent: jest.fn() };
-  const ctx = { artifacts } as unknown as StepContext;
+  const artifacts = {
+    readCurrent: jest.fn(),
+    readRefineInput: jest.fn(),
+  };
+  const run = { getLatestCompletedResearch: jest.fn() };
+  const ctx = { artifacts, run } as unknown as StepContext;
 
   const state = {
-    input: { artifactId: 'artifact-1', version: 1 },
+    input: { artifactId: 'artifact-1', version: 1, kind: 'INITIAL' },
   } as unknown as RunState;
 
-  return { ctx, mocks: { artifacts }, fixtures: { state } };
+  return { ctx, mocks: { artifacts, run }, fixtures: { state } };
 };
 
 let ctx: StepContext;
@@ -59,5 +70,61 @@ describe('resolveInputStep', () => {
     mocks.artifacts.readCurrent.mockRejectedValue(outage);
 
     await expect(resolveInputStep(fixtures.state, ctx)).rejects.toBe(outage);
+  });
+
+  it('should seed prior content, feedback, and cached research when resolving a REFINE run', async () => {
+    fixtures.state.input = {
+      artifactId: 'artifact-1',
+      version: 2,
+      kind: 'REFINE',
+    } as never;
+    mocks.artifacts.readCurrent.mockResolvedValue({ version: 2 });
+    mocks.artifacts.readRefineInput.mockResolvedValue({
+      priorContent: { commentary: 'The original post.' },
+      feedback: 'Make the hook sharper',
+    });
+    mocks.run.getLatestCompletedResearch.mockResolvedValue({
+      findings: 'Cached findings',
+      sources: [{ title: 'Source', url: 'https://example.com' }],
+    });
+
+    await expect(resolveInputStep(fixtures.state, ctx)).resolves.toEqual({
+      refine: {
+        priorContent: { commentary: 'The original post.' },
+        feedback: 'Make the hook sharper',
+      },
+      research: {
+        findings: 'Cached findings',
+        sources: [{ title: 'Source', url: 'https://example.com' }],
+      },
+    });
+    expect(mocks.artifacts.readRefineInput).toHaveBeenCalledWith(
+      'artifact-1',
+      2,
+    );
+    expect(mocks.run.getLatestCompletedResearch).toHaveBeenCalledWith(
+      'artifact-1',
+    );
+  });
+
+  it('should leave the research slot empty when no completed run has cached research for a REFINE run', async () => {
+    fixtures.state.input = {
+      artifactId: 'artifact-1',
+      version: 2,
+      kind: 'REFINE',
+    } as never;
+    mocks.artifacts.readCurrent.mockResolvedValue({ version: 2 });
+    mocks.artifacts.readRefineInput.mockResolvedValue({
+      priorContent: { commentary: 'The original post.' },
+      feedback: 'Make the hook sharper',
+    });
+    mocks.run.getLatestCompletedResearch.mockResolvedValue(undefined);
+
+    await expect(resolveInputStep(fixtures.state, ctx)).resolves.toEqual({
+      refine: {
+        priorContent: { commentary: 'The original post.' },
+        feedback: 'Make the hook sharper',
+      },
+    });
   });
 });

--- a/src/workflow/steps/resolve-input.step.ts
+++ b/src/workflow/steps/resolve-input.step.ts
@@ -1,4 +1,5 @@
 import { NotFoundException } from '@nestjs/common';
+import { RunKind } from '../../database/schemas';
 import { terminal } from '../engine/workflow.error';
 import type { StepHandler } from '../engine/workflow.types';
 
@@ -35,5 +36,24 @@ export const resolveInputStep: StepHandler = async (state, ctx) => {
     );
   }
 
-  return {};
+  if (state.input.kind !== RunKind.REFINE) {
+    return {};
+  }
+
+  let refine: Awaited<ReturnType<typeof ctx.artifacts.readRefineInput>>;
+  try {
+    refine = await ctx.artifacts.readRefineInput(artifactId, version);
+  } catch (error: unknown) {
+    if (error instanceof NotFoundException) {
+      throw terminal(error.message, error);
+    }
+    throw error;
+  }
+
+  const research = await ctx.run.getLatestCompletedResearch(artifactId);
+
+  return {
+    refine,
+    ...(research ? { research } : {}),
+  };
 };

--- a/src/workflow/workers/artifact-run.worker.handler.spec.ts
+++ b/src/workflow/workers/artifact-run.worker.handler.spec.ts
@@ -21,7 +21,7 @@ import {
 // These POST-run tests never reach RENDER_PDF, so a never-called stub suffices.
 const stubRenderer = { render: jest.fn() };
 
-const buildInput = (): BuildInput =>
+const buildInput = (overrides: Partial<BuildInput> = {}): BuildInput =>
   ({
     type: 'POST',
     kind: 'INITIAL',
@@ -30,6 +30,7 @@ const buildInput = (): BuildInput =>
     userId: 'user-1',
     artifactId: 'artifact-1',
     version: 1,
+    ...overrides,
   }) as unknown as BuildInput;
 
 const makeJob = (overrides: Partial<Job<BuildInput>> = {}): Job<BuildInput> =>
@@ -61,6 +62,7 @@ const makeProcessor = () => {
   };
   const artifacts = {
     readCurrent: jest.fn().mockResolvedValue({ version: 1 }),
+    readRefineInput: jest.fn(),
     setVersionContent: jest.fn().mockResolvedValue(undefined),
     failVersion: jest.fn().mockResolvedValue(undefined),
   };
@@ -68,6 +70,7 @@ const makeProcessor = () => {
     runId: 'run-1',
     setCurrentStep: jest.fn().mockResolvedValue(undefined),
     saveResearchContext: jest.fn().mockResolvedValue(undefined),
+    getLatestCompletedResearch: jest.fn(),
     complete: jest.fn().mockResolvedValue(undefined),
     fail: jest.fn().mockResolvedValue(undefined),
   };
@@ -161,6 +164,118 @@ describe('ArtifactRunProcessor', () => {
         'step.completed',
         'run.completed',
       ]);
+    });
+
+    it('should refine from cached research without running the RESEARCH step when processing a REFINE job', async () => {
+      const research = {
+        findings: 'Cached findings',
+        sources: [{ title: 'Source', url: 'https://example.com' }],
+      };
+      mocks.artifacts.readCurrent.mockResolvedValue({ version: 2 });
+      mocks.artifacts.readRefineInput.mockResolvedValue({
+        priorContent: { commentary: 'The original post.' },
+        feedback: 'Make the hook sharper',
+      });
+      mocks.runHandle.getLatestCompletedResearch.mockResolvedValue(research);
+      const job = makeJob({
+        data: buildInput({ kind: 'REFINE', withResearch: true, version: 2 }),
+      });
+
+      await processor.process(job);
+
+      expect(mocks.agent.research).not.toHaveBeenCalled();
+      expect(mocks.agent.generate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          research,
+          refine: {
+            priorContent: { commentary: 'The original post.' },
+            feedback: 'Make the hook sharper',
+          },
+        }),
+        expect.any(Object),
+      );
+      const runStarted = mocks.redis.xadd.mock.calls.find(
+        (call) => call[6] === 'run.started',
+      );
+      expect(JSON.parse(runStarted[8]).steps).toEqual([
+        'RESOLVE_INPUT',
+        'GENERATE',
+        'PERSIST_VERSION',
+      ]);
+      expect(emittedTypes(mocks.redis)).toEqual([
+        'run.started',
+        'step.started',
+        'step.completed',
+        'step.started',
+        'step.completed',
+        'step.started',
+        'step.completed',
+        'run.completed',
+      ]);
+    });
+
+    it('should render a DOCUMENT refine to the new version key when processing a DOCUMENT REFINE job', async () => {
+      mocks.artifacts.readCurrent.mockResolvedValue({ version: 2 });
+      mocks.artifacts.readRefineInput.mockResolvedValue({
+        priorContent: {
+          document: {
+            templateId: 'minimal',
+            slides: [
+              { type: 'cover', fields: { title: 'The original' } },
+              { type: 'content', fields: { heading: 'A', body: 'B' } },
+            ],
+          },
+        },
+        feedback: 'Make the first slide clearer',
+      });
+      mocks.runHandle.getLatestCompletedResearch.mockResolvedValue(undefined);
+      mocks.agent.generate.mockResolvedValue({
+        document: {
+          templateId: 'minimal',
+          slides: [
+            { type: 'cover', fields: { title: 'A clearer cover' } },
+            { type: 'content', fields: { heading: 'A', body: 'B' } },
+          ],
+        },
+      });
+      stubRenderer.render.mockResolvedValue({
+        pdfKey: 'artifacts/artifact-1/2/document.pdf',
+        pageCount: 2,
+      });
+      const job = makeJob({
+        data: buildInput({
+          type: 'DOCUMENT',
+          kind: 'REFINE',
+          withResearch: true,
+          version: 2,
+        }),
+      });
+
+      await processor.process(job);
+
+      expect(stubRenderer.render).toHaveBeenCalledWith({
+        artifactId: 'artifact-1',
+        version: 2,
+        templateId: 'minimal',
+        slides: [
+          { type: 'cover', fields: { title: 'A clearer cover' } },
+          { type: 'content', fields: { heading: 'A', body: 'B' } },
+        ],
+      });
+      expect(mocks.artifacts.setVersionContent).toHaveBeenCalledWith(
+        'artifact-1',
+        2,
+        {
+          document: {
+            templateId: 'minimal',
+            slides: [
+              { type: 'cover', fields: { title: 'A clearer cover' } },
+              { type: 'content', fields: { heading: 'A', body: 'B' } },
+            ],
+          },
+        },
+        { pdfKey: 'artifacts/artifact-1/2/document.pdf', pageCount: 2 },
+      );
     });
 
     it('should meter the LLM turn and commit the credits once', async () => {

--- a/src/workflow/workflow-run.service.spec.ts
+++ b/src/workflow/workflow-run.service.spec.ts
@@ -23,6 +23,7 @@ describe('WorkflowRunService', () => {
       create: jest.fn(),
       updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
       findById: jest.fn(),
+      findOne: jest.fn(),
     };
     const service = new WorkflowRunService(workflowRunModel as any);
 
@@ -93,6 +94,44 @@ describe('WorkflowRunService', () => {
     it('should return null without touching the model for a malformed id', async () => {
       await expect(service.getRun('not-an-object-id')).resolves.toBeNull();
       expect(mocks.workflowRunModel.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getLatestCompletedResearch', () => {
+    it('should return cached research from the latest completed run when one exists', async () => {
+      const research = {
+        findings: 'cached findings',
+        sources: [{ title: 'Source', url: 'https://example.com' }],
+      };
+      const sort = jest.fn().mockResolvedValue({ researchContext: research });
+      mocks.workflowRunModel.findOne.mockReturnValue({ sort });
+
+      await expect(
+        service.getLatestCompletedResearch(fixtures.artifactId),
+      ).resolves.toEqual(research);
+
+      expect(mocks.workflowRunModel.findOne).toHaveBeenCalledWith({
+        artifact: expect.any(Types.ObjectId),
+        status: RunStatus.COMPLETED,
+        researchContext: { $exists: true },
+      });
+      expect(sort).toHaveBeenCalledWith({ createdAt: -1 });
+    });
+
+    it('should return undefined when the artifact has no cached research', async () => {
+      const sort = jest.fn().mockResolvedValue(null);
+      mocks.workflowRunModel.findOne.mockReturnValue({ sort });
+
+      await expect(
+        service.getLatestCompletedResearch(fixtures.artifactId),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should not query when the artifact id is malformed', async () => {
+      await expect(
+        service.getLatestCompletedResearch('not-an-object-id'),
+      ).resolves.toBeUndefined();
+      expect(mocks.workflowRunModel.findOne).not.toHaveBeenCalled();
     });
   });
 

--- a/src/workflow/workflow-run.service.ts
+++ b/src/workflow/workflow-run.service.ts
@@ -43,6 +43,22 @@ export class WorkflowRunService {
     return this.workflowRunModel.findById(runId);
   }
 
+  async getLatestCompletedResearch(
+    artifactId: string,
+  ): Promise<ResearchResult | undefined> {
+    if (!isValidObjectId(artifactId)) return undefined;
+
+    const run = await this.workflowRunModel
+      .findOne({
+        artifact: new Types.ObjectId(artifactId),
+        status: RunStatus.COMPLETED,
+        researchContext: { $exists: true },
+      })
+      .sort({ createdAt: -1 });
+
+    return run?.researchContext;
+  }
+
   /**
    * The engine depends on `RunRecordHandle`, not on this service. Binding the
    * runId here keeps every call site from re-threading it.
@@ -54,6 +70,8 @@ export class WorkflowRunService {
         this.patch(runId, { currentStep: step }),
       saveResearchContext: (research: ResearchResult) =>
         this.patch(runId, { researchContext: research }),
+      getLatestCompletedResearch: (artifactId: string) =>
+        this.getLatestCompletedResearch(artifactId),
       complete: (creditsUsed: number) =>
         this.patch(runId, { status: RunStatus.COMPLETED, creditsUsed }),
       fail: (failureReason: string) =>


### PR DESCRIPTION
## Summary

Implements issue #123, adding refine-after-completion runs for existing artifacts.

- Adds POST /artifacts/:id/refine with balance validation and asynchronous run enqueueing.
- Adds REFINE workflow handling that seeds prior content and feedback.
- Reuses cached research from the latest completed run without an additional web-search surcharge.
- Persists refine feedback and appends a new generating artifact version.
- Re-renders refined DOCUMENT artifacts with the prior theme.

## Validation

- npm run build
- 70 focused tests passed
- Full suite: 648 tests passed; 1 unrelated pre-existing auth DI suite failure involving ambiguous PostDraft.type Mongoose metadata.