### PR TITLE
Handle expired LinkedIn access

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.paddle-docs]
+url = "https://paddlehq.mcp.kapa.ai"

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ OPENROUTER_API_KEY=sk-or-key
 # drives the research tool loop.
 GENERATION_MODEL=openai/gpt-5.4
 RESEARCH_MODEL=openai/gpt-5-mini
+# Maximum completion budget for each role. Optional; both default to 8192.
+# Explicit caps prevent OpenRouter from reserving a model's full output ceiling
+# when it performs its preflight affordability check.
+GENERATION_MAX_OUTPUT_TOKENS=8192
+RESEARCH_MAX_OUTPUT_TOKENS=8192
 # How many tool-calling turns the research agent may take before it is forced to
 # finalize (one extra tools-free completion). Optional; defaults to 5.
 RESEARCH_MAX_STEPS=5

--- a/.scratch/ai-document-design-systems/issues/01-research-visual-review-economics.md
+++ b/.scratch/ai-document-design-systems/issues/01-research-visual-review-economics.md
@@ -1,0 +1,12 @@
+# Research the economics and value of AI visual review
+
+Type: research
+Status: claimed
+Blocked by:
+
+Research branch: `research/visual-review-economics`
+Expected findings: `docs/ai-document-visual-review-research.md`
+
+## Question
+
+What visual-review approaches are feasible through the current OpenRouter and Browserless stack, and what incremental cost, latency, and failure-detection value should the backend specification expect for always-on, conditional, sampled, and omitted visual review of 2–15-page generated documents?

--- a/.scratch/ai-document-design-systems/issues/02-choose-visual-review-policy.md
+++ b/.scratch/ai-document-design-systems/issues/02-choose-visual-review-policy.md
@@ -1,0 +1,9 @@
+# Choose the document visual-review policy
+
+Type: grilling
+Status: open
+Blocked by: 01
+
+## Question
+
+Given the measured cost, latency, capabilities, and quality benefits, should visual AI review be omitted, sampled, triggered only by risk signals, or required for every generated document, and how many critique-and-repair attempts may it cause?

--- a/.scratch/ai-document-design-systems/issues/03-prototype-design-system-definition.md
+++ b/.scratch/ai-document-design-systems/issues/03-prototype-design-system-definition.md
@@ -1,0 +1,9 @@
+# Prototype the Design System Definition contract
+
+Type: prototype
+Status: open
+Blocked by:
+
+## Question
+
+What should the versioned YAML contract for an app-owned Design System contain so that palette, Google Fonts, spacing, typography, icon usage, page geometry, composition guidance, and anti-patterns are expressive for the AI while remaining parseable and enforceable by the backend?

--- a/.scratch/ai-document-design-systems/issues/04-decide-design-system-persistence-and-api.md
+++ b/.scratch/ai-document-design-systems/issues/04-decide-design-system-persistence-and-api.md
@@ -1,0 +1,9 @@
+# Decide Design System persistence and read APIs
+
+Type: grilling
+Status: open
+Blocked by: 03
+
+## Question
+
+What exact MongoDB identity, immutable-version, activation, idempotent seeding, selection, and runtime read contract should app-owned Design Systems expose to generation and to backend clients?

--- a/.scratch/ai-document-design-systems/issues/05-decide-document-source-contract.md
+++ b/.scratch/ai-document-design-systems/issues/05-decide-document-source-contract.md
@@ -1,0 +1,9 @@
+# Decide the untrusted Document Source contract
+
+Type: grilling
+Status: open
+Blocked by: 03
+
+## Question
+
+What exact generated HTML/CSS envelope, page structure, CSS capabilities, token references, Google Font URLs, icon references, size limits, sanitization rules, and prohibited constructs define a valid internal Document Source?

--- a/.scratch/ai-document-design-systems/issues/06-prototype-render-validation-and-repair.md
+++ b/.scratch/ai-document-design-systems/issues/06-prototype-render-validation-and-repair.md
@@ -1,0 +1,9 @@
+# Prototype render validation and repair diagnostics
+
+Type: prototype
+Status: open
+Blocked by: 05
+
+## Question
+
+How should Browserless load, inspect, and render a candidate Document Source so it can prove page count and geometry, font readiness, overflow safety, and PDF page count, then return useful bounded repair diagnostics without executing untrusted content?

--- a/.scratch/ai-document-design-systems/issues/07-decide-artifact-version-and-refinement-contract.md
+++ b/.scratch/ai-document-design-systems/issues/07-decide-artifact-version-and-refinement-contract.md
@@ -1,0 +1,9 @@
+# Decide the Document Artifact version and refinement contract
+
+Type: grilling
+Status: open
+Blocked by: 04, 05
+
+## Question
+
+What exact persisted Document Version shape, Design System Version reference, Current Version rule, failed-attempt history, signed-PDF response, refinement input, design-system switching behavior, and scheduled or published version pinning should replace `templateId + slides[]`?

--- a/.scratch/ai-document-design-systems/issues/08-decide-generation-workflow-contract.md
+++ b/.scratch/ai-document-design-systems/issues/08-decide-generation-workflow-contract.md
@@ -1,0 +1,9 @@
+# Decide the generation workflow and failure contract
+
+Type: grilling
+Status: open
+Blocked by: 02, 06, 07
+
+## Question
+
+How should resolve-input, content generation, source validation, render inspection, bounded AI repair, optional visual review, PDF persistence, version promotion, event emission, retry classification, and provider-usage settlement compose into the Document workflow?

--- a/.scratch/ai-document-design-systems/issues/09-prototype-default-design-systems.md
+++ b/.scratch/ai-document-design-systems/issues/09-prototype-default-design-systems.md
@@ -1,0 +1,9 @@
+# Prototype the four default Design Systems
+
+Type: prototype
+Status: open
+Blocked by: 03
+
+## Question
+
+How should the visual identities of `bold`, `minimal`, `editorial`, and `gradient` be translated from fixed templates into representative app-owned Design System Definitions and preview references without preserving runtime layouts or slide types?

--- a/.scratch/ai-document-design-systems/issues/10-decide-acceptance-and-observability.md
+++ b/.scratch/ai-document-design-systems/issues/10-decide-acceptance-and-observability.md
@@ -1,0 +1,9 @@
+# Decide acceptance tests and operational observability
+
+Type: grilling
+Status: open
+Blocked by: 02, 06, 08, 09
+
+## Question
+
+What fixtures, schema tests, sanitizer adversarial cases, render assertions, visual-quality checks, integration tests, metrics, logs, and cost or latency thresholds are required before and after rollout?

--- a/.scratch/ai-document-design-systems/issues/11-decide-documentation-reconciliation.md
+++ b/.scratch/ai-document-design-systems/issues/11-decide-documentation-reconciliation.md
@@ -1,0 +1,9 @@
+# Decide the canonical documentation and reconciliation plan
+
+Type: grilling
+Status: open
+Blocked by: 04, 05, 06, 07, 08, 09, 10
+
+## Question
+
+What exact canonical specification structure, supersession notices, and amendments are required across the carousel-template, artifact-schema, workflow PRD, workflow-step, API, and related documents so the repository expresses one non-contradictory backend contract?

--- a/.scratch/ai-document-design-systems/map.md
+++ b/.scratch/ai-document-design-systems/map.md
@@ -1,0 +1,34 @@
+# AI-authored document design systems
+
+Label: wayfinder:map
+
+## Destination
+
+Produce a decision-complete backend specification for replacing fixed carousel templates with AI-authored Document Source constrained by app-owned, versioned Design Systems, including the artifact, workflow, rendering, validation, safety, API, migration, testing, and documentation contracts needed for implementation.
+
+## Notes
+
+- This is a planning map. It resolves decisions and produces detailed backend contract documentation; it does not implement the feature.
+- Every session should consult `CONTEXT.md`, `docs/carousel-template-system-design.md`, `docs/artifact-schema-and-library-api-design.md`, `docs/artifact-workflow-prd.md`, and the narrower workflow documents relevant to its question.
+- Grilling tickets use the `grilling` and `domain-modeling` skills one question at a time.
+- Research uses primary sources and records citations in a repository Markdown document.
+- Settled launch boundaries: Design Systems are app-owned; repository YAML seeds versioned MongoDB records; generated HTML/CSS is internal and untrusted; Google Fonts are allowlisted and loaded by Browserless; icons come from an app-owned inline catalog; image assets, frontend implementation, an admin authoring API, user-owned Design Systems, and compatibility with template-based Document Versions are outside scope.
+- A Refinement creates a new immutable version. The prior READY version remains current until its replacement reaches READY.
+- Provider usage from generation, repair, validation, rendering, and any visual review is metered through the existing workflow credit path.
+
+## Decisions so far
+
+## Not yet specified
+
+- The exact final specification structure and the precise amendments needed in each existing decision document will become clear after the component contracts settle.
+- Rollout and operational acceptance thresholds may need to split into separate decisions once the render-validation and visual-review policies are known.
+
+## Out of scope
+
+- Frontend implementation, including a Design System picker or HTML editor.
+- Administrative APIs or runtime UI for authoring app-owned Design Systems.
+- User-owned or organization-owned Design Systems.
+- Image assets, including uploads, stock images, and AI-generated raster artwork.
+- Direct client access to or submission of generated Document Source.
+- Compatibility or data migration for existing `templateId + slides[]` Document Versions.
+- Implementing the feature after the backend specification is complete.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# LinkGen
+
+LinkGen turns a user's intent into versioned, publishable LinkedIn content.
+
+## Document generation
+
+**Design System**:
+A reusable visual constraint profile that guides AI generation of a document's layout and styling.
+_Avoid_: Template, theme
+
+**App-Owned Design System**:
+A Design System curated and made available by LinkGen. All Design Systems at launch are app-owned.
+_Avoid_: Default template, built-in theme
+
+**Design System Definition**:
+The canonical YAML text of a Design System, parsed and validated against a versioned contract before use.
+_Avoid_: Prompt fragment, template configuration
+
+**Design System Version**:
+An immutable snapshot of a Design System Definition. Each Document Version records the Design System Version that guided its generation.
+_Avoid_: Current theme, design revision
+
+**Document Source**:
+The complete, self-contained HTML and CSS generated for one Document Version and used to render its PDF.
+_Avoid_: Template output, slide fields
+
+**Document Version**:
+An immutable snapshot of a generated document, including its Document Source and derived PDF.
+_Avoid_: Edit, revision
+
+**Current Version**:
+The newest `READY` version of an Artifact. A failed generation attempt never replaces it.
+_Avoid_: Latest attempt, head
+
+**Refinement**:
+A user-requested AI regeneration that appends a new immutable version of an Artifact.
+_Avoid_: Edit, fix, patch

--- a/docs/agent-loop-and-research-agent-design.md
+++ b/docs/agent-loop-and-research-agent-design.md
@@ -280,6 +280,11 @@ BullMQ `attempts:3`; terminal → `UnrecoverableError`):
   turns) and `GENERATION_MODEL` (stronger, for final content) — no hardcoded model
   strings (retires the scattered `gemini-3-flash` / `gpt-5.4` / `gpt-5-mini` literals,
   per AGENTS.md's config rule).
+- **Per-role output budgets** via `RESEARCH_MAX_OUTPUT_TOKENS` and
+  `GENERATION_MAX_OUTPUT_TOKENS`, both optional positive integers defaulting to 8192.
+  Every tool-loop, forced-finalization, generation, refine, and repair request sends
+  its role's cap explicitly. This bounds worst-case spend and prevents OpenRouter from
+  applying a model's full output ceiling during its affordability check.
 
 **Rejected — reinstate a multi-provider abstraction now** (port Mark's gateway/anthropic
 paths). Two+ live SDKs, more config and test surface, for a launch where OpenRouter
@@ -328,5 +333,6 @@ Per the #100 resolution this is a clean write-over (relaunch, no users):
   `getYouTubeTranscripts`, `extractInsight`, `createDraft`, `createLinkedInPost`,
   `updateDraft`) — folded into `research()` + `generate()` — and their `PostDraft`
   coupling.
-- Config: add `RESEARCH_MODEL`, `GENERATION_MODEL`, `RESEARCH_MAX_STEPS`, `TAVILY_API_KEY`;
-  retire `MARK_*`.
+- Config: add `RESEARCH_MODEL`, `GENERATION_MODEL`,
+  `RESEARCH_MAX_OUTPUT_TOKENS`, `GENERATION_MAX_OUTPUT_TOKENS`,
+  `RESEARCH_MAX_STEPS`, `TAVILY_API_KEY`; retire `MARK_*`.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -9,6 +9,7 @@ The API is versioned under `/api/v1`:
 | Artifact library and generation     | [artifacts.md](./artifacts.md) |
 | Generation progress over SSE        | [runs.md](./runs.md)           |
 | Binding artifacts to LinkedIn posts | [posts.md](./posts.md)         |
+| LinkedIn connected accounts         | [linkedin.md](./linkedin.md)   |
 | Paddle checkout and billing         | [payment.md](./payment.md)     |
 
 ## Common conventions

--- a/docs/api/linkedin.md
+++ b/docs/api/linkedin.md
@@ -1,0 +1,31 @@
+# LinkedIn Connected Accounts API
+
+These endpoints require authentication.
+
+## Fetch organizations
+
+### `GET /api/v1/auth/linkedin/orgs`
+
+Returns the LinkedIn organizations the connected personal account can
+administer. The account must be active and have usable publishing access.
+
+If the stored access expiry has passed, or LinkedIn rejects the credential with
+`401`, the endpoint returns `409`:
+
+```json
+{
+  "statusCode": 409,
+  "message": "Reconnect your LinkedIn account to fetch organizations.",
+  "error": "Conflict"
+}
+```
+
+The client should direct the user through LinkedIn reconnection before retrying.
+
+## Connect organizations
+
+### `POST /api/v1/auth/linkedin/orgs`
+
+Connects selected organizations after verifying them against the organizations
+available to the personal LinkedIn account. It inherits the same `409`
+reconnection response when that personal account no longer has usable access.

--- a/docs/api/posts.md
+++ b/docs/api/posts.md
@@ -108,11 +108,13 @@ The older `GET /posts/linkedin/image/:urn` route remains available for compatibi
 
 ### `POST /posts/:id/publish`
 
-Publishes a `DRAFT`, `FAILED`, or `SCHEDULED` Post immediately. A pending schedule job is removed first. `PUBLISHED` is terminal.
+Publishes a `DRAFT`, `FAILED`, or `SCHEDULED` Post immediately. After the connected-account preflight succeeds, a pending schedule job is removed. `PUBLISHED` is terminal.
 
 Publishing is blocked with `409` while any media item is `PENDING`, `UPLOADING`, or `FAILED`; failed media must be removed or uploaded again. READY media is composed as one `content.media` object or an ordered `content.multiImage` object.
 
 LinkedIn failures persist `status: "FAILED"` and `failureReason`. The Post may be edited, retried, or scheduled again.
+
+Expired or revoked LinkedIn access returns `409` with `Reconnect connected account to publish posts.` A known local expiry is rejected before a pending schedule is removed or the Post is changed. If LinkedIn returns `401` during an actual publish attempt, the Post moves to `FAILED` with the same reconnect reason.
 
 ### `POST /posts/:id/schedule`
 
@@ -123,6 +125,8 @@ Schedules a `DRAFT` or `FAILED` Post, or reschedules a `SCHEDULED` Post.
 ```
 
 The date must be in the future. The same media-readiness rules as immediate publishing apply. First-time scheduling consumes the existing scheduled-post quota; rescheduling and unscheduling do not refund or charge it again.
+
+Expired LinkedIn access returns `409` with `Reconnect connected account to schedule posts.` before quota usage, artifact pinning, queue changes, or Post mutation.
 
 ### `POST /posts/:id/unschedule`
 

--- a/docs/artifact-workflow-prd.md
+++ b/docs/artifact-workflow-prd.md
@@ -577,7 +577,10 @@ them, so absence is a bug, and re-running cannot fix it.
 surfaces as `WorkflowError { retryable }` per `src/llm`'s classification.
 
 **`GENERATE`** — calls `ctx.agent.generate(...)` → `{ title?, content }`, one `complete`
-call with no tools, validated against the §4 Zod union with **one inline repair retry**.
+call with no tools. Its concrete per-type Zod object is sent to OpenRouter as a strict
+JSON-Schema response format with parameter-compatible routing, then validated locally
+against the same schema. A local failure receives **one inline repair retry**, also
+provider-constrained and locally validated.
 Initial runs require a trimmed 1–100 character title; refine runs produce content only.
 Dispatch on `type`. For DOCUMENT, `templateId` resolution happens **inside this step**: a
 user-supplied `theme` is stamped authoritatively (the model cannot override it); if omitted
@@ -724,10 +727,11 @@ interface GenerateInput {
 ```
 
 **Generation is not a loop.** `generate()` has all its inputs already; it emits typed
-`ArtifactContent` via Layer 1's `complete` (no tools), validated by
-`ResponseParserService.parseWithSchema` against the §4 union, with one inline repair retry
-re-prompting with the validation error. Prompt selection per type and per revision is
-`AgentRunner`'s internal concern.
+`ArtifactContent` via Layer 1's `complete` (no tools). The concrete generation Zod object
+is both the provider's strict JSON-Schema response format and
+`ResponseParserService.parseWithSchema`'s local contract. One inline repair retry
+re-prompts with the validation error and reuses that constraint. Prompt selection per type
+and per revision is `AgentRunner`'s internal concern.
 
 ### The research agent
 

--- a/docs/artifact-workflow-step-pipelines-design.md
+++ b/docs/artifact-workflow-step-pipelines-design.md
@@ -149,8 +149,12 @@ upstream slot is missing — #103 §3) and **write only their own slots** via a 
 - **Reads:** `input` (`type, prompt, stylePreset`), `research?` (cached or fresh),
   `refine?` (prior content + feedback).
 - **Calls:** `ctx.agent.generate({ type, prompt, stylePreset, research?, refine? })`
-  → `ArtifactContent`, a single `complete` call (no tools), validated against #102 §4's
-  Zod discriminated union with **one inline repair retry** on Zod failure (#104 §4, §8).
+  → `ArtifactContent`, a single `complete` call (no tools). The same concrete Zod
+  object is converted to a strict OpenRouter JSON-Schema response format and then
+  validated locally after completion. OpenRouter routing requires response-format
+  support rather than allowing a provider to ignore the constraint. A local Zod
+  failure still receives **one inline repair retry**, constrained and validated by
+  that same schema (#104 §4, §8).
   Dispatch on `type`:
   - **POST** → `{ commentary }` (text is the whole artifact).
   - **POLL** → `{ commentary?, poll { question ≤140, options[2–4] ≤30 each,

--- a/docs/linkedin-poll-document-api-research.md
+++ b/docs/linkedin-poll-document-api-research.md
@@ -224,9 +224,13 @@ Consequences for map #99:
   ([Poll API schema](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
 - **Document + image: not possible.** A document post is `content.media` with a
   single document URN; you cannot also attach an image in the same post.
-- **Anything + text: yes.** `commentary` is a top-level field independent of
-  `content`, so *every* content type (poll, document, image, video, multiImage)
-  can carry accompanying text ([Posts API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04)).
+- **Every post carries the top-level `commentary` field.** The Posts schema marks
+  `commentary` required, independently of `content`, and the poll/document examples
+  both include it. The app may model framing text as optional for a poll or document,
+  but the outbound Posts request must still serialize `commentary` (as an empty
+  string when the artifact has no framing text)
+  ([Posts API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-04),
+  [Poll API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/poll-post-api?view=li-lms-2026-05)).
 - **`multiImage`** (many images) and single `media` are themselves mutually
   exclusive — exactly as the app already models in `publishOnLinkedIn`
   (single → `content.media`, many → `content.multiImage`).

--- a/docs/post-schema-and-publish-flow-design.md
+++ b/docs/post-schema-and-publish-flow-design.md
@@ -161,12 +161,16 @@ The code resolves the pinned artifact version's **`ArtifactContent`** (#102 §4)
 folds READY uploaded media into the LinkedIn content object. It composes per type,
 using the **#101** publish facts:
 
-| Artifact `type` | `commentary` | `content` object | LinkedIn asset upload at publish |
+| Artifact `type` | Artifact framing text | `content` object | LinkedIn asset upload at publish |
 |---|---|---|---|
 | **POST** | the text | *(none)* | none |
 | **POLL** | optional | `content.poll = { question, options[], settings:{ duration, voteSelectionType:'SINGLE_VOTE', isVoterVisibleToAuthor:true } }` | **none** — poll is inline JSON (#101 §1, §5) |
 | **DOCUMENT** | optional | `content.media = { id: <documentUrn>, title }` | **yes** — upload the version's R2 `pdfUrl` → LinkedIn (#101 §2–3) |
 
+- **Wire-level commentary is always present:** LinkedIn's Posts contract requires
+  the top-level `commentary` field for every content type. POLL and DOCUMENT may
+  omit framing text in their artifact content, but `publishPost` serializes that
+  absence as `commentary: ""`.
 - **`IContent` gains a `poll` arm** (today it has only `media`/`multiImage`); document rides
   in the existing `media.id` with a `urn:li:document:*` id (no new `IContent` field — #101 §5).
 - **Duration mapping:** #102 stores `durationDays: 1|3|7|14` → LinkedIn `settings.duration`

--- a/src/agent/agent-runner.service.spec.ts
+++ b/src/agent/agent-runner.service.spec.ts
@@ -31,6 +31,7 @@ import { z } from 'zod';
 import { LLMError } from '../llm/errors';
 import { LLMProvider, MessageRole } from '../llm/interfaces';
 import type {
+  CompletionOptions,
   CompletionResult,
   LLMMessage,
   ToolTurnResult,
@@ -49,6 +50,7 @@ import { StylePreset } from './style-presets.config';
 const GENERATION_MODEL = 'test/generation-model';
 const RESEARCH_MODEL = 'test/research-model';
 const TAVILY_API_KEY = 'test/tavily-key';
+const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
 
 const CONFIG: Record<string, string> = {
   GENERATION_MODEL,
@@ -83,7 +85,19 @@ const toolTurn = (
   usage: usage(cost),
 });
 
-const makeService = (maxSteps?: number, maxSuccessfulSearches?: number) => {
+interface ServiceConfig {
+  maxSteps?: number;
+  maxSuccessfulSearches?: number;
+  researchMaxOutputTokens?: string | number;
+  generationMaxOutputTokens?: string | number;
+}
+
+const makeService = ({
+  maxSteps,
+  maxSuccessfulSearches,
+  researchMaxOutputTokens,
+  generationMaxOutputTokens,
+}: ServiceConfig = {}) => {
   const llmService = { complete: jest.fn(), completeWithTools: jest.fn() };
   const configService = {
     getOrThrow: jest.fn((key: string) => CONFIG[key]),
@@ -91,6 +105,12 @@ const makeService = (maxSteps?: number, maxSuccessfulSearches?: number) => {
       if (key === 'RESEARCH_MAX_STEPS') return maxSteps;
       if (key === 'RESEARCH_MAX_SUCCESSFUL_SEARCHES') {
         return maxSuccessfulSearches;
+      }
+      if (key === 'RESEARCH_MAX_OUTPUT_TOKENS') {
+        return researchMaxOutputTokens;
+      }
+      if (key === 'GENERATION_MAX_OUTPUT_TOKENS') {
+        return generationMaxOutputTokens;
       }
       return undefined;
     }),
@@ -116,9 +136,23 @@ let service: AgentRunnerService;
 let mocks: ReturnType<typeof makeService>['mocks'];
 let fixtures: ReturnType<typeof makeService>['fixtures'];
 
+type CompleteCall = [LLMProvider, LLMMessage[], CompletionOptions | undefined];
+type CompleteWithToolsCall = [
+  LLMProvider,
+  LLMMessage[],
+  unknown[],
+  CompletionOptions | undefined,
+];
+
+const completeCalls = (): CompleteCall[] =>
+  mocks.llmService.complete.mock.calls as unknown as CompleteCall[];
+
+const completeWithToolsCalls = (): CompleteWithToolsCall[] =>
+  mocks.llmService.completeWithTools.mock
+    .calls as unknown as CompleteWithToolsCall[];
+
 /** The messages passed to `llmService.complete` on its nth (1-based) call. */
-const messagesOfCall = (n: number): LLMMessage[] =>
-  mocks.llmService.complete.mock.calls[n - 1][1] as LLMMessage[];
+const messagesOfCall = (n: number): LLMMessage[] => completeCalls()[n - 1][1];
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -175,7 +209,27 @@ describe('AgentRunnerService', () => {
       expect(mocks.llmService.complete).toHaveBeenCalledWith(
         LLMProvider.OPENROUTER,
         expect.any(Array),
-        { model: GENERATION_MODEL },
+        {
+          model: GENERATION_MODEL,
+          max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        },
+      );
+    });
+
+    it('should cap generation with GENERATION_MAX_OUTPUT_TOKENS', async () => {
+      ({ service, mocks, fixtures } = makeService({
+        generationMaxOutputTokens: 4096,
+      }));
+      mocks.llmService.complete.mockResolvedValue(
+        completion(generatedJson({ commentary: 'Write more.' })),
+      );
+
+      await service.generate(fixtures.input);
+
+      expect(mocks.llmService.complete).toHaveBeenCalledWith(
+        LLMProvider.OPENROUTER,
+        expect.any(Array),
+        { model: GENERATION_MODEL, max_tokens: 4096 },
       );
     });
 
@@ -255,6 +309,10 @@ describe('AgentRunnerService', () => {
       expect(user.content).toContain('Make the hook sharper.');
       expect(messagesOfCall(1)[0].content).not.toContain('TITLE:');
       expect(generated).toEqual({ content: { commentary: 'Revised.' } });
+      expect(completeCalls()[0][2]).toEqual({
+        model: GENERATION_MODEL,
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      });
     });
 
     it('should report usage per LLM turn, tagged with the model', async () => {
@@ -312,6 +370,15 @@ describe('AgentRunnerService', () => {
           content: { commentary: 'Repaired.' },
         });
         expect(mocks.llmService.complete).toHaveBeenCalledTimes(2);
+        expect(mocks.llmService.complete).toHaveBeenNthCalledWith(
+          2,
+          LLMProvider.OPENROUTER,
+          expect.any(Array),
+          {
+            model: GENERATION_MODEL,
+            max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+          },
+        );
 
         const repair = messagesOfCall(2);
         expect(repair).toHaveLength(4);
@@ -527,8 +594,7 @@ describe('AgentRunnerService', () => {
       expect(result.steps[0].toolResults).toEqual([{ answer: 42 }]);
 
       // The tool output is fed back as a role:'tool' message on the 2nd turn.
-      const secondTurnMessages = mocks.llmService.completeWithTools.mock
-        .calls[1][1] as LLMMessage[];
+      const secondTurnMessages = completeWithToolsCalls()[1][1];
       const toolMessage = secondTurnMessages.find(
         (m) => m.role === MessageRole.Tool,
       );
@@ -615,8 +681,11 @@ describe('AgentRunnerService', () => {
       expect(result.steps).toHaveLength(2);
 
       // The finalization turn is passed no tools.
-      const [, , finalOptions] = mocks.llmService.complete.mock.calls[0];
-      expect(finalOptions).toEqual({ model: RESEARCH_MODEL });
+      const [, , finalOptions] = completeCalls()[0];
+      expect(finalOptions).toEqual({
+        model: RESEARCH_MODEL,
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      });
     });
 
     it('should accumulate usage across every turn including finalization', async () => {
@@ -788,7 +857,9 @@ describe('AgentRunnerService', () => {
     });
 
     it('should clamp configured successful Tavily lookups to the five-search safety ceiling', async () => {
-      ({ service, mocks, fixtures } = makeService(undefined, 6));
+      ({ service, mocks, fixtures } = makeService({
+        maxSuccessfulSearches: 6,
+      }));
       tavilySearch.mockResolvedValue(tavilyResults([]));
       const calls = Array.from({ length: 6 }, (_, index) => ({
         id: `c${index + 1}`,
@@ -852,14 +923,46 @@ describe('AgentRunnerService', () => {
 
       await service.research({ prompt: 'topic', type: ArtifactType.POST });
 
-      const [, , tools, options] =
-        mocks.llmService.completeWithTools.mock.calls[0];
-      expect(options).toEqual({ model: RESEARCH_MODEL });
+      const [, , tools, options] = completeWithToolsCalls()[0];
+      expect(options).toEqual({
+        model: RESEARCH_MODEL,
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      });
       expect(tools).toEqual([expect.objectContaining({ name: 'searchWeb' })]);
     });
 
+    it('should cap every research turn with RESEARCH_MAX_OUTPUT_TOKENS', async () => {
+      ({ service, mocks, fixtures } = makeService({
+        maxSteps: 2,
+        researchMaxOutputTokens: 4096,
+      }));
+      tavilySearch.mockResolvedValue(tavilyResults([]));
+      mocks.llmService.completeWithTools.mockResolvedValue(
+        toolTurn([{ id: 'c', name: 'searchWeb', input: { query: 'x' } }]),
+      );
+      mocks.llmService.complete.mockResolvedValue(
+        completion('forced synthesis'),
+      );
+
+      await service.research({
+        prompt: 'topic',
+        type: ArtifactType.POST,
+      });
+
+      for (const call of completeWithToolsCalls()) {
+        expect(call[3]).toEqual({
+          model: RESEARCH_MODEL,
+          max_tokens: 4096,
+        });
+      }
+      expect(completeCalls()[0][2]).toEqual({
+        model: RESEARCH_MODEL,
+        max_tokens: 4096,
+      });
+    });
+
     it('should stop at RESEARCH_MAX_STEPS and finalize when the model keeps searching', async () => {
-      ({ service, mocks, fixtures } = makeService(2));
+      ({ service, mocks, fixtures } = makeService({ maxSteps: 2 }));
       tavilySearch.mockResolvedValue(tavilyResults([]));
       mocks.llmService.completeWithTools.mockResolvedValue(
         toolTurn([{ id: 'c', name: 'searchWeb', input: { query: 'x' } }]),
@@ -876,5 +979,38 @@ describe('AgentRunnerService', () => {
       expect(mocks.llmService.completeWithTools).toHaveBeenCalledTimes(2);
       expect(result.findings).toBe('forced synthesis');
     });
+  });
+
+  describe('output-token configuration', () => {
+    it.each([undefined, '', 0, -1, 1.5, 'not-a-number'])(
+      'should fall back to 8192 when output-token settings are invalid (%p)',
+      async (configuredValue) => {
+        ({ service, mocks, fixtures } = makeService({
+          researchMaxOutputTokens: configuredValue,
+          generationMaxOutputTokens: configuredValue,
+        }));
+        mocks.llmService.complete.mockResolvedValue(
+          completion(generatedJson({ commentary: 'Generated.' })),
+        );
+        mocks.llmService.completeWithTools.mockResolvedValue(
+          toolTurn([], 0.01, 'Researched.'),
+        );
+
+        await service.generate(fixtures.input);
+        await service.research({
+          prompt: 'topic',
+          type: ArtifactType.POST,
+        });
+
+        expect(completeCalls()[0][2]).toEqual({
+          model: GENERATION_MODEL,
+          max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        });
+        expect(completeWithToolsCalls()[0][3]).toEqual({
+          model: RESEARCH_MODEL,
+          max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        });
+      },
+    );
   });
 });

--- a/src/agent/agent-runner.service.spec.ts
+++ b/src/agent/agent-runner.service.spec.ts
@@ -154,6 +154,16 @@ const completeWithToolsCalls = (): CompleteWithToolsCall[] =>
 /** The messages passed to `llmService.complete` on its nth (1-based) call. */
 const messagesOfCall = (n: number): LLMMessage[] => completeCalls()[n - 1][1];
 
+const expectGenerationOptions = (
+  options: CompletionOptions | undefined,
+  maxTokens = DEFAULT_MAX_OUTPUT_TOKENS,
+): void => {
+  expect(options?.model).toBe(GENERATION_MODEL);
+  expect(options?.max_tokens).toBe(maxTokens);
+  expect(options?.responseSchema?.name).toBe('artifact_generation');
+  expect(options?.responseSchema?.schema).toBeInstanceOf(z.ZodType);
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
   ({ service, mocks, fixtures } = makeService());
@@ -206,14 +216,9 @@ describe('AgentRunnerService', () => {
 
       await service.generate(fixtures.input);
 
-      expect(mocks.llmService.complete).toHaveBeenCalledWith(
-        LLMProvider.OPENROUTER,
-        expect.any(Array),
-        {
-          model: GENERATION_MODEL,
-          max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
-        },
-      );
+      const [provider, , options] = completeCalls()[0];
+      expect(provider).toBe(LLMProvider.OPENROUTER);
+      expectGenerationOptions(options);
     });
 
     it('should cap generation with GENERATION_MAX_OUTPUT_TOKENS', async () => {
@@ -226,11 +231,7 @@ describe('AgentRunnerService', () => {
 
       await service.generate(fixtures.input);
 
-      expect(mocks.llmService.complete).toHaveBeenCalledWith(
-        LLMProvider.OPENROUTER,
-        expect.any(Array),
-        { model: GENERATION_MODEL, max_tokens: 4096 },
-      );
+      expectGenerationOptions(completeCalls()[0][2], 4096);
     });
 
     it('should strip markdown fences before validating', async () => {
@@ -309,10 +310,7 @@ describe('AgentRunnerService', () => {
       expect(user.content).toContain('Make the hook sharper.');
       expect(messagesOfCall(1)[0].content).not.toContain('TITLE:');
       expect(generated).toEqual({ content: { commentary: 'Revised.' } });
-      expect(completeCalls()[0][2]).toEqual({
-        model: GENERATION_MODEL,
-        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
-      });
+      expectGenerationOptions(completeCalls()[0][2]);
     });
 
     it('should report usage per LLM turn, tagged with the model', async () => {
@@ -370,15 +368,8 @@ describe('AgentRunnerService', () => {
           content: { commentary: 'Repaired.' },
         });
         expect(mocks.llmService.complete).toHaveBeenCalledTimes(2);
-        expect(mocks.llmService.complete).toHaveBeenNthCalledWith(
-          2,
-          LLMProvider.OPENROUTER,
-          expect.any(Array),
-          {
-            model: GENERATION_MODEL,
-            max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
-          },
-        );
+        expect(completeCalls()[1][0]).toBe(LLMProvider.OPENROUTER);
+        expectGenerationOptions(completeCalls()[1][2]);
 
         const repair = messagesOfCall(2);
         expect(repair).toHaveLength(4);
@@ -499,6 +490,53 @@ describe('AgentRunnerService', () => {
         expect(mocks.llmService.complete).toHaveBeenCalledTimes(1);
       });
 
+      it('should constrain both attempts when repairing over-limit slide copy', async () => {
+        const overLimitDeck = generatedJson({
+          document: {
+            templateId: 'minimal',
+            slides: [
+              { type: 'cover', fields: { title: 'A carousel' } },
+              {
+                type: 'list',
+                fields: {
+                  heading: 'Three ideas',
+                  items: [
+                    'Valid item',
+                    'a'.repeat(81),
+                    'b'.repeat(81),
+                    'c'.repeat(81),
+                  ],
+                },
+              },
+              {
+                type: 'cta',
+                fields: {
+                  headline: 'Keep learning',
+                  action: 'Follow',
+                  handle: 'h'.repeat(41),
+                },
+              },
+            ],
+          },
+        });
+        mocks.llmService.complete
+          .mockResolvedValueOnce(completion(overLimitDeck))
+          .mockResolvedValueOnce(completion(deckJson('minimal')));
+
+        await expect(service.generate(documentInput)).resolves.toMatchObject({
+          content: { document: { templateId: 'minimal' } },
+        });
+
+        expect(mocks.llmService.complete).toHaveBeenCalledTimes(2);
+        for (const [, , options] of completeCalls()) {
+          expectGenerationOptions(options);
+        }
+        const repairPrompt = messagesOfCall(2).at(-1)?.content ?? '';
+        expect(repairPrompt).toContain('maximum');
+        expect(repairPrompt).toContain('80');
+        expect(repairPrompt).toContain('40');
+      });
+
       it('should keep the model-chosen theme when the user supplied none', async () => {
         mocks.llmService.complete.mockResolvedValue(
           completion(deckJson('gradient')),
@@ -508,6 +546,56 @@ describe('AgentRunnerService', () => {
 
         expect(generated.content).toMatchObject({
           document: { templateId: 'gradient' },
+        });
+      });
+
+      it('should remove provider null placeholders from optional document fields', async () => {
+        mocks.llmService.complete.mockResolvedValue(
+          completion(
+            generatedJson({
+              commentary: null,
+              document: {
+                templateId: 'minimal',
+                slides: [
+                  {
+                    type: 'cover',
+                    fields: {
+                      eyebrow: null,
+                      title: 'A carousel',
+                      subtitle: null,
+                    },
+                  },
+                  {
+                    type: 'cta',
+                    fields: {
+                      headline: 'Keep learning',
+                      action: 'Follow',
+                      handle: null,
+                    },
+                  },
+                ],
+              },
+            }),
+          ),
+        );
+
+        await expect(service.generate(documentInput)).resolves.toEqual({
+          title: 'Artifact title',
+          content: {
+            document: {
+              templateId: 'minimal',
+              slides: [
+                { type: 'cover', fields: { title: 'A carousel' } },
+                {
+                  type: 'cta',
+                  fields: {
+                    headline: 'Keep learning',
+                    action: 'Follow',
+                  },
+                },
+              ],
+            },
+          },
         });
       });
 
@@ -1002,10 +1090,7 @@ describe('AgentRunnerService', () => {
           type: ArtifactType.POST,
         });
 
-        expect(completeCalls()[0][2]).toEqual({
-          model: GENERATION_MODEL,
-          max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
-        });
+        expectGenerationOptions(completeCalls()[0][2]);
         expect(completeWithToolsCalls()[0][3]).toEqual({
           model: RESEARCH_MODEL,
           max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,

--- a/src/agent/agent-runner.service.ts
+++ b/src/agent/agent-runner.service.ts
@@ -45,6 +45,7 @@ import {
 
 const DEFAULT_RESEARCH_MAX_STEPS = 5;
 const DEFAULT_RESEARCH_MAX_SUCCESSFUL_SEARCHES = 5;
+const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
 
 const describeError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
@@ -97,6 +98,8 @@ export class AgentRunnerService implements AgentRunner {
   private readonly researchModel: string;
   private readonly researchMaxSteps: number;
   private readonly researchMaxSuccessfulSearches: number;
+  private readonly researchMaxOutputTokens: number;
+  private readonly generationMaxOutputTokens: number;
   private readonly searchWebTool: Tool;
 
   constructor(
@@ -115,6 +118,14 @@ export class AgentRunnerService implements AgentRunner {
         DEFAULT_RESEARCH_MAX_SUCCESSFUL_SEARCHES,
       ),
       DEFAULT_RESEARCH_MAX_SUCCESSFUL_SEARCHES,
+    );
+    this.researchMaxOutputTokens = this.readPositiveInteger(
+      'RESEARCH_MAX_OUTPUT_TOKENS',
+      DEFAULT_MAX_OUTPUT_TOKENS,
+    );
+    this.generationMaxOutputTokens = this.readPositiveInteger(
+      'GENERATION_MAX_OUTPUT_TOKENS',
+      DEFAULT_MAX_OUTPUT_TOKENS,
     );
     this.searchWebTool = createSearchWebTool(
       this.configService.getOrThrow<string>('TAVILY_API_KEY'),
@@ -171,14 +182,8 @@ export class AgentRunnerService implements AgentRunner {
     config: AgentRunConfig,
     hooks?: AgentHooks,
   ): Promise<AgentRunResult> {
-    const {
-      system,
-      messages,
-      tools,
-      maxSteps,
-      maxSuccessfulToolCalls,
-      model,
-    } = config;
+    const { system, messages, tools, maxSteps, maxSuccessfulToolCalls, model } =
+      config;
     // A label for the usage tag; the request itself passes `model` through as-is,
     // letting the strategy fall back to its default when it is undefined.
     const usageModel = model ?? 'default';
@@ -197,7 +202,7 @@ export class AgentRunnerService implements AgentRunner {
         LLMProvider.OPENROUTER,
         conversation,
         toolDefinitions,
-        { model },
+        { model, max_tokens: this.researchMaxOutputTokens },
       );
       addUsage(usage, turn.usage);
       hooks?.onUsage?.({ ...turn.usage, model: usageModel });
@@ -216,9 +221,7 @@ export class AgentRunnerService implements AgentRunner {
       if (maxSuccessfulToolCalls === undefined) {
         toolResults.push(
           ...(await Promise.all(
-            turn.toolCalls.map((call) =>
-              this.executeTool(tools, call, hooks),
-            ),
+            turn.toolCalls.map((call) => this.executeTool(tools, call, hooks)),
           )),
         );
       } else {
@@ -240,11 +243,11 @@ export class AgentRunnerService implements AgentRunner {
             (output) => !isToolError(output),
           ).length;
         }
-        for (const _call of pending) {
-          toolResults.push({
+        toolResults.push(
+          ...pending.map(() => ({
             error: `Successful tool-call limit of ${maxSuccessfulToolCalls} reached`,
-          });
-        }
+          })),
+        );
       }
 
       turn.toolCalls.forEach((call, i) => {
@@ -263,7 +266,7 @@ export class AgentRunnerService implements AgentRunner {
     const final = await this.llmService.complete(
       LLMProvider.OPENROUTER,
       conversation,
-      { model },
+      { model, max_tokens: this.researchMaxOutputTokens },
     );
     addUsage(usage, final.usage);
     hooks?.onUsage?.({ ...final.usage, model: usageModel });
@@ -438,7 +441,10 @@ export class AgentRunnerService implements AgentRunner {
     const { text, usage } = await this.llmService.complete(
       LLMProvider.OPENROUTER,
       messages,
-      { model: this.generationModel },
+      {
+        model: this.generationModel,
+        max_tokens: this.generationMaxOutputTokens,
+      },
     );
 
     hooks?.onUsage?.({ ...usage, model: this.generationModel });

--- a/src/agent/agent-runner.service.ts
+++ b/src/agent/agent-runner.service.ts
@@ -1,12 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ArtifactType } from 'src/database/schemas';
-import { z } from 'zod';
-import {
-  ArtifactContent,
-  artifactTitleSchema,
-  contentSchemaFor,
-} from '../artifact/schemas';
+import type { ZodType } from 'zod';
+import { ArtifactContent, generationSchemaFor } from '../artifact/schemas';
 import { LLMProvider, MessageRole } from '../llm/interfaces';
 import type {
   LLMMessage,
@@ -286,10 +282,7 @@ export class AgentRunnerService implements AgentRunner {
     hooks?: AgentHooks,
   ): Promise<ArtifactGenerationResult> {
     const includeTitle = input.refine === undefined;
-    const contentSchema = contentSchemaFor(input.type);
-    const schema = includeTitle
-      ? contentSchema.and(z.object({ title: artifactTitleSchema }))
-      : contentSchema;
+    const schema = generationSchemaFor(input.type, includeTitle);
     const messages: LLMMessage[] = [
       {
         role: MessageRole.System,
@@ -298,12 +291,14 @@ export class AgentRunnerService implements AgentRunner {
       { role: MessageRole.User, content: buildGenerationUserPrompt(input) },
     ];
 
-    const draft = await this.complete(messages, hooks);
+    const draft = await this.complete(messages, hooks, schema);
 
     let validationError: unknown;
     try {
       return this.toGenerationResult(
-        this.parser.parseWithSchema(draft, schema),
+        this.parser.parseWithSchema(draft, schema, {
+          stripNullObjectValues: true,
+        }),
         input,
         includeTitle,
       );
@@ -312,7 +307,7 @@ export class AgentRunnerService implements AgentRunner {
     }
 
     this.logger.warn(
-      `Generated ${input.type} content failed validation; repairing: ${describeError(validationError)}`,
+      `Generated ${input.type} first draft failed validation; attempting one repair: ${describeError(validationError)}`,
     );
 
     const repaired = await this.complete(
@@ -325,11 +320,14 @@ export class AgentRunnerService implements AgentRunner {
         },
       ],
       hooks,
+      schema,
     );
 
     try {
       return this.toGenerationResult(
-        this.parser.parseWithSchema(repaired, schema),
+        this.parser.parseWithSchema(repaired, schema, {
+          stripNullObjectValues: true,
+        }),
         input,
         includeTitle,
       );
@@ -437,6 +435,7 @@ export class AgentRunnerService implements AgentRunner {
   private async complete(
     messages: LLMMessage[],
     hooks?: AgentHooks,
+    responseSchema?: ZodType,
   ): Promise<string> {
     const { text, usage } = await this.llmService.complete(
       LLMProvider.OPENROUTER,
@@ -444,6 +443,14 @@ export class AgentRunnerService implements AgentRunner {
       {
         model: this.generationModel,
         max_tokens: this.generationMaxOutputTokens,
+        ...(responseSchema
+          ? {
+              responseSchema: {
+                name: 'artifact_generation',
+                schema: responseSchema,
+              },
+            }
+          : {}),
       },
     );
 

--- a/src/artifact/schemas/artifact-content.schema.spec.ts
+++ b/src/artifact/schemas/artifact-content.schema.spec.ts
@@ -12,9 +12,29 @@ jest.mock(
   { virtual: true },
 );
 
-import { ZodError } from 'zod';
+import { z, ZodError } from 'zod';
 import { ArtifactType } from 'src/database/schemas';
-import { parseArtifactContent } from './artifact-content.schema';
+import {
+  generationSchemaFor,
+  parseArtifactContent,
+} from './artifact-content.schema';
+
+describe('generationSchemaFor', () => {
+  it('should expose one provider-compatible DOCUMENT object with the slide caps', () => {
+    const jsonSchema = z.toJSONSchema(
+      generationSchemaFor(ArtifactType.DOCUMENT, true),
+      { target: 'draft-7', io: 'output' },
+    );
+    const serialized = JSON.stringify(jsonSchema);
+
+    expect(jsonSchema).not.toHaveProperty('allOf');
+    expect(serialized).toContain('"maxLength":80');
+    expect(serialized).toContain('"maxLength":40');
+    expect(serialized).toContain('"maxLength":100');
+    expect(serialized).not.toContain('"pdfKey"');
+    expect(serialized).not.toContain('"pageCount"');
+  });
+});
 
 describe('parseArtifactContent', () => {
   describe('POST arm', () => {

--- a/src/artifact/schemas/artifact-content.schema.ts
+++ b/src/artifact/schemas/artifact-content.schema.ts
@@ -101,6 +101,13 @@ export const documentContentSchema = z.object({
   }),
 });
 
+const documentGenerationContentSchema = documentContentSchema.extend({
+  document: documentContentSchema.shape.document.omit({
+    pdfKey: true,
+    pageCount: true,
+  }),
+});
+
 export type DocumentContent = z.infer<typeof documentContentSchema>;
 
 // Discriminated on the artifact's family-level `type`. POST/POLL carry text
@@ -129,6 +136,38 @@ export function contentSchemaFor(
     throw new Error(`No content schema implemented for artifact type ${type}`);
   }
   return schema;
+}
+
+/**
+ * The provider-facing generation contract. Initial generation adds a title by
+ * extending the concrete content object instead of intersecting two schemas:
+ * JSON-Schema structured-output providers handle a single object reliably,
+ * while an `allOf` intersection is not uniformly supported.
+ */
+export function generationSchemaFor(
+  type: ArtifactType,
+  includeTitle: boolean,
+): z.ZodType<ArtifactContent & { title?: string }> {
+  let schema: z.ZodObject;
+  switch (type) {
+    case ArtifactType.POST:
+      schema = postContentSchema;
+      break;
+    case ArtifactType.POLL:
+      schema = pollContentSchema;
+      break;
+    case ArtifactType.DOCUMENT:
+      schema = documentGenerationContentSchema;
+      break;
+    default:
+      throw new Error(
+        `No generation schema implemented for artifact type ${String(type)}`,
+      );
+  }
+
+  return (includeTitle
+    ? schema.extend({ title: artifactTitleSchema })
+    : schema) as unknown as z.ZodType<ArtifactContent & { title?: string }>;
 }
 
 export function parseArtifactContent(

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -515,6 +515,115 @@ describe('AuthService.disconnectConnectedAccount', () => {
   });
 });
 
+describe('AuthService.getLinkedinOrganizations', () => {
+  const makeService = () => {
+    const connectedAccountModel = { findOne: jest.fn() };
+    const encryptionService = {
+      decrypt: jest.fn().mockResolvedValue('decrypted-token'),
+    };
+    const featureGatingService = {
+      assertCompanyPagesAccess: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new AuthService(
+      {} as any,
+      {} as any,
+      connectedAccountModel as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      encryptionService as any,
+      featureGatingService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    return {
+      service,
+      mocks: {
+        connectedAccountModel,
+        encryptionService,
+        featureGatingService,
+      },
+    };
+  };
+
+  const usableAccount = () => ({
+    user: new Types.ObjectId(),
+    provider: AccountProvider.LINKEDIN,
+    accountType: LinkedinAccountType.PERSON,
+    externalId: 'person-1',
+    isActive: true,
+    accessToken: 'encrypted-token',
+    accessTokenExpiresAt: new Date(Date.now() + 60_000),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reject organization fetching when LinkedIn access has expired', async () => {
+    const { service, mocks } = makeService();
+    mocks.connectedAccountModel.findOne.mockResolvedValue({
+      ...usableAccount(),
+      accessTokenExpiresAt: new Date(Date.now() - 60_000),
+    });
+
+    await expect(
+      service.getLinkedinOrganizations(new Types.ObjectId().toString()),
+    ).rejects.toMatchObject({
+      response: {
+        statusCode: 409,
+        message: 'Reconnect your LinkedIn account to fetch organizations.',
+      },
+    });
+
+    expect(mocks.encryptionService.decrypt).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('should map a LinkedIn ACL 401 response to a reconnect conflict', async () => {
+    const { service, mocks } = makeService();
+    mocks.connectedAccountModel.findOne.mockResolvedValue(usableAccount());
+    (apiFetch as jest.Mock).mockRejectedValue(
+      new ApiError(401, 'Unauthorized', { message: 'Expired token' }),
+    );
+
+    await expect(
+      service.getLinkedinOrganizations(new Types.ObjectId().toString()),
+    ).rejects.toMatchObject({
+      response: {
+        statusCode: 409,
+        message: 'Reconnect your LinkedIn account to fetch organizations.',
+      },
+    });
+  });
+
+  it('should map an organization detail 401 response to a reconnect conflict', async () => {
+    const { service, mocks } = makeService();
+    mocks.connectedAccountModel.findOne.mockResolvedValue(usableAccount());
+    (apiFetch as jest.Mock)
+      .mockResolvedValueOnce({
+        data: {
+          elements: [
+            {
+              organization: 'urn:li:organization:123',
+              role: 'ADMINISTRATOR',
+              state: 'APPROVED',
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(
+        new ApiError(401, 'Unauthorized', { message: 'Expired token' }),
+      );
+
+    await expect(
+      service.getLinkedinOrganizations(new Types.ObjectId().toString()),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+});
+
 describe('AuthService.getLinkedinUser', () => {
   const createService = () =>
     new AuthService(

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -24,6 +24,7 @@ import { FeatureGatingService } from '../feature-gating/feature-gating.service';
 import { LinkedinAvatarRefreshQueue } from '../workflow/linkedin-avatar-refresh.queue';
 import { ScheduleQueue } from '../workflow/schedule.queue';
 import { EmailQueue } from '../workflow/email.queue';
+import { isLinkedinAccessUsable } from '../common/HelperFn/linkedin-access.helper';
 
 interface LinkedinUserInfo {
   memberId: string;
@@ -221,60 +222,71 @@ export class AuthService {
     if (!connectedAccount) {
       throw new NotFoundException('LinkedIn account not connected');
     }
-    if (!connectedAccount.isActive || !connectedAccount.accessToken) {
-      throw new BadRequestException(
-        'Reconnect your LinkedIn account to fetch organizations',
+    if (!isLinkedinAccessUsable(connectedAccount)) {
+      throw new ConflictException(
+        'Reconnect your LinkedIn account to fetch organizations.',
       );
     }
 
-    const accessToken = await this.encryptionService.decrypt(
-      connectedAccount.accessToken,
-    );
-    const memberUrn = this.resolveMemberUrn(connectedAccount);
-    if (!memberUrn) {
-      throw new BadRequestException(
-        'Unable to resolve LinkedIn member identity from connected account',
+    try {
+      const accessToken = await this.encryptionService.decrypt(
+        connectedAccount.accessToken!,
       );
-    }
-
-    interface OrganizationAclResponse {
-      elements: LinkedinOrganizationAclElement[];
-    }
-
-    const aclUrl = `${this.LINKEDIN_API_BASE}/organizationAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED`;
-    const { data } = await apiFetch<OrganizationAclResponse>(aclUrl, {
-      method: 'GET',
-      headers: {
-        'X-Restli-Protocol-Version': '2.0.0',
-        'LinkedIn-Version': '202601',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    const filtered = (data.elements ?? []).filter((element) =>
-      this.LINKEDIN_ALLOWED_ORG_ROLES.has(element.role),
-    );
-
-    const enriched = await Promise.all(
-      filtered.map(async (element) => {
-        const organizationId = this.extractOrganizationId(element.organization);
-        const orgDetails = await this.fetchLinkedinOrganizationDetails(
-          organizationId,
-          accessToken,
+      const memberUrn = this.resolveMemberUrn(connectedAccount);
+      if (!memberUrn) {
+        throw new BadRequestException(
+          'Unable to resolve LinkedIn member identity from connected account',
         );
+      }
 
-        return {
-          id: organizationId,
-          urn: `urn:li:organization:${organizationId}`,
-          role: element.role,
-          state: element.state,
-          name: orgDetails?.localizedName ?? `Organization ${organizationId}`,
-          logoUrl: this.extractOrgLogoUrl(orgDetails),
-        };
-      }),
-    );
+      interface OrganizationAclResponse {
+        elements: LinkedinOrganizationAclElement[];
+      }
 
-    return enriched;
+      const aclUrl = `${this.LINKEDIN_API_BASE}/organizationAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED`;
+      const { data } = await apiFetch<OrganizationAclResponse>(aclUrl, {
+        method: 'GET',
+        headers: {
+          'X-Restli-Protocol-Version': '2.0.0',
+          'LinkedIn-Version': '202601',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const filtered = (data.elements ?? []).filter((element) =>
+        this.LINKEDIN_ALLOWED_ORG_ROLES.has(element.role),
+      );
+
+      const enriched = await Promise.all(
+        filtered.map(async (element) => {
+          const organizationId = this.extractOrganizationId(
+            element.organization,
+          );
+          const orgDetails = await this.fetchLinkedinOrganizationDetails(
+            organizationId,
+            accessToken,
+          );
+
+          return {
+            id: organizationId,
+            urn: `urn:li:organization:${organizationId}`,
+            role: element.role,
+            state: element.state,
+            name: orgDetails?.localizedName ?? `Organization ${organizationId}`,
+            logoUrl: this.extractOrgLogoUrl(orgDetails),
+          };
+        }),
+      );
+
+      return enriched;
+    } catch (error) {
+      if (error instanceof ApiError && error.statusCode === 401) {
+        throw new ConflictException(
+          'Reconnect your LinkedIn account to fetch organizations.',
+        );
+      }
+      throw error;
+    }
   }
 
   private async fetchLinkedinOrganizationDetails(
@@ -293,6 +305,9 @@ export class AuthService {
       });
       return data;
     } catch (error) {
+      if (error instanceof ApiError && error.statusCode === 401) {
+        throw error;
+      }
       this.logger.warn(
         `Failed to fetch details for organization ${organizationId}: ${error?.message}`,
       );
@@ -339,17 +354,14 @@ export class AuthService {
     if (!personalConnectedAccount) {
       throw new NotFoundException('LinkedIn account not connected');
     }
-    if (
-      !personalConnectedAccount.isActive ||
-      !personalConnectedAccount.accessToken
-    ) {
-      throw new BadRequestException(
-        'Reconnect your LinkedIn account before connecting organizations',
+    if (!isLinkedinAccessUsable(personalConnectedAccount)) {
+      throw new ConflictException(
+        'Reconnect your LinkedIn account before connecting organizations.',
       );
     }
 
     const accessToken = await this.encryptionService.decrypt(
-      personalConnectedAccount.accessToken,
+      personalConnectedAccount.accessToken!,
     );
     const encryptedAccessToken =
       await this.encryptionService.encrypt(accessToken);

--- a/src/carousel/schemas.spec.ts
+++ b/src/carousel/schemas.spec.ts
@@ -68,6 +68,15 @@ describe('carousel schemas', () => {
       ).toBe(false);
     });
 
+    it('should accept an item at exactly the 80-character cap', () => {
+      expect(
+        slideFieldSchemas.list.safeParse({
+          heading: 'H',
+          items: ['ok', 'a'.repeat(80)],
+        }).success,
+      ).toBe(true);
+    });
+
     it('should accept 2-6 items each within the cap', () => {
       expect(
         slideFieldSchemas.list.safeParse({
@@ -96,6 +105,26 @@ describe('carousel schemas', () => {
     it('should require headline and action', () => {
       expect(
         slideFieldSchemas.cta.safeParse({ headline: 'Follow' }).success,
+      ).toBe(false);
+    });
+
+    it('should accept a handle at exactly the 40-character cap', () => {
+      expect(
+        slideFieldSchemas.cta.safeParse({
+          headline: 'Follow',
+          action: 'Read more',
+          handle: 'a'.repeat(40),
+        }).success,
+      ).toBe(true);
+    });
+
+    it('should reject a handle over the 40-character cap', () => {
+      expect(
+        slideFieldSchemas.cta.safeParse({
+          headline: 'Follow',
+          action: 'Read more',
+          handle: 'a'.repeat(41),
+        }).success,
       ).toBe(false);
     });
   });

--- a/src/common/HelperFn/index.ts
+++ b/src/common/HelperFn/index.ts
@@ -2,3 +2,4 @@ export * from './delay.helper';
 export * from './parseSrtToText';
 export * from './apiFetch.helper';
 export * from './formatLinkedin.helper';
+export * from './linkedin-access.helper';

--- a/src/common/HelperFn/linkedin-access.helper.spec.ts
+++ b/src/common/HelperFn/linkedin-access.helper.spec.ts
@@ -1,0 +1,73 @@
+import { isLinkedinAccessUsable } from './linkedin-access.helper';
+
+describe('isLinkedinAccessUsable', () => {
+  const now = new Date('2026-08-11T08:00:00.000Z').getTime();
+
+  it('should accept active access with a future expiry', () => {
+    expect(
+      isLinkedinAccessUsable(
+        {
+          isActive: true,
+          accessToken: 'encrypted-token',
+          accessTokenExpiresAt: new Date(now + 1),
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('should reject access expiring exactly now', () => {
+    expect(
+      isLinkedinAccessUsable(
+        {
+          isActive: true,
+          accessToken: 'encrypted-token',
+          accessTokenExpiresAt: new Date(now),
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('should reject access with a past expiry', () => {
+    expect(
+      isLinkedinAccessUsable(
+        {
+          isActive: true,
+          accessToken: 'encrypted-token',
+          accessTokenExpiresAt: new Date(now - 1),
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('should accept legacy access without an expiry', () => {
+    expect(
+      isLinkedinAccessUsable(
+        { isActive: true, accessToken: 'encrypted-token' },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('should reject a malformed stored expiry', () => {
+    expect(
+      isLinkedinAccessUsable(
+        {
+          isActive: true,
+          accessToken: 'encrypted-token',
+          accessTokenExpiresAt: 'not-a-date',
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    { isActive: false, accessToken: 'encrypted-token' },
+    { isActive: true, accessToken: null },
+  ])('should reject inactive or missing-token access', (account) => {
+    expect(isLinkedinAccessUsable(account, now)).toBe(false);
+  });
+});

--- a/src/common/HelperFn/linkedin-access.helper.ts
+++ b/src/common/HelperFn/linkedin-access.helper.ts
@@ -1,0 +1,25 @@
+export interface LinkedinAccessAccount {
+  isActive?: boolean;
+  accessToken?: string | null;
+  accessTokenExpiresAt?: Date | string | null;
+}
+
+export function isLinkedinAccessUsable(
+  account: LinkedinAccessAccount,
+  now = Date.now(),
+): boolean {
+  if (!account.isActive || !account.accessToken) {
+    return false;
+  }
+
+  if (account.accessTokenExpiresAt == null) {
+    return true;
+  }
+
+  const expiresAt =
+    account.accessTokenExpiresAt instanceof Date
+      ? account.accessTokenExpiresAt.getTime()
+      : new Date(account.accessTokenExpiresAt).getTime();
+
+  return Number.isFinite(expiresAt) && expiresAt > now;
+}

--- a/src/llm/interfaces/llm.interfaces.ts
+++ b/src/llm/interfaces/llm.interfaces.ts
@@ -78,6 +78,10 @@ export type CompletionOptions = {
   model?: string;
   max_tokens?: number;
   temperature?: number;
+  responseSchema?: {
+    name: string;
+    schema: ZodType;
+  };
 };
 
 export interface LLMStrategy {

--- a/src/llm/parsers/responseParser.service.ts
+++ b/src/llm/parsers/responseParser.service.ts
@@ -2,19 +2,43 @@
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 
+const describeError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const stripNullObjectValues = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(stripNullObjectValues);
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, nested]) => nested !== null)
+      .map(([key, nested]) => [key, stripNullObjectValues(nested)]),
+  );
+};
+
 //TODO: Fix string type response input.
 @Injectable()
 export class ResponseParserService {
   /**
    * Parse JSON response with Zod schema validation
    */
-  parseWithSchema<T>(response: string, schema: z.ZodSchema<T>): T {
+  parseWithSchema<T>(
+    response: string,
+    schema: z.ZodSchema<T>,
+    options?: { stripNullObjectValues?: boolean },
+  ): T {
     try {
       const cleaned = this.cleanJsonResponse(response);
-      const parsed = JSON.parse(cleaned);
+      const raw = JSON.parse(cleaned) as unknown;
+      const parsed = options?.stripNullObjectValues
+        ? stripNullObjectValues(raw)
+        : raw;
       return schema.parse(parsed);
-    } catch (error) {
-      throw new Error(`Failed to parse response: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to parse response: ${describeError(error)}`);
     }
   }
 
@@ -24,15 +48,15 @@ export class ResponseParserService {
   parseArray<T = string>(response: string): T[] {
     try {
       const cleaned = this.cleanJsonResponse(response);
-      const parsed = JSON.parse(cleaned);
+      const parsed = JSON.parse(cleaned) as unknown;
 
       if (!Array.isArray(parsed)) {
         throw new Error('Response is not an array');
       }
 
       return parsed as T[];
-    } catch (error) {
-      throw new Error(`Failed to parse array: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to parse array: ${describeError(error)}`);
     }
   }
 
@@ -42,7 +66,7 @@ export class ResponseParserService {
   parseObject<T extends Record<string, any>>(response: string): T {
     try {
       const cleaned = this.cleanJsonResponse(response);
-      const parsed = JSON.parse(cleaned);
+      const parsed = JSON.parse(cleaned) as unknown;
 
       if (
         typeof parsed !== 'object' ||
@@ -53,8 +77,8 @@ export class ResponseParserService {
       }
 
       return parsed as T;
-    } catch (error) {
-      throw new Error(`Failed to parse object: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to parse object: ${describeError(error)}`);
     }
   }
 

--- a/src/llm/strategies/openrouter.strategy.spec.ts
+++ b/src/llm/strategies/openrouter.strategy.spec.ts
@@ -34,6 +34,15 @@ type ChatRequestPayload = {
   tools?: unknown[];
   maxTokens?: number;
   temperature?: number;
+  responseFormat?: {
+    type: string;
+    jsonSchema: {
+      name: string;
+      strict: boolean;
+      schema: Record<string, unknown>;
+    };
+  };
+  provider?: { requireParameters?: boolean };
   stream: boolean;
 };
 
@@ -151,6 +160,130 @@ describe('OpenRouterStrategy', () => {
       await strategy.complete([{ role: MessageRole.User, content: 'hi' }]);
 
       expect(lastChatRequest()).not.toHaveProperty('tools');
+    });
+
+    it('should constrain a completion to the supplied Zod response schema', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: '{}' } }] });
+      const responseSchema = z.object({
+        document: z.object({
+          slides: z.array(
+            z.object({
+              items: z.array(z.string().max(80)),
+              handle: z.string().max(40),
+            }),
+          ),
+        }),
+      });
+
+      await strategy.complete(
+        [{ role: MessageRole.User, content: 'build a document' }],
+        {
+          responseSchema: {
+            name: 'artifact_generation',
+            schema: responseSchema,
+          },
+        },
+      );
+
+      expect(lastChatRequest()).toMatchObject({
+        responseFormat: {
+          type: 'json_schema',
+          jsonSchema: {
+            name: 'artifact_generation',
+            strict: true,
+            schema: {
+              properties: {
+                document: {
+                  properties: {
+                    slides: {
+                      items: {
+                        properties: {
+                          items: { items: { maxLength: 80 } },
+                          handle: { maxLength: 40 },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        provider: { requireParameters: true },
+      });
+      expect(
+        lastChatRequest().responseFormat?.jsonSchema.schema,
+      ).not.toHaveProperty('$schema');
+    });
+
+    it('should normalize discriminated unions to provider-supported anyOf schemas', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: '{}' } }] });
+      const responseSchema = z.object({
+        slide: z.discriminatedUnion('type', [
+          z.object({
+            type: z.literal('list'),
+            items: z.array(z.string().max(80)),
+          }),
+          z.object({
+            type: z.literal('cta'),
+            handle: z.string().max(40),
+          }),
+        ]),
+      });
+
+      await strategy.complete(
+        [{ role: MessageRole.User, content: 'build a slide' }],
+        {
+          responseSchema: {
+            name: 'artifact_generation',
+            schema: responseSchema,
+          },
+        },
+      );
+
+      const serialized = JSON.stringify(
+        lastChatRequest().responseFormat?.jsonSchema.schema,
+      );
+      expect(serialized).toContain('"anyOf"');
+      expect(serialized).not.toContain('"oneOf"');
+      expect(serialized).toContain('"maxLength":80');
+      expect(serialized).toContain('"maxLength":40');
+    });
+
+    it('should represent optional properties as required nullable fields in strict schemas', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: '{}' } }] });
+
+      await strategy.complete(
+        [{ role: MessageRole.User, content: 'build an object' }],
+        {
+          responseSchema: {
+            name: 'optional_fields',
+            schema: z.object({
+              required: z.string(),
+              optional: z.string().max(40).optional(),
+            }),
+          },
+        },
+      );
+
+      expect(lastChatRequest().responseFormat?.jsonSchema.schema).toMatchObject(
+        {
+          required: ['required', 'optional'],
+          properties: {
+            required: { type: 'string' },
+            optional: { type: ['string', 'null'], maxLength: 40 },
+          },
+        },
+      );
+    });
+
+    it('should omit response constraints for an unconstrained completion', async () => {
+      send.mockResolvedValue({ choices: [{ message: { content: 'x' } }] });
+
+      await strategy.complete([{ role: MessageRole.User, content: 'hi' }]);
+
+      expect(lastChatRequest()).not.toHaveProperty('responseFormat');
+      expect(lastChatRequest()).not.toHaveProperty('provider');
     });
 
     it('should throw a terminal LLMError when the model returns no text', async () => {

--- a/src/llm/strategies/openrouter.strategy.ts
+++ b/src/llm/strategies/openrouter.strategy.ts
@@ -89,6 +89,83 @@ const toChatTool = (tool: ToolDefinition): ChatFunctionTool => {
   };
 };
 
+/**
+ * Adapt Zod's JSON Schema to OpenAI's strict response-format subset:
+ * discriminated unions use `anyOf` instead of rejected `oneOf`, and optional
+ * properties become required-nullable because strict objects require every
+ * property name in `required`. Literal discriminators keep union arms mutually
+ * exclusive; the generation parser removes provider null placeholders before
+ * applying the unchanged local Zod contract.
+ */
+const nullableJsonSchema = (
+  schema: Record<string, unknown>,
+): Record<string, unknown> => {
+  const type = schema.type;
+  if (typeof type === 'string') {
+    return { ...schema, type: [type, 'null'] };
+  }
+  if (Array.isArray(type)) {
+    const types = type as unknown[];
+    return {
+      ...schema,
+      type: types.includes('null') ? types : [...types, 'null'],
+    };
+  }
+  const anyOf = schema.anyOf;
+  if (Array.isArray(anyOf)) {
+    const variants = anyOf as unknown[];
+    return { ...schema, anyOf: [...variants, { type: 'null' }] };
+  }
+  return { anyOf: [schema, { type: 'null' }] };
+};
+
+const toProviderJsonSchema = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(toProviderJsonSchema);
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const normalized = Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [
+      key === 'oneOf' ? 'anyOf' : key,
+      toProviderJsonSchema(nested),
+    ]),
+  );
+
+  const properties = normalized.properties;
+  if (
+    normalized.type === 'object' &&
+    typeof properties === 'object' &&
+    properties !== null &&
+    !Array.isArray(properties)
+  ) {
+    const required = new Set(
+      Array.isArray(normalized.required)
+        ? normalized.required.filter(
+            (name): name is string => typeof name === 'string',
+          )
+        : [],
+    );
+    const strictProperties = Object.fromEntries(
+      Object.entries(properties).map(([name, schema]) => [
+        name,
+        required.has(name)
+          ? schema
+          : nullableJsonSchema(schema as Record<string, unknown>),
+      ]),
+    );
+    return {
+      ...normalized,
+      properties: strictProperties,
+      required: Object.keys(strictProperties),
+    };
+  }
+
+  return normalized;
+};
+
 /** Tool arguments arrive as a JSON string the model wrote, so they can be malformed. */
 const parseToolArguments = (args: string, toolName: string): unknown => {
   if (args.trim() === '') return {};
@@ -177,6 +254,18 @@ export class OpenRouterStrategy implements LLMStrategy {
     options?: CompletionOptions,
     tools?: Array<ToolDefinition>,
   ): Promise<ChatResult> {
+    const responseJsonSchema = options?.responseSchema
+      ? (toProviderJsonSchema(
+          z.toJSONSchema(options.responseSchema.schema, {
+            target: 'draft-7',
+            io: 'output',
+          }),
+        ) as Record<string, unknown>)
+      : undefined;
+    if (responseJsonSchema) {
+      delete responseJsonSchema.$schema;
+    }
+
     // Built outside the try: a fault in our own conversion is not a provider fault.
     const chatRequest = {
       model: options?.model || DEFAULT_MODEL,
@@ -184,6 +273,19 @@ export class OpenRouterStrategy implements LLMStrategy {
       temperature: options?.temperature,
       messages: messages.map(toChatMessage),
       ...(tools?.length ? { tools: tools.map(toChatTool) } : {}),
+      ...(options?.responseSchema && responseJsonSchema
+        ? {
+            responseFormat: {
+              type: 'json_schema' as const,
+              jsonSchema: {
+                name: options.responseSchema.name,
+                strict: true,
+                schema: responseJsonSchema,
+              },
+            },
+            provider: { requireParameters: true },
+          }
+        : {}),
       stream: false as const,
     };
 

--- a/src/post/post.interface.ts
+++ b/src/post/post.interface.ts
@@ -1,6 +1,6 @@
 export interface ILinkedInPost {
   author: string;
-  commentary?: string;
+  commentary: string;
   content?: IContent;
   visibility: 'PUBLIC' | 'CONNECTIONS';
   distribution: {

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Types } from 'mongoose';
 
 jest.mock(
@@ -36,7 +40,15 @@ jest.mock(
   'src/common/HelperFn/apiFetch.helper',
   () => ({
     apiFetch: jest.fn(),
-    ApiError: class ApiError extends Error {},
+    ApiError: class ApiError extends Error {
+      constructor(
+        public statusCode: number,
+        public statusText: string,
+        public data: any,
+      ) {
+        super(`HTTP error! status: ${statusCode} ${statusText}`);
+      }
+    },
   }),
   { virtual: true },
 );
@@ -66,7 +78,7 @@ jest.mock(
 import { PostService } from './post.service';
 import type { User } from 'src/database/schemas';
 import { deleteFile, getFile, getSignedUploadUrl, headFile } from 'src/s3';
-import { apiFetch } from 'src/common/HelperFn/apiFetch.helper';
+import { ApiError, apiFetch } from 'src/common/HelperFn/apiFetch.helper';
 import { formatLinkedinContent } from 'src/common/HelperFn';
 
 describe('PostService.getPosts', () => {
@@ -644,6 +656,48 @@ describe('PostService.schedulePost', () => {
     expect(mocks.incrementScheduledPostUsage).not.toHaveBeenCalled();
   });
 
+  it('should reject scheduling when LinkedIn access has expired', async () => {
+    const { service, mocks } = createService();
+    const userId = new Types.ObjectId();
+    const postId = new Types.ObjectId();
+    const scheduledAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const post = {
+      _id: postId,
+      user: userId,
+      connectedAccount: new Types.ObjectId(),
+      status: 'DRAFT',
+      scheduledPostUsageCounted: false,
+      save: mocks.save,
+    } as any;
+
+    mocks.findById.mockResolvedValue(post);
+    mocks.findConnectedAccountById.mockResolvedValue({
+      user: userId,
+      provider: 'LINKEDIN',
+      isActive: true,
+      accessToken: 'encrypted-token',
+      accessTokenExpiresAt: new Date(Date.now() - 60_000),
+    });
+
+    await expect(
+      service.schedulePost({ _id: userId } as any, postId.toString(), {
+        scheduledAt,
+      } as any),
+    ).rejects.toMatchObject({
+      response: {
+        statusCode: 409,
+        message: 'Reconnect connected account to schedule posts.',
+      },
+    });
+
+    expect(mocks.getJob).not.toHaveBeenCalled();
+    expect(mocks.assertScheduledPostQuota).not.toHaveBeenCalled();
+    expect(mocks.updateArtifactPinRevision).not.toHaveBeenCalled();
+    expect(mocks.addScheduleJob).not.toHaveBeenCalled();
+    expect(mocks.incrementScheduledPostUsage).not.toHaveBeenCalled();
+    expect(mocks.save).not.toHaveBeenCalled();
+  });
+
   it('does not increment scheduling usage when queue enqueue fails', async () => {
     const { service, mocks } = createService();
     const userId = new Types.ObjectId();
@@ -825,7 +879,15 @@ describe('PostService artifact publishing', () => {
     return {
       service,
       mocks,
-      fixtures: { userId, artifactId, accountId, postId, post, artifact },
+      fixtures: {
+        userId,
+        artifactId,
+        accountId,
+        postId,
+        post,
+        artifact,
+        account,
+      },
     };
   };
 
@@ -1111,6 +1173,48 @@ describe('PostService artifact publishing', () => {
       expect(fixtures.post.status).toBe('FAILED');
       expect(fixtures.post.failureReason).toBe('Failed to publish post');
     });
+
+    it('should reject expired LinkedIn access and persist a reconnect failure', async () => {
+      const { service, mocks, fixtures } = makeService();
+      fixtures.account.accessTokenExpiresAt = new Date(Date.now() - 60_000);
+
+      await expect(
+        service.publishPost(fixtures.postId.toString()),
+      ).rejects.toMatchObject({
+        response: {
+          statusCode: 409,
+          message: 'Reconnect connected account to publish posts.',
+        },
+      });
+
+      expect(fixtures.post.status).toBe('FAILED');
+      expect(fixtures.post.failureReason).toBe(
+        'Reconnect connected account to publish posts.',
+      );
+      expect(mocks.decrypt).not.toHaveBeenCalled();
+      expect(apiFetch).not.toHaveBeenCalled();
+    });
+
+    it('should map a LinkedIn 401 response to a reconnect conflict', async () => {
+      const { service, fixtures } = makeService();
+      (apiFetch as jest.Mock).mockRejectedValue(
+        new ApiError(401, 'Unauthorized', { message: 'Expired token' }),
+      );
+
+      await expect(
+        service.publishPost(fixtures.postId.toString()),
+      ).rejects.toMatchObject({
+        response: {
+          statusCode: 409,
+          message: 'Reconnect connected account to publish posts.',
+        },
+      });
+
+      expect(fixtures.post.status).toBe('FAILED');
+      expect(fixtures.post.failureReason).toBe(
+        'Reconnect connected account to publish posts.',
+      );
+    });
   });
 
   describe('publishPostNow', () => {
@@ -1156,6 +1260,23 @@ describe('PostService artifact publishing', () => {
         ),
       ).rejects.toBeInstanceOf(ForbiddenException);
       expect(mocks.getScheduleJob).not.toHaveBeenCalled();
+      expect(apiFetch).not.toHaveBeenCalled();
+    });
+
+    it('should preserve a scheduled post when LinkedIn access is already expired', async () => {
+      const { service, mocks, fixtures } = makeService();
+      fixtures.account.accessTokenExpiresAt = new Date(Date.now() - 60_000);
+
+      await expect(
+        service.publishPostNow(
+          { _id: fixtures.userId } as any,
+          fixtures.postId.toString(),
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(mocks.getScheduleJob).not.toHaveBeenCalled();
+      expect(fixtures.post.status).toBe('SCHEDULED');
+      expect(fixtures.post.save).not.toHaveBeenCalled();
       expect(apiFetch).not.toHaveBeenCalled();
     });
   });

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -1016,6 +1016,23 @@ describe('PostService artifact publishing', () => {
       expect(mocks.uploadDocument).not.toHaveBeenCalled();
     });
 
+    it('should send empty commentary when a poll has no framing text', async () => {
+      const { service, fixtures } = makeService();
+      fixtures.artifact.type = 'POLL';
+      fixtures.artifact.versions[0].content = {
+        poll: {
+          question: 'Best day?',
+          options: ['Monday', 'Friday'],
+          durationDays: 7,
+        },
+      };
+
+      await service.publishPost(fixtures.postId.toString());
+
+      const body = JSON.parse((apiFetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.commentary).toBe('');
+    });
+
     it('should upload pinned PDF bytes and publish the returned urn when the artifact is a DOCUMENT', async () => {
       const { service, mocks, fixtures } = makeService();
       const pdf = Buffer.from('rendered-pdf');
@@ -1047,6 +1064,29 @@ describe('PostService artifact publishing', () => {
       expect(JSON.parse(postCall[1].body).content).toEqual({
         media: { id: 'urn:li:document:1', title: 'First slide' },
       });
+    });
+
+    it('should send empty commentary when a document has no framing text', async () => {
+      const { service, fixtures } = makeService();
+      fixtures.artifact.type = 'DOCUMENT';
+      fixtures.artifact.versions[0].content = {
+        document: {
+          templateId: 'bold',
+          slides: [
+            { type: 'cover', fields: { title: 'First slide' } },
+            { type: 'cta', fields: { headline: 'Go', action: 'Try it' } },
+          ],
+          pdfKey: 'artifacts/deck/1/document.pdf',
+          pageCount: 8,
+        },
+      };
+      (getFile as jest.Mock).mockResolvedValue(Buffer.from('rendered-pdf'));
+
+      await service.publishPost(fixtures.postId.toString());
+
+      const postCall = (apiFetch as jest.Mock).mock.calls.at(-1);
+      const body = JSON.parse(postCall[1].body);
+      expect(body.commentary).toBe('');
     });
 
     it('should fail safely when the pinned version is unavailable', async () => {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -253,9 +253,10 @@ export class PostService {
       }
       const data: ILinkedInPost = {
         author,
-        ...(typeof version.content.commentary === 'string'
-          ? { commentary: formatLinkedinContent(version.content.commentary) }
-          : {}),
+        commentary:
+          typeof version.content.commentary === 'string'
+            ? formatLinkedinContent(version.content.commentary)
+            : '',
         ...(content ? { content } : {}),
         visibility: 'PUBLIC',
         distribution: {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -47,6 +47,7 @@ import { LinkedinMediaService } from './linkedin-media.service';
 import type { DocumentContent, PollContent } from '../artifact/schemas';
 import { CONTENT_TITLE_MAX_LENGTH } from '../common/constants';
 import { randomUUID } from 'crypto';
+import { isLinkedinAccessUsable } from '../common/HelperFn/linkedin-access.helper';
 
 interface PostFilters {
   availableMonths: string[];
@@ -54,6 +55,8 @@ interface PostFilters {
 }
 
 const POST_PAGE_SIZE = 20;
+const PUBLISH_RECONNECT_MESSAGE =
+  'Reconnect connected account to publish posts.';
 
 export interface PostArtifactMetadata {
   _id: Types.ObjectId;
@@ -178,6 +181,20 @@ export class PostService {
       throw new BadRequestException('Post is already published');
     }
 
+    let connectedAccount: ConnectedAccount;
+    try {
+      connectedAccount = await this.getOwnedUsableLinkedinConnectedAccount(
+        this.referenceId(post.user),
+        this.referenceId(post.connectedAccount),
+        'publish posts',
+      );
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        await this.failPost(post, PUBLISH_RECONNECT_MESSAGE);
+      }
+      throw error;
+    }
+
     const source = post.artifacts[0];
     if (source) {
       await this.bumpArtifactPinRevision(source.artifact, source.version);
@@ -201,12 +218,6 @@ export class PostService {
     await this.assertMediaReadyForPublication(post, artifact.type);
 
     try {
-      const connectedAccount =
-        await this.getOwnedUsableLinkedinConnectedAccount(
-          this.referenceId(post.user),
-          this.referenceId(post.connectedAccount),
-          'publish posts',
-        );
       const accessToken = await this.encryptionService.decrypt(
         connectedAccount.accessToken!,
       );
@@ -289,15 +300,20 @@ export class PostService {
       return post;
     } catch (error) {
       this.logger.error(error);
+      const accessExpired =
+        error instanceof ApiError && error.statusCode === 401;
       const reconnectRequired =
         error instanceof ApiError &&
         error.statusCode === 400 &&
         typeof error.data?.message === 'string' &&
         error.data.message.includes('Organization permissions must be used');
-      const failureReason = reconnectRequired
-        ? 'Your LinkedIn account needs to be reconnected to enable company page posting. Please disconnect and reconnect your LinkedIn account.'
-        : 'Failed to publish post';
+      const failureReason = accessExpired
+        ? PUBLISH_RECONNECT_MESSAGE
+        : reconnectRequired
+          ? 'Your LinkedIn account needs to be reconnected to enable company page posting. Please disconnect and reconnect your LinkedIn account.'
+          : 'Failed to publish post';
       await this.failPost(post, failureReason);
+      if (accessExpired) throw new ConflictException(failureReason);
       if (reconnectRequired) throw new BadRequestException(failureReason);
       throw new InternalServerErrorException(failureReason);
     }
@@ -637,6 +653,12 @@ export class PostService {
     ) {
       throw new BadRequestException('Post cannot be published');
     }
+
+    await this.getOwnedUsableLinkedinConnectedAccount(
+      user._id.toString(),
+      this.referenceId(post.connectedAccount),
+      'publish posts',
+    );
 
     const scheduledJob = await this.scheduleQueue.queue.getJob(postId);
     if (scheduledJob) await scheduledJob.remove();
@@ -1334,7 +1356,7 @@ export class PostService {
   }
 
   private isLinkedinAccountUsable(connectedAccount: ConnectedAccount): boolean {
-    return Boolean(connectedAccount.isActive && connectedAccount.accessToken);
+    return isLinkedinAccessUsable(connectedAccount);
   }
 
   private resolveLinkedinAuthorUrn(connectedAccount: ConnectedAccount): string {

--- a/src/scripts/tier-seeds.ts
+++ b/src/scripts/tier-seeds.ts
@@ -104,7 +104,7 @@ export const TIER_SEEDS: TierSeed[] = [
       features: [
         '30,000 AI credits/month',
         'AI research',
-        '10 connected accounts',
+        '5 connected accounts',
         'unlimited scheduled posts',
         'unlimited post history',
       ],


### PR DESCRIPTION
## Summary

- centralize LinkedIn connected-account access validation, including stored token expiry
- return actionable `409 Conflict` reconnect responses for publish, schedule, and organization endpoints
- normalize LinkedIn `401` responses during publishing and organization lookup
- preserve scheduled posts when immediate-publish preflight detects expiry
- document the reconnect contract and add regression coverage

## Root cause

Connected-account usability only checked whether an account was active and had a token. It ignored `accessTokenExpiresAt`, organization lookup duplicated the incomplete check, and publishing's broad catch converted reconnect failures into generic `500` errors.

## Validation

- `npm run build`
- `bun jest src/common/HelperFn/linkedin-access.helper.spec.ts src/post/post.service.spec.ts src/auth/auth.service.spec.ts --runInBand` — 91 tests passed
- full unit suite — 741 tests passed; 3 unrelated existing failures remain in `clerk-auth.guard.spec.ts` and `auth.di.spec.ts`
- `git diff --check`

## Impact

Clients receive a consistent reconnect signal before scheduling or immediate-publish side effects occur. Scheduled worker/API publish attempts that encounter expired credentials retain a clear failure reason for retry after reconnection.