### PR TITLE
Fix Clerk user identity indexes

### DIFF
--- a/docs/clerk-integration-analysis.md
+++ b/docs/clerk-integration-analysis.md
@@ -6,6 +6,7 @@
 ## 1. How authentication works today
 
 ### Login (Google only)
+
 - `GoogleStrategy` (`passport-google-oauth20`) handles the OAuth dance via `@nestjs/passport`.
 - `AuthService.validateGoogleUser` finds or creates a `User`, keyed on `googleId` with an
   email fallback, assigns the default `Tier`, and enqueues a welcome email.
@@ -14,12 +15,14 @@
   `.marquill.com` (prod), plus a **non-httpOnly `user` cookie** holding the serialized user.
 
 ### Session validation
+
 - `JwtStrategy` (`passport-jwt`) pulls `access_token` from the cookie, verifies it with
   `JWT_SECRET`, then **loads the Mongo `User` and populates `tier`**.
 - `JwtAuthGuard` (`AuthGuard('jwt')`) protects routes; `@GetUser()` injects the full
   Mongoose `User` document onto the request.
 
 ### Blast radius
+
 - **8 controllers** use `JwtAuthGuard` + `@GetUser()` (12 route guards): `post`, `auth`,
   `payment`, `feedback`, `workflow`, `users`, `onboarding`, `tier`.
 - `SubscriptionAccessGuard` reads `request.user._id` to resolve entitlement — it depends on
@@ -27,11 +30,13 @@
 - The **worker process** bootstraps an `ApplicationContext` and does no HTTP auth — unaffected.
 
 ### What is NOT authentication (leave alone)
-- **LinkedIn** is *not* a login provider today. It is a **connected publishing account**:
+
+- **LinkedIn** is _not_ a login provider today. It is a **connected publishing account**:
   hand-rolled OAuth, AES-256-GCM encrypted tokens in `ConnectedAccount`, avatar refresh, org
   support. See §8 for how LinkedIn-as-login relates to this.
 
 ### Key constraints any option must preserve
+
 1. Downstream code expects `request.user` to be the **local Mongo `User`** (with `_id` and a
    populated `tier`), not a raw token payload.
 2. `SubscriptionAccessGuard`, feature gating, and `ConnectedAccount.user` references all key off
@@ -44,27 +49,38 @@
 
 Whatever we adopt, we must map a Clerk identity to the existing `User._id`. Recommended:
 
-- Add a sparse-unique `clerkId` field to the `User` schema (alongside, not replacing, `googleId`).
+- Add `clerkId` alongside (not replacing) `googleId`. Both optional provider IDs use a unique
+  partial index restricted to string values; missing and explicit `null` values are not indexed.
 - On first authenticated request (or via webhook — see §6), find-or-create the local user by
   `clerkId`, falling back to `email` to **link existing Google users** so nobody loses data.
 
 ```ts
-// user.schema.ts (additive)
-@Prop({ unique: true, sparse: true })
+// user.schema.ts (additive field; index declared explicitly below the schema)
+@Prop()
 clerkId?: string;
+
+UserSchema.index(
+  { clerkId: 1 },
+  {
+    name: 'user_clerk_id_unique',
+    unique: true,
+    partialFilterExpression: { clerkId: { $type: 'string' } },
+  },
+);
 ```
 
 This means existing users keep their `_id`, drafts, subscriptions, and connected accounts.
 
 ---
 
-## 3. Option A — Full cutover: Clerk-issued tokens, networkless verification *(RECOMMENDED target)*
+## 3. Option A — Full cutover: Clerk-issued tokens, networkless verification _(RECOMMENDED target)_
 
 Clerk becomes the only identity provider. The frontend uses Clerk's components/SDK for sign-in
 (Google, email/magic-link, LinkedIn, etc.). The backend stops minting JWTs and instead
 **verifies the Clerk session token** on every request.
 
 ### Mechanism
+
 - Frontend sends the Clerk session token via the `__session` cookie (same-origin — see §8).
 - A new `ClerkAuthGuard` replaces `JwtAuthGuard`. It verifies the token **networklessly** using
   Clerk's `jwtKey` (the JWKS public key, cached) — no per-request call to Clerk's API:
@@ -75,7 +91,7 @@ import { verifyToken } from '@clerk/backend';
 
 const token = request.cookies?.__session; // same-origin cookie transport
 const claims = await verifyToken(token, {
-  jwtKey: this.config.getOrThrow('CLERK_JWT_KEY'),      // networkless
+  jwtKey: this.config.getOrThrow('CLERK_JWT_KEY'), // networkless
   authorizedParties: [this.config.get('FRONTEND_URL')], // anti-CSRF / subdomain leakage
 });
 // claims.sub === Clerk user id
@@ -88,6 +104,7 @@ request.user = user; // keeps @GetUser() and SubscriptionAccessGuard working unc
   `passport-google-oauth20`, and `@nestjs/jwt` can be dropped.
 
 ### Advantages
+
 - **Single source of truth** for identity; no two-session drift.
 - **Offloads the hard parts**: MFA, social providers, magic links, bot/abuse protection,
   session revocation, password resets, account recovery, email verification — all Clerk's job.
@@ -97,6 +114,7 @@ request.user = user; // keeps @GetUser() and SubscriptionAccessGuard working unc
 - Easy to add providers later with zero backend changes.
 
 ### Disadvantages
+
 - **Vendor lock-in** and a new **per-MAU cost** once past the free tier.
 - **External dependency / availability**: Clerk outage or JWKS rotation issues affect login
   (mitigated: networkless verify survives brief API outages; tokens are short-lived though).
@@ -107,41 +125,46 @@ request.user = user; // keeps @GetUser() and SubscriptionAccessGuard working unc
 
 ---
 
-## 4. Option B — Incremental strangler: dual guard *(RECOMMENDED migration path to reach A)*
+## 4. Option B — Incremental strangler: dual guard _(RECOMMENDED migration path to reach A)_
 
 Don't flip everything at once. Ship a `ClerkAuthGuard` that **accepts a Clerk token if present,
 otherwise falls back to the legacy `access_token` JWT**. Both produce the same `request.user`.
 
 ### Mechanism
+
 - One composite guard tries Clerk verification first, then the existing `passport-jwt` path.
 - Roll out per-route or globally behind a flag. New logins go through Clerk; existing cookies
   keep working until they expire (≤30 days), then everyone is on Clerk.
 - Once legacy JWT traffic hits zero, delete the fallback → you are now at Option A.
 
 ### Advantages
+
 - **Zero forced logout**; existing sessions drain naturally.
 - De-risks the frontend cutover — can A/B or roll back per route.
 - Same end-state as A with a safe path there.
 
 ### Disadvantages
+
 - Temporarily **two auth code paths** to maintain and test.
 - Slightly more complex guard logic during the window.
 - Requires discipline to actually finish the migration and remove the fallback.
 
 ---
 
-## 5. Option C — Hybrid façade: Clerk for login, keep minting our own JWT *(NOT recommended)*
+## 5. Option C — Hybrid façade: Clerk for login, keep minting our own JWT _(NOT recommended)_
 
 Use Clerk only for the credential UI, but after Clerk sign-in, exchange the Clerk token once and
 **continue issuing our own `access_token` cookie** as today.
 
 ### Advantages
+
 - Minimal change to backend guards and the frontend session model.
 - Keeps cookie-based same-site session ergonomics.
 
 ### Disadvantages
+
 - **Two session systems** running at once — the worst of both: we still own JWT signing,
-  rotation, revocation, and the `JWT_SECRET`, *plus* now depend on Clerk.
+  rotation, revocation, and the `JWT_SECRET`, _plus_ now depend on Clerk.
 - Session **revocation in Clerk doesn't propagate** to our long-lived cookie → security gap.
 - We keep nearly all the code Clerk was supposed to remove. Low payoff for the added dependency.
 
@@ -166,13 +189,14 @@ the welcome-email enqueue off the request path.
 
 **Adopt Option A (Clerk-issued tokens, networkless verification) as the target architecture, and
 get there via Option B (dual-guard strangler).** Provision users **lazily** at first, keyed on a
-new sparse-unique `clerkId` with email-based linking for existing Google users.
+new partial-unique `clerkId` with email-based linking for existing Google users.
 
 Rationale:
+
 - The custom JWT/cookie/Google-OAuth stack is exactly the kind of undifferentiated, security-
   sensitive code Clerk eliminates, and the blast radius is contained: `@GetUser()` and
   `SubscriptionAccessGuard` keep working as long as the guard still attaches the local Mongo user.
-- LinkedIn *publishing* (the actually-valuable, domain-specific integration) is untouched (§8).
+- LinkedIn _publishing_ (the actually-valuable, domain-specific integration) is untouched (§8).
 - The strangler path means **no forced logout** and a reversible rollout.
 
 Avoid Option C — it doubles the session surface instead of shrinking it.
@@ -181,14 +205,15 @@ Avoid Option C — it doubles the session surface instead of shrinking it.
 
 ## 8. Decisions (locked)
 
-| Question | Decision | Implication |
-|---|---|---|
-| **Sign-in methods** | Google, Email + magic link, **LinkedIn** | Adds two new login paths beyond today's Google-only. All resolve to one local `User` via `clerkId`/email linking. |
-| **LinkedIn login vs publishing** | **Keep separate** | Clerk's LinkedIn connection provides **identity only** (`openid profile email`). The existing hand-rolled publishing OAuth + `ConnectedAccount` + encrypted-token flow is **unchanged**. |
-| **Token transport** | **`__session` cookie** (same-origin) | Frontend and API share a domain (already `.marquill.com` in prod). Guard reads the `__session` cookie; keep CSRF in mind for state-changing routes. CORS stays `credentials: true`. |
-| **Replace `user` cookie** | **Backend `GET /users/me`** | Drop the non-httpOnly `user` cookie. Frontend loads the local Mongo user (incl. `tier`) from an authenticated `/users/me`; identity (name/avatar/email) can also come from Clerk's SDK. |
+| Question                         | Decision                                 | Implication                                                                                                                                                                              |
+| -------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sign-in methods**              | Google, Email + magic link, **LinkedIn** | Adds two new login paths beyond today's Google-only. All resolve to one local `User` via `clerkId`/email linking.                                                                        |
+| **LinkedIn login vs publishing** | **Keep separate**                        | Clerk's LinkedIn connection provides **identity only** (`openid profile email`). The existing hand-rolled publishing OAuth + `ConnectedAccount` + encrypted-token flow is **unchanged**. |
+| **Token transport**              | **`__session` cookie** (same-origin)     | Frontend and API share a domain (already `.marquill.com` in prod). Guard reads the `__session` cookie; keep CSRF in mind for state-changing routes. CORS stays `credentials: true`.      |
+| **Replace `user` cookie**        | **Backend `GET /users/me`**              | Drop the non-httpOnly `user` cookie. Frontend loads the local Mongo user (incl. `tier`) from an authenticated `/users/me`; identity (name/avatar/email) can also come from Clerk's SDK.  |
 
 ### Consequences of "LinkedIn login, kept separate"
+
 - A user can sign in **with LinkedIn** (identity) yet still have **no posting capability** until
   they run the existing "connect LinkedIn" flow — login ≠ publishing token. The connect-to-publish
   step stays mandatory for every user regardless of how they logged in.
@@ -201,13 +226,15 @@ Avoid Option C — it doubles the session surface instead of shrinking it.
   re-architecting the org-ACL / `impersonatorUrn` logic, which would still be needed.
 
 ### Consequences of the `__session` cookie choice
+
 - Verify with `verifyToken`/`authenticateRequest` reading the `__session` cookie (not just Bearer).
 - Set `authorizedParties` to the frontend origin(s) to prevent subdomain cookie leakage.
 - Same-site cookie semantics mirror today's `access_token` cookie, so the prod cookie-domain setup
   on `.marquill.com` carries over conceptually.
 
 ### Migration sequence (reflecting decisions)
-1. Add `clerkId` (sparse-unique) to `User`; `UserProvisioningService.findOrCreate(claims)` with
+
+1. Add `clerkId` (partial-unique for string values) to `User`; `UserProvisioningService.findOrCreate(claims)` with
    email linking.
 2. Add `@clerk/backend`; `ClerkAuthGuard` verifies the **`__session` cookie** networklessly
    (`jwtKey` + `authorizedParties`), then attaches the local Mongo `User`.
@@ -218,5 +245,29 @@ Avoid Option C — it doubles the session surface instead of shrinking it.
 6. Frontend sign-in moves to Clerk; new sessions are Clerk-only.
 7. After legacy cookie TTL (≤30 days), remove the JWT fallback, `JwtStrategy`, `GoogleStrategy`,
    `AuthService.login`, the `user` cookie, and unused passport/jwt deps.
-8. **Untouched throughout:** the entire LinkedIn *publishing* flow (`ConnectedAccount`, encryption,
+8. **Untouched throughout:** the entire LinkedIn _publishing_ flow (`ConnectedAccount`, encryption,
    org ACLs, avatar refresh).
+
+### Production identity-index repair
+
+The original `googleId_1` unique index treats missing values as `null`, which prevents more than
+one Clerk-only user from being inserted. Do not fix this by repeatedly deleting the index in
+Compass: the old schema can recreate it.
+
+After deploying the partial-index schema, audit production locally using the `MONGO_URI` in
+`.env`:
+
+```bash
+npm run db:migrate:user-indexes
+```
+
+The command is dry-run by default. After reviewing the two explicit create/drop operations, apply
+them with:
+
+```bash
+npm run db:migrate:user-indexes -- --apply
+```
+
+The migration connects with automatic indexing disabled, creates the replacement indexes before
+dropping only the known legacy definitions, verifies the final catalog, and is safe to rerun. It
+does not rewrite or delete user documents.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "start:worker": "node dist/workflow/workers/workflow.worker.js",
+    "db:migrate:user-indexes": "ts-node src/scripts/migrate-user-identity-indexes.ts",
     "review:credit-economics": "ts-node src/scripts/run-credit-economics-review.ts",
     "seed:tiers:temp": "ts-node src/scripts/temp-seed-tiers.ts"
   },

--- a/src/auth/clerk/clerk-auth.guard.spec.ts
+++ b/src/auth/clerk/clerk-auth.guard.spec.ts
@@ -122,5 +122,23 @@ describe('ClerkAuthGuard', () => {
       expect(mocks.userProvisioning.findOrCreate).not.toHaveBeenCalled();
       expect(mocks.jwtAuthGuard.canActivate).toHaveBeenCalledTimes(1);
     });
+
+    it('should propagate provisioning failures without using the legacy fallback', async () => {
+      const request: any = {
+        cookies: { __session: 'valid.jwt' },
+        headers: {},
+      };
+      const provisioningError = new Error('database unavailable');
+      verifyToken.mockResolvedValueOnce({ sub: 'user_clerk_4' });
+      mocks.userProvisioning.findOrCreate.mockRejectedValueOnce(
+        provisioningError,
+      );
+
+      await expect(guard.canActivate(makeContext(request))).rejects.toBe(
+        provisioningError,
+      );
+
+      expect(mocks.jwtAuthGuard.canActivate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/auth/clerk/clerk-auth.guard.ts
+++ b/src/auth/clerk/clerk-auth.guard.ts
@@ -40,17 +40,18 @@ export class ClerkAuthGuard implements CanActivate {
       return this.legacyFallback(context);
     }
 
+    let claims: Awaited<ReturnType<typeof verifyToken>>;
     try {
-      const claims = await verifyToken(token, this.verifyOptions());
-
-      const user = await this.userProvisioning.findOrCreate(claims.sub);
-      (request as Request & { user: unknown }).user = user;
-      return true;
+      claims = await verifyToken(token, this.verifyOptions());
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.debug(`Clerk token verification failed: ${message}`);
       return this.legacyFallback(context);
     }
+
+    const user = await this.userProvisioning.findOrCreate(claims.sub);
+    (request as Request & { user: unknown }).user = user;
+    return true;
   }
 
   private async legacyFallback(context: ExecutionContext): Promise<boolean> {
@@ -59,11 +60,12 @@ export class ClerkAuthGuard implements CanActivate {
   }
 
   private extractClerkToken(request: Request): string | null {
-    const cookieToken = (
-      request as Request & { cookies?: Record<string, string> }
-    ).cookies?.__session;
-    if (cookieToken) {
-      return cookieToken;
+    const cookies: unknown = request.cookies;
+    if (typeof cookies === 'object' && cookies !== null) {
+      const cookieToken = (cookies as Record<string, unknown>).__session;
+      if (typeof cookieToken === 'string' && cookieToken) {
+        return cookieToken;
+      }
     }
 
     const authHeader = request.headers?.authorization;

--- a/src/auth/clerk/user-provisioning.service.spec.ts
+++ b/src/auth/clerk/user-provisioning.service.spec.ts
@@ -1,40 +1,30 @@
+import { ConflictException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { UserProvisioningService } from './user-provisioning.service';
 
 const makeService = () => {
   const userModel = {
     findOne: jest.fn(),
-    create: jest.fn(),
+    findOneAndUpdate: jest.fn(),
   };
-  const tierModel = {
-    findOne: jest.fn(),
-  };
-  const clerkClient = {
-    users: {
-      getUser: jest.fn(),
-    },
-  };
+  const tierModel = { findOne: jest.fn() };
+  const clerkClient = { users: { getUser: jest.fn() } };
   const emailQueue = {
     addWelcomeEmailJob: jest.fn().mockResolvedValue(undefined),
   };
-
   const service = new UserProvisioningService(
     userModel as any,
     tierModel as any,
     clerkClient as any,
     emailQueue as any,
   );
-
   const fixtures = {
     clerkUserId: 'user_clerk_123',
     defaultTier: { _id: new Types.ObjectId() },
     clerkUser: {
       id: 'user_clerk_123',
       primaryEmailAddressId: 'idn_1',
-      emailAddresses: [
-        { id: 'idn_1', emailAddress: 'a@b.com' },
-        { id: 'idn_2', emailAddress: 'old@b.com' },
-      ],
+      emailAddresses: [{ id: 'idn_1', emailAddress: 'a@b.com' }],
       firstName: 'Ada',
       lastName: 'Lovelace',
       username: 'ada',
@@ -61,80 +51,152 @@ describe('UserProvisioningService', () => {
 
   describe('findOrCreate', () => {
     it('should return the existing user without calling Clerk when clerkId is already linked', async () => {
-      const existing = {
-        _id: new Types.ObjectId(),
-        clerkId: fixtures.clerkUserId,
-      };
+      const existing = { _id: new Types.ObjectId(), clerkId: 'user_clerk_123' };
       mocks.userModel.findOne.mockResolvedValueOnce(existing);
 
-      const result = await service.findOrCreate(fixtures.clerkUserId);
-
-      expect(result).toBe(existing);
+      await expect(service.findOrCreate(fixtures.clerkUserId)).resolves.toBe(
+        existing,
+      );
       expect(mocks.clerkClient.users.getUser).not.toHaveBeenCalled();
-      expect(mocks.userModel.create).not.toHaveBeenCalled();
+      expect(mocks.userModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
-    it('should link an existing user by email when clerkId is not yet set', async () => {
-      const linked = {
+    it('should atomically link an unclaimed existing email without sending a welcome email', async () => {
+      const owner = {
         _id: new Types.ObjectId(),
         email: 'a@b.com',
+        clerkId: undefined,
         avatar: undefined,
-        clerkId: undefined as string | undefined,
-        save: jest.fn().mockResolvedValue(undefined),
       };
+      const linked = { ...owner, clerkId: fixtures.clerkUserId };
       mocks.userModel.findOne
-        .mockResolvedValueOnce(null) // by clerkId
-        .mockResolvedValueOnce(linked); // by email
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(owner);
       mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+      mocks.userModel.findOneAndUpdate.mockResolvedValueOnce(linked);
 
-      const result = await service.findOrCreate(fixtures.clerkUserId);
-
-      expect(result).toBe(linked);
-      expect(linked.clerkId).toBe(fixtures.clerkUserId);
-      expect(linked.avatar).toBe('https://img/ada.png');
-      expect(linked.save).toHaveBeenCalledTimes(1);
-      expect(mocks.userModel.create).not.toHaveBeenCalled();
+      await expect(service.findOrCreate(fixtures.clerkUserId)).resolves.toBe(
+        linked,
+      );
+      expect(mocks.userModel.findOneAndUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ _id: owner._id }),
+        {
+          $set: {
+            clerkId: fixtures.clerkUserId,
+            avatar: 'https://img/ada.png',
+          },
+        },
+        { new: true },
+      );
       expect(mocks.emailQueue.addWelcomeEmailJob).not.toHaveBeenCalled();
     });
 
-    it('should create a new user with the default tier and enqueue a welcome email when no match exists', async () => {
-      const created = {
-        _id: new Types.ObjectId(),
-        clerkId: fixtures.clerkUserId,
-      };
+    it('should reject linking an email owned by another Clerk identity', async () => {
       mocks.userModel.findOne
-        .mockResolvedValueOnce(null) // by clerkId
-        .mockResolvedValueOnce(null); // by email
-      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
-      mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
-      mocks.userModel.create.mockResolvedValueOnce(created);
-
-      const result = await service.findOrCreate(fixtures.clerkUserId);
-
-      expect(result).toBe(created);
-      expect(mocks.userModel.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          clerkId: fixtures.clerkUserId,
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          _id: new Types.ObjectId(),
           email: 'a@b.com',
-          name: 'Ada Lovelace',
-          avatar: 'https://img/ada.png',
-          tier: fixtures.defaultTier._id,
-        }),
-      );
-      expect(mocks.emailQueue.addWelcomeEmailJob).toHaveBeenCalledWith(
-        'a@b.com',
-        'Ada Lovelace',
-      );
+          clerkId: 'user_clerk_other',
+        });
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+
+      await expect(
+        service.findOrCreate(fixtures.clerkUserId),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(mocks.userModel.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
-    it('should still create the user when the welcome email enqueue fails', async () => {
-      const created = { _id: new Types.ObjectId() };
+    it('should atomically create a user and send one welcome email when the upsert inserts', async () => {
+      const created = { _id: new Types.ObjectId(), clerkId: 'user_clerk_123' };
       mocks.userModel.findOne
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null);
       mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
       mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
-      mocks.userModel.create.mockResolvedValueOnce(created);
+      mocks.userModel.findOneAndUpdate.mockResolvedValueOnce({
+        value: created,
+        lastErrorObject: { upserted: created._id },
+        ok: 1,
+      });
+
+      await expect(service.findOrCreate(fixtures.clerkUserId)).resolves.toBe(
+        created,
+      );
+      expect(mocks.userModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { clerkId: fixtures.clerkUserId },
+        {
+          $setOnInsert: {
+            clerkId: fixtures.clerkUserId,
+            email: 'a@b.com',
+            name: 'Ada Lovelace',
+            avatar: 'https://img/ada.png',
+            tier: fixtures.defaultTier._id,
+          },
+        },
+        {
+          includeResultMetadata: true,
+          new: true,
+          setDefaultsOnInsert: true,
+          upsert: true,
+        },
+      );
+      expect(mocks.emailQueue.addWelcomeEmailJob).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not send a welcome email when a concurrent upsert returns the existing user', async () => {
+      const existing = { _id: new Types.ObjectId(), clerkId: 'user_clerk_123' };
+      mocks.userModel.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+      mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
+      mocks.userModel.findOneAndUpdate.mockResolvedValueOnce({
+        value: existing,
+        lastErrorObject: { updatedExisting: true },
+        ok: 1,
+      });
+
+      await expect(service.findOrCreate(fixtures.clerkUserId)).resolves.toBe(
+        existing,
+      );
+      expect(mocks.emailQueue.addWelcomeEmailJob).not.toHaveBeenCalled();
+    });
+
+    it('should surface a conflict when a concurrent signup claims the same email for another Clerk identity', async () => {
+      mocks.userModel.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          _id: new Types.ObjectId(),
+          email: 'a@b.com',
+          clerkId: 'user_clerk_other',
+        });
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+      mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
+      mocks.userModel.findOneAndUpdate.mockRejectedValueOnce(
+        Object.assign(new Error('E11000 duplicate key'), { code: 11000 }),
+      );
+
+      await expect(
+        service.findOrCreate(fixtures.clerkUserId),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(mocks.emailQueue.addWelcomeEmailJob).not.toHaveBeenCalled();
+    });
+
+    it('should still return the inserted user when welcome email enqueue fails', async () => {
+      const created = { _id: new Types.ObjectId(), clerkId: 'user_clerk_123' };
+      mocks.userModel.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      mocks.clerkClient.users.getUser.mockResolvedValueOnce(fixtures.clerkUser);
+      mocks.tierModel.findOne.mockResolvedValueOnce(fixtures.defaultTier);
+      mocks.userModel.findOneAndUpdate.mockResolvedValueOnce({
+        value: created,
+        lastErrorObject: { upserted: created._id },
+        ok: 1,
+      });
       mocks.emailQueue.addWelcomeEmailJob.mockRejectedValueOnce(
         new Error('queue down'),
       );

--- a/src/auth/clerk/user-provisioning.service.ts
+++ b/src/auth/clerk/user-provisioning.service.ts
@@ -1,6 +1,12 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, ModifyResult } from 'mongoose';
 import type { ClerkClient, User as ClerkUser } from '@clerk/backend';
 import { User } from '../../database/schemas/user.schema';
 import { Tier } from '../../database/schemas/tier.schema';
@@ -38,27 +44,48 @@ export class UserProvisioningService {
     const avatar = clerkUser.imageUrl ?? undefined;
 
     if (email) {
-      const linked = await this.userModel.findOne({ email });
-      if (linked) {
-        linked.clerkId = clerkUserId;
-        if (!linked.avatar && avatar) {
-          linked.avatar = avatar;
-        }
-        await linked.save();
-        return linked;
+      const emailOwner = await this.userModel.findOne({ email });
+      if (emailOwner) {
+        return this.linkEmailOwner(emailOwner, clerkUserId, avatar);
       }
     }
 
     const defaultTier = await this.tierModel.findOne({ isDefault: true });
-    const created = await this.userModel.create({
-      clerkId: clerkUserId,
-      email,
-      name,
-      avatar,
-      tier: defaultTier ? defaultTier._id : undefined,
-    });
+    let result: ModifyResult<User>;
+    try {
+      result = await this.userModel.findOneAndUpdate(
+        { clerkId: clerkUserId },
+        {
+          $setOnInsert: {
+            clerkId: clerkUserId,
+            email,
+            name,
+            avatar,
+            tier: defaultTier ? defaultTier._id : undefined,
+          },
+        },
+        {
+          includeResultMetadata: true,
+          new: true,
+          setDefaultsOnInsert: true,
+          upsert: true,
+        },
+      );
+    } catch (error) {
+      if (!this.isDuplicateKeyError(error)) {
+        throw error;
+      }
+      return this.resolveDuplicateRace(clerkUserId, email, avatar);
+    }
 
-    if (email) {
+    const user = result.value;
+    if (!user) {
+      throw new InternalServerErrorException(
+        'Clerk user provisioning did not return a user',
+      );
+    }
+
+    if (email && result.lastErrorObject?.upserted) {
       try {
         await this.emailQueue.addWelcomeEmailJob(email, name);
       } catch (error) {
@@ -70,7 +97,86 @@ export class UserProvisioningService {
       }
     }
 
-    return created;
+    return user;
+  }
+
+  private async linkEmailOwner(
+    emailOwner: User,
+    clerkUserId: string,
+    avatar?: string,
+  ): Promise<User> {
+    if (emailOwner.clerkId && emailOwner.clerkId !== clerkUserId) {
+      throw this.emailOwnershipConflict();
+    }
+
+    const update: { clerkId: string; avatar?: string } = {
+      clerkId: clerkUserId,
+    };
+    if (!emailOwner.avatar && avatar) {
+      update.avatar = avatar;
+    }
+
+    const linked = await this.userModel.findOneAndUpdate(
+      {
+        _id: emailOwner._id,
+        $or: [
+          { clerkId: { $exists: false } },
+          { clerkId: null },
+          { clerkId: clerkUserId },
+        ],
+      },
+      { $set: update },
+      { new: true },
+    );
+    if (linked) {
+      return linked;
+    }
+
+    const winner = await this.userModel.findOne({ clerkId: clerkUserId });
+    if (winner) {
+      return winner;
+    }
+    throw this.emailOwnershipConflict();
+  }
+
+  private async resolveDuplicateRace(
+    clerkUserId: string,
+    email: string,
+    avatar?: string,
+  ): Promise<User> {
+    const clerkWinner = await this.userModel.findOne({
+      clerkId: clerkUserId,
+    });
+    if (clerkWinner) {
+      return clerkWinner;
+    }
+
+    if (email) {
+      const emailWinner = await this.userModel.findOne({ email });
+      if (emailWinner) {
+        return this.linkEmailOwner(emailWinner, clerkUserId, avatar);
+      }
+    }
+
+    throw new InternalServerErrorException(
+      'Unable to resolve concurrent Clerk user provisioning',
+    );
+  }
+
+  private isDuplicateKeyError(error: unknown): boolean {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 11000
+    );
+  }
+
+  private emailOwnershipConflict(): ConflictException {
+    return new ConflictException({
+      message: 'This email is already linked to another Clerk identity.',
+      code: 'CLERK_EMAIL_ALREADY_LINKED',
+    });
   }
 
   private resolvePrimaryEmail(clerkUser: ClerkUser): string {

--- a/src/database/schemas/user.schema.spec.ts
+++ b/src/database/schemas/user.schema.spec.ts
@@ -1,0 +1,23 @@
+import { UserSchema } from './user.schema';
+
+describe('UserSchema', () => {
+  it.each([
+    ['googleId', 'user_google_id_unique'],
+    ['clerkId', 'user_clerk_id_unique'],
+  ])(
+    'should only enforce uniqueness for string %s values',
+    (field, expectedName) => {
+      const index = UserSchema.indexes().find(([keys]) => keys[field] === 1);
+
+      expect(index).toBeDefined();
+      expect(index?.[1]).toMatchObject({
+        name: expectedName,
+        unique: true,
+        partialFilterExpression: {
+          [field]: { $type: 'string' },
+        },
+      });
+      expect(index?.[1]).not.toHaveProperty('sparse');
+    },
+  );
+});

--- a/src/database/schemas/user.schema.ts
+++ b/src/database/schemas/user.schema.ts
@@ -10,10 +10,10 @@ export class User extends Document {
   @Prop({ required: true, unique: true })
   email: string;
 
-  @Prop({ unique: true })
+  @Prop()
   googleId?: string;
 
-  @Prop({ unique: true, sparse: true })
+  @Prop()
   clerkId?: string;
 
   @Prop()
@@ -28,3 +28,24 @@ export class User extends Document {
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);
+
+export const USER_GOOGLE_ID_INDEX_NAME = 'user_google_id_unique';
+export const USER_CLERK_ID_INDEX_NAME = 'user_clerk_id_unique';
+
+UserSchema.index(
+  { googleId: 1 },
+  {
+    name: USER_GOOGLE_ID_INDEX_NAME,
+    unique: true,
+    partialFilterExpression: { googleId: { $type: 'string' } },
+  },
+);
+
+UserSchema.index(
+  { clerkId: 1 },
+  {
+    name: USER_CLERK_ID_INDEX_NAME,
+    unique: true,
+    partialFilterExpression: { clerkId: { $type: 'string' } },
+  },
+);

--- a/src/scripts/migrate-user-identity-indexes.ts
+++ b/src/scripts/migrate-user-identity-indexes.ts
@@ -1,0 +1,48 @@
+import 'dotenv/config';
+import mongoose from 'mongoose';
+import {
+  migrateUserIdentityIndexes,
+  parseUserIndexCatalog,
+  type UserIdentityIndexCollection,
+} from './user-identity-index-migration';
+
+async function run(): Promise<void> {
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    throw new Error('MONGO_URI is missing. Please set it in your environment.');
+  }
+
+  const apply = process.argv.slice(2).includes('--apply');
+  await mongoose.connect(mongoUri, { autoIndex: false });
+  console.log('[user-indexes] Connected using MONGO_URI.');
+
+  try {
+    const collection = mongoose.connection.collection('users');
+    const indexCollection: UserIdentityIndexCollection = {
+      listIndexes: async () => {
+        const catalog: unknown = await collection.listIndexes().toArray();
+        return parseUserIndexCatalog(catalog);
+      },
+      createIndex: (key, options) => collection.createIndex(key, options),
+      dropIndex: (name) => collection.dropIndex(name),
+    };
+    await migrateUserIdentityIndexes(indexCollection, {
+      apply,
+      log: (message) => console.log(`[user-indexes] ${message}`),
+    });
+    if (!apply) {
+      console.log(
+        '[user-indexes] No changes applied. Re-run with --apply after reviewing the plan.',
+      );
+    }
+  } finally {
+    await mongoose.disconnect();
+    console.log('[user-indexes] Disconnected.');
+  }
+}
+
+run().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[user-indexes] Failed: ${message}`);
+  process.exit(1);
+});

--- a/src/scripts/user-identity-index-migration.spec.ts
+++ b/src/scripts/user-identity-index-migration.spec.ts
@@ -1,0 +1,144 @@
+import {
+  migrateUserIdentityIndexes,
+  type UserIdentityIndexCollection,
+  type UserIndexInfo,
+  type UserIdentityIndexMigrationResult,
+} from './user-identity-index-migration';
+
+const legacyIndexes = (): UserIndexInfo[] => [
+  { name: '_id_', key: { _id: 1 } },
+  { name: 'email_1', key: { email: 1 }, unique: true },
+  { name: 'googleId_1', key: { googleId: 1 }, unique: true },
+  {
+    name: 'clerkId_1',
+    key: { clerkId: 1 },
+    unique: true,
+    sparse: true,
+  },
+];
+
+const desiredIndexes = (): UserIndexInfo[] => [
+  {
+    name: 'user_google_id_unique',
+    key: { googleId: 1 },
+    unique: true,
+    partialFilterExpression: { googleId: { $type: 'string' } },
+  },
+  {
+    name: 'user_clerk_id_unique',
+    key: { clerkId: 1 },
+    unique: true,
+    partialFilterExpression: { clerkId: { $type: 'string' } },
+  },
+];
+
+const makeCollection = (startingIndexes: UserIndexInfo[]) => {
+  let indexes = structuredClone(startingIndexes);
+  const createIndex = jest.fn(
+    (key: Record<string, number>, options: Record<string, unknown>) => {
+      indexes.push({ key, ...options } as UserIndexInfo);
+      return Promise.resolve(String(options.name));
+    },
+  );
+  const dropIndex = jest.fn((name: string) => {
+    indexes = indexes.filter((index) => index.name !== name);
+    return Promise.resolve({ ok: 1 });
+  });
+  const collection = {
+    listIndexes: jest.fn(() => Promise.resolve(structuredClone(indexes))),
+    createIndex,
+    dropIndex,
+  } satisfies UserIdentityIndexCollection;
+
+  return { collection, createIndex, dropIndex, getIndexes: () => indexes };
+};
+
+describe('migrateUserIdentityIndexes', () => {
+  it('should report changes without writing during a dry run', async () => {
+    const harness = makeCollection(legacyIndexes());
+
+    const result = await migrateUserIdentityIndexes(harness.collection, {
+      apply: false,
+    });
+
+    expect(result).toEqual<UserIdentityIndexMigrationResult>({
+      applied: false,
+      toCreate: ['user_google_id_unique', 'user_clerk_id_unique'],
+      toDrop: ['googleId_1', 'clerkId_1'],
+    });
+    expect(harness.createIndex).not.toHaveBeenCalled();
+    expect(harness.dropIndex).not.toHaveBeenCalled();
+  });
+
+  it('should create conditional indexes before dropping known legacy indexes', async () => {
+    const harness = makeCollection(legacyIndexes());
+    const operations: string[] = [];
+    harness.createIndex.mockImplementation((key, options) => {
+      operations.push(`create:${String(options.name)}`);
+      harness.getIndexes().push({ key, ...options } as UserIndexInfo);
+      return Promise.resolve(String(options.name));
+    });
+    harness.dropIndex.mockImplementation((name) => {
+      operations.push(`drop:${name}`);
+      const index = harness
+        .getIndexes()
+        .findIndex((candidate) => candidate.name === name);
+      if (index >= 0) harness.getIndexes().splice(index, 1);
+      return Promise.resolve({ ok: 1 });
+    });
+
+    await migrateUserIdentityIndexes(harness.collection, { apply: true });
+
+    expect(operations).toEqual([
+      'create:user_google_id_unique',
+      'create:user_clerk_id_unique',
+      'drop:googleId_1',
+      'drop:clerkId_1',
+    ]);
+  });
+
+  it('should be a no-op when indexes are already compliant', async () => {
+    const harness = makeCollection([
+      ...legacyIndexes().slice(0, 2),
+      ...desiredIndexes(),
+    ]);
+
+    await migrateUserIdentityIndexes(harness.collection, { apply: true });
+
+    expect(harness.createIndex).not.toHaveBeenCalled();
+    expect(harness.dropIndex).not.toHaveBeenCalled();
+  });
+
+  it('should refuse to drop an unexpectedly configured legacy index', async () => {
+    const indexes = legacyIndexes();
+    const google = indexes.find((index) => index.name === 'googleId_1');
+    if (google) google.unique = false;
+    const harness = makeCollection(indexes);
+
+    await expect(
+      migrateUserIdentityIndexes(harness.collection, { apply: true }),
+    ).rejects.toThrow('unexpected definition');
+    expect(harness.createIndex).not.toHaveBeenCalled();
+    expect(harness.dropIndex).not.toHaveBeenCalled();
+  });
+
+  it('should tolerate a legacy index removed concurrently', async () => {
+    const harness = makeCollection(legacyIndexes());
+    harness.dropIndex.mockImplementation((name) => {
+      const index = harness
+        .getIndexes()
+        .findIndex((candidate) => candidate.name === name);
+      if (index >= 0) harness.getIndexes().splice(index, 1);
+      if (name === 'googleId_1') {
+        return Promise.reject(
+          Object.assign(new Error('index not found'), { code: 27 }),
+        );
+      }
+      return Promise.resolve({ ok: 1 });
+    });
+
+    await expect(
+      migrateUserIdentityIndexes(harness.collection, { apply: true }),
+    ).resolves.toMatchObject({ applied: true });
+  });
+});

--- a/src/scripts/user-identity-index-migration.ts
+++ b/src/scripts/user-identity-index-migration.ts
@@ -1,0 +1,222 @@
+import {
+  USER_CLERK_ID_INDEX_NAME,
+  USER_GOOGLE_ID_INDEX_NAME,
+} from '../database/schemas/user.schema';
+
+type IdentityField = 'googleId' | 'clerkId';
+
+type DesiredIndex = {
+  field: IdentityField;
+  name: string;
+  legacyName: string;
+  legacySparse: boolean;
+};
+
+export type UserIndexInfo = {
+  name: string;
+  key: Record<string, unknown>;
+  unique?: boolean;
+  sparse?: boolean;
+  partialFilterExpression?: Record<string, unknown>;
+};
+
+export type UserIdentityIndexCollection = {
+  listIndexes: () => Promise<UserIndexInfo[]>;
+  createIndex: (
+    key: Record<string, number>,
+    options: Record<string, unknown>,
+  ) => Promise<string>;
+  dropIndex: (name: string) => Promise<unknown>;
+};
+
+export type UserIdentityIndexMigrationResult = {
+  applied: boolean;
+  toCreate: string[];
+  toDrop: string[];
+};
+
+const DESIRED_INDEXES: DesiredIndex[] = [
+  {
+    field: 'googleId',
+    name: USER_GOOGLE_ID_INDEX_NAME,
+    legacyName: 'googleId_1',
+    legacySparse: false,
+  },
+  {
+    field: 'clerkId',
+    name: USER_CLERK_ID_INDEX_NAME,
+    legacyName: 'clerkId_1',
+    legacySparse: true,
+  },
+];
+
+const noopLogger = () => undefined;
+
+export async function migrateUserIdentityIndexes(
+  collection: UserIdentityIndexCollection,
+  options: { apply: boolean; log?: (message: string) => void },
+): Promise<UserIdentityIndexMigrationResult> {
+  const log = options.log ?? noopLogger;
+  const indexes = await collection.listIndexes();
+  const toCreate: DesiredIndex[] = [];
+  const toDrop: DesiredIndex[] = [];
+
+  for (const desired of DESIRED_INDEXES) {
+    const current = indexes.find((index) => index.name === desired.name);
+    if (current && !isDesiredIndex(current, desired)) {
+      throw new Error(
+        `Index ${desired.name} exists with an unexpected definition; refusing to modify it.`,
+      );
+    }
+    if (!current) {
+      toCreate.push(desired);
+    }
+
+    const legacy = indexes.find((index) => index.name === desired.legacyName);
+    if (legacy && !isKnownLegacyIndex(legacy, desired)) {
+      throw new Error(
+        `Legacy index ${desired.legacyName} has an unexpected definition; refusing to drop it.`,
+      );
+    }
+    if (legacy) {
+      toDrop.push(desired);
+    }
+  }
+
+  const result: UserIdentityIndexMigrationResult = {
+    applied: options.apply,
+    toCreate: toCreate.map((index) => index.name),
+    toDrop: toDrop.map((index) => index.legacyName),
+  };
+
+  if (!options.apply) {
+    logMigrationPlan(result, log);
+    return result;
+  }
+
+  for (const desired of toCreate) {
+    await collection.createIndex(
+      { [desired.field]: 1 },
+      {
+        name: desired.name,
+        unique: true,
+        partialFilterExpression: {
+          [desired.field]: { $type: 'string' },
+        },
+      },
+    );
+    log(`Created ${desired.name}.`);
+  }
+
+  for (const desired of toDrop) {
+    try {
+      await collection.dropIndex(desired.legacyName);
+      log(`Dropped ${desired.legacyName}.`);
+    } catch (error) {
+      if (!isIndexNotFoundError(error)) {
+        throw error;
+      }
+      log(`${desired.legacyName} was already removed concurrently.`);
+    }
+  }
+
+  await verifyMigration(collection);
+  log('Verified user identity indexes.');
+  return result;
+}
+
+export function parseUserIndexCatalog(value: unknown): UserIndexInfo[] {
+  if (!Array.isArray(value)) {
+    throw new Error('MongoDB returned an invalid index catalog.');
+  }
+
+  return value.map((candidate) => {
+    if (!isRecord(candidate) || typeof candidate.name !== 'string') {
+      throw new Error('MongoDB returned an index without a valid name.');
+    }
+    if (!isRecord(candidate.key)) {
+      throw new Error(`MongoDB index ${candidate.name} has an invalid key.`);
+    }
+
+    const parsed: UserIndexInfo = {
+      name: candidate.name,
+      key: candidate.key,
+    };
+    if (candidate.unique === true) parsed.unique = true;
+    if (candidate.sparse === true) parsed.sparse = true;
+    if (isRecord(candidate.partialFilterExpression)) {
+      parsed.partialFilterExpression = candidate.partialFilterExpression;
+    }
+    return parsed;
+  });
+}
+
+function isDesiredIndex(index: UserIndexInfo, desired: DesiredIndex): boolean {
+  const filter = index.partialFilterExpression;
+  const fieldFilter = filter?.[desired.field];
+
+  return (
+    hasOnlyKey(index, desired.field) &&
+    index.unique === true &&
+    index.sparse !== true &&
+    filter !== undefined &&
+    Object.keys(filter).length === 1 &&
+    isRecord(fieldFilter) &&
+    fieldFilter.$type === 'string' &&
+    Object.keys(fieldFilter).length === 1
+  );
+}
+
+function isKnownLegacyIndex(
+  index: UserIndexInfo,
+  desired: DesiredIndex,
+): boolean {
+  return (
+    hasOnlyKey(index, desired.field) &&
+    index.unique === true &&
+    Boolean(index.sparse) === desired.legacySparse &&
+    index.partialFilterExpression === undefined
+  );
+}
+
+function hasOnlyKey(index: UserIndexInfo, field: IdentityField): boolean {
+  return Object.keys(index.key).length === 1 && index.key[field] === 1;
+}
+
+function isIndexNotFoundError(error: unknown): boolean {
+  return isRecord(error) && error.code === 27;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function verifyMigration(
+  collection: UserIdentityIndexCollection,
+): Promise<void> {
+  const indexes = await collection.listIndexes();
+  for (const desired of DESIRED_INDEXES) {
+    const current = indexes.find((index) => index.name === desired.name);
+    if (!current || !isDesiredIndex(current, desired)) {
+      throw new Error(`Verification failed for ${desired.name}.`);
+    }
+    if (indexes.some((index) => index.name === desired.legacyName)) {
+      throw new Error(
+        `Verification failed because ${desired.legacyName} still exists.`,
+      );
+    }
+  }
+}
+
+function logMigrationPlan(
+  result: UserIdentityIndexMigrationResult,
+  log: (message: string) => void,
+): void {
+  if (result.toCreate.length === 0 && result.toDrop.length === 0) {
+    log('Dry run: user identity indexes are already compliant.');
+    return;
+  }
+  log(
+    `Dry run: create [${result.toCreate.join(', ') || 'none'}], drop [${result.toDrop.join(', ') || 'none'}].`,
+  );
+}


### PR DESCRIPTION
## What changed

- replace optional `googleId` and `clerkId` uniqueness constraints with named partial unique indexes that only index string values
- add a guarded, idempotent local migration with dry-run and explicit `--apply` modes
- make Clerk user provisioning converge safely under concurrent first requests
- keep provisioning/database errors out of the Clerk token-verification fallback path
- document the production repair workflow and add regression coverage

## Root cause

MongoDB's legacy `googleId_1` unique index stores a null index entry for users without a Google ID. Clerk-only users omit `googleId`, so after the first such user, subsequent provisioning fails with `E11000 ... googleId_1 dup key: { googleId: null }`. Changing the Mongoose decorator alone does not remove the persisted production index.

## Impact

New Clerk users can be provisioned without a Google ID while real provider IDs remain unique. Concurrent first requests converge on one local user and welcome email. Provisioning failures are reported accurately rather than being mislabeled as token verification failures.

The production migration is intentionally not automatic. Deploy this schema first, then run `npm run db:migrate:user-indexes -- --apply` locally against the production `MONGO_URI`.

## Validation

- focused Jest regression suite: 4 suites, 20 tests passed
- `npm run build`
- changed-file ESLint checks
- `git diff --check`
- production migration dry-run confirmed it will create `user_google_id_unique` and `user_clerk_id_unique`, then drop only `googleId_1` and `clerkId_1`

The full Jest run also reached 64 passing suites; the existing S3 mock/DNS suite and `auth.di.spec.ts` remain unrelated failures.