### PR TITLE
Fix worker credit error classification

### DIFF
--- a/docs/api/runs.md
+++ b/docs/api/runs.md
@@ -46,7 +46,7 @@ data: {"seq":4,"ts":1752500000123,"step":"GENERATE","index":2,"total":4}
 | `usage.tick` | `kind`, `credits`, `totalCredits`, optional `detail` | Update the live credit display. |
 | `step.failed` | `step`, `retryable`, `message` | When `retryable` is true, show a transient retry notice. When false, `run.failed` follows. |
 | `run.completed` | `artifactId`, `version` | The version is `READY`; refetch the artifact and close the stream. |
-| `run.failed` | `failureReason` | Show the failure and close the stream. |
+| `run.failed` | `failureReason` | Show the failure and close the stream. Retry-exhausted infrastructure failures use a client-safe generic reason. |
 
 The possible workflow steps are `RESOLVE_INPUT`, `RESEARCH`, `GENERATE`, `RENDER_PDF`, and `PERSIST_VERSION`.
 
@@ -79,6 +79,19 @@ type RunEventData =
 ```
 
 The current `step.progress` signal is `sourcesFound` for `RESEARCH`. PDF rendering is atomic and does not currently emit page-level progress.
+
+### Failure reason policy
+
+Deliberate terminal failures use their stable domain reason, such as
+`insufficient credits`. When a transient failure exhausts the worker's retry
+budget, the worker keeps the technical cause in its server logs and emits:
+
+```text
+Generation is temporarily unavailable. Please try again.
+```
+
+Clients must not depend on provider, database, or network error text appearing
+in `failureReason`.
 
 ## Reconnect and close behavior
 

--- a/src/workflow/engine/run-credit-meter.spec.ts
+++ b/src/workflow/engine/run-credit-meter.spec.ts
@@ -1,5 +1,7 @@
+import { FeatureGateForbiddenException } from '../../feature-gating/feature-gating.exception';
 import { RunCreditMeter } from './run-credit-meter';
 import { RunEventType } from './run-event.types';
+import { WorkflowError } from './workflow.error';
 
 describe('RunCreditMeter', () => {
   const userId = '665f1b2c3d4e5f6a7b8c9d0e';
@@ -134,13 +136,36 @@ describe('RunCreditMeter', () => {
       expect(checked).toBe(debited);
     });
 
-    it('should propagate the gate rejection', async () => {
+    it('should classify exhausted credits as a terminal workflow failure', async () => {
       mocks.creditMeterService.assertBalance.mockRejectedValue(
-        new Error('FEATURE_LIMIT_EXCEEDED'),
+        new FeatureGateForbiddenException({
+          code: 'FEATURE_LIMIT_EXCEEDED',
+          feature: 'credits',
+          limit: 120,
+          currentUsage: 120,
+          tier: { id: 'tier-1', name: 'Free' },
+          upgradeHint: 'You have used all your credits for this period.',
+        }),
+      );
+
+      const error: unknown = await meter
+        .assertBalance()
+        .catch((cause: unknown): unknown => cause);
+
+      expect(error).toBeInstanceOf(WorkflowError);
+      expect(error).toMatchObject({
+        reason: 'insufficient credits',
+        retryable: false,
+      });
+    });
+
+    it('should preserve an unexpected balance-check failure', async () => {
+      mocks.creditMeterService.assertBalance.mockRejectedValue(
+        new Error("Socket 'secureConnect' timed out"),
       );
 
       await expect(meter.assertBalance()).rejects.toThrow(
-        'FEATURE_LIMIT_EXCEEDED',
+        "Socket 'secureConnect' timed out",
       );
     });
   });

--- a/src/workflow/engine/run-credit-meter.ts
+++ b/src/workflow/engine/run-credit-meter.ts
@@ -1,8 +1,9 @@
 import type { Logger } from '@nestjs/common';
 import type { UsageRecord } from '../../feature-gating/credit-meter.constants';
 import type { CreditMeterService } from '../../feature-gating/credit-meter.service';
+import { FeatureGateForbiddenException } from '../../feature-gating/feature-gating.exception';
 import { RunEventType, type EmittedEvent } from './run-event.types';
-import { describeError } from './workflow.error';
+import { describeError, terminal } from './workflow.error';
 import type { CreditMeter } from './workflow.types';
 
 /**
@@ -32,8 +33,16 @@ export class RunCreditMeter implements CreditMeter {
    * already bound: taking it again as a parameter would be a second source of
    * truth that could silently disagree with the one `commit` debits.
    */
-  assertBalance(): Promise<void> {
-    return this.creditMeterService.assertBalance(this.userId);
+  async assertBalance(): Promise<void> {
+    try {
+      await this.creditMeterService.assertBalance(this.userId);
+    } catch (error: unknown) {
+      if (error instanceof FeatureGateForbiddenException) {
+        throw terminal('insufficient credits', error);
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/src/workflow/engine/workflow.engine.spec.ts
+++ b/src/workflow/engine/workflow.engine.spec.ts
@@ -217,7 +217,9 @@ describe('runWorkflow', () => {
     it('should fail terminally when the balance guard rejects', async () => {
       // Guards the race where balance drained between enqueue and pickup — a
       // retry cannot refill it, so there is nothing to retry.
-      mocks.meter.assertBalance.mockRejectedValue(new Error('gate'));
+      mocks.meter.assertBalance.mockRejectedValue(
+        terminal('insufficient credits'),
+      );
 
       await expect(runWorkflow(makeInput(), deps)).rejects.toBeInstanceOf(
         UnrecoverableError,
@@ -225,11 +227,30 @@ describe('runWorkflow', () => {
     });
 
     it('should report insufficient credits as the failure reason', async () => {
-      mocks.meter.assertBalance.mockRejectedValue(new Error('gate'));
+      mocks.meter.assertBalance.mockRejectedValue(
+        terminal('insufficient credits'),
+      );
 
       await expect(runWorkflow(makeInput(), deps)).rejects.toThrow(
         'insufficient credits',
       );
+    });
+
+    it('should preserve a database timeout as a retryable failure', async () => {
+      mocks.meter.assertBalance.mockRejectedValue(
+        new Error("Socket 'secureConnect' timed out"),
+      );
+
+      const error: unknown = await runWorkflow(makeInput(), deps).catch(
+        (cause: unknown): unknown => cause,
+      );
+
+      expect(error).toBeInstanceOf(WorkflowError);
+      expect(error).toMatchObject({
+        reason: "Socket 'secureConnect' timed out",
+        retryable: true,
+      });
+      expect(mocks.emitter.flush).toHaveBeenCalledTimes(1);
     });
 
     it('should not run any step when the balance guard rejects', async () => {

--- a/src/workflow/engine/workflow.engine.ts
+++ b/src/workflow/engine/workflow.engine.ts
@@ -108,7 +108,8 @@ export async function runWorkflow(
 
 /**
  * Guards the race where a user's balance drained between enqueue and pickup.
- * Terminal by construction: a retry cannot refill a wallet.
+ * Confirmed exhaustion is terminal because a retry cannot refill a wallet.
+ * Infrastructure and configuration failures keep their normal retry taxonomy.
  */
 async function assertBalance(
   ctx: StepContext,
@@ -116,9 +117,12 @@ async function assertBalance(
 ): Promise<void> {
   try {
     await ctx.meter.assertBalance();
-  } catch {
+  } catch (error: unknown) {
     await emitter.flush();
-    throw new UnrecoverableError('insufficient credits');
+    const workflowError = toWorkflowError(error);
+    throw workflowError.retryable
+      ? workflowError
+      : new UnrecoverableError(workflowError.reason);
   }
 }
 

--- a/src/workflow/workers/artifact-run.worker.handler.spec.ts
+++ b/src/workflow/workers/artifact-run.worker.handler.spec.ts
@@ -13,6 +13,7 @@ jest.mock(
 
 import { ContentValidationError } from '../../agent/agent-runner.error';
 import { FeatureGateForbiddenException } from '../../feature-gating/feature-gating.exception';
+import { WorkflowError } from '../engine/workflow.error';
 import type { BuildInput } from '../engine/workflow.types';
 import {
   ArtifactRunProcessor,
@@ -204,6 +205,42 @@ describe('ArtifactRunProcessor', () => {
       await processor.process(makeJob());
 
       expect(mocks.featureGating.assertResearchAccess).not.toHaveBeenCalled();
+    });
+
+    it('should stop immediately when the worker confirms exhausted credits', async () => {
+      mocks.creditMeter.assertBalance.mockRejectedValue(
+        new FeatureGateForbiddenException({
+          code: 'FEATURE_LIMIT_EXCEEDED',
+          feature: 'credits',
+          limit: 120,
+          currentUsage: 120,
+          tier: { id: 'tier-1', name: 'Free' },
+          upgradeHint: 'You have used all your credits for this period.',
+        }),
+      );
+
+      await expect(processor.process(makeJob())).rejects.toMatchObject({
+        name: 'UnrecoverableError',
+        message: 'insufficient credits',
+      });
+      expect(mocks.agent.generate).not.toHaveBeenCalled();
+    });
+
+    it('should retry a database failure during the worker balance check', async () => {
+      mocks.creditMeter.assertBalance.mockRejectedValue(
+        new Error("Socket 'secureConnect' timed out"),
+      );
+
+      const error: unknown = await processor
+        .process(makeJob())
+        .catch((cause: unknown): unknown => cause);
+
+      expect(error).toBeInstanceOf(WorkflowError);
+      expect(error).toMatchObject({
+        reason: "Socket 'secureConnect' timed out",
+        retryable: true,
+      });
+      expect(mocks.agent.generate).not.toHaveBeenCalled();
     });
 
     it('should run a research-off POST job to a READY version', async () => {
@@ -548,11 +585,24 @@ describe('ArtifactRunProcessor', () => {
       expect(mocks.redis.xadd).not.toHaveBeenCalled();
     });
 
-    it('should still announce run.failed when the attempt ran in another process', async () => {
-      await processor.onFailed(makeJob({ attemptsMade: 3 }), new Error('boom'));
+    it('should hide an exhausted transient cause from the artifact client', async () => {
+      await processor.onFailed(
+        makeJob({ attemptsMade: 3 }),
+        new Error("Socket 'secureConnect' timed out"),
+      );
 
-      expect(mocks.runHandle.fail).toHaveBeenCalledWith('boom');
+      expect(mocks.artifacts.failVersion).toHaveBeenCalledWith(
+        'artifact-1',
+        1,
+        'Generation is temporarily unavailable. Please try again.',
+      );
+      expect(mocks.runHandle.fail).toHaveBeenCalledWith(
+        'Generation is temporarily unavailable. Please try again.',
+      );
       expect(emittedTypes(mocks.redis)).toEqual(['run.failed']);
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Socket 'secureConnect' timed out"),
+      );
     });
 
     it('should log and return when the job has no id', async () => {

--- a/src/workflow/workers/artifact-run.worker.handler.ts
+++ b/src/workflow/workers/artifact-run.worker.handler.ts
@@ -38,6 +38,12 @@ export interface ArtifactRunDeps {
   logger: Logger;
 }
 
+const TEMPORARY_FAILURE_REASON =
+  'Generation is temporarily unavailable. Please try again.';
+
+const isUnrecoverableFailure = (error: Error): boolean =>
+  error instanceof UnrecoverableError || error.name === 'UnrecoverableError';
+
 /**
  * BullMQ stops retrying either because a step declared its failure terminal, or
  * because the attempt budget ran out. `UnrecoverableError` is matched by name as
@@ -45,9 +51,7 @@ export interface ArtifactRunDeps {
  * `instanceof`, and getting this wrong would silently strand a run `RUNNING`.
  */
 export const isTerminalJobFailure = (job: Job, error: Error): boolean =>
-  error instanceof UnrecoverableError ||
-  error.name === 'UnrecoverableError' ||
-  job.attemptsMade >= (job.opts.attempts ?? 1);
+  isUnrecoverableFailure(error) || job.attemptsMade >= (job.opts.attempts ?? 1);
 
 /**
  * The `workflow` queue's consumer: it builds a `StepContext` out of the six role
@@ -136,6 +140,9 @@ export class ArtifactRunProcessor {
     // Absent from the map only when the attempt ran in another process; a fresh
     // emitter restarts `seq`, a lesser evil than losing the client's `run.failed`.
     logger.error(`Artifact run ${runId} failed terminally: ${error.message}`);
+    const failureReason = isUnrecoverableFailure(error)
+      ? describeError(error)
+      : TEMPORARY_FAILURE_REASON;
 
     await handleTerminalFailure(
       {
@@ -147,7 +154,7 @@ export class ArtifactRunProcessor {
       {
         artifactId: job.data.artifactId,
         version: job.data.version,
-        failureReason: describeError(error),
+        failureReason,
       },
     );
   }


### PR DESCRIPTION
## Summary
- classify only real credit-limit rejections as terminal `insufficient credits`
- retry MongoDB and other unexpected balance-check failures with their original server-side cause
- keep exhausted transient failures generic for artifact clients while retaining technical worker logs
- document the `run.failed` failure-reason policy

## Root cause
The worker converted every balance-check exception, including MongoDB TLS connection timeouts, into `insufficient credits` and skipped BullMQ retries.

## Validation
- `npx jest src/workflow/engine/run-credit-meter.spec.ts src/workflow/engine/workflow.engine.spec.ts src/workflow/workers/artifact-run.worker.handler.spec.ts --runInBand`
- `npm run build`

The full unit suite has unrelated existing failures in feedback GitHub API tests and `auth.di.spec.ts` Mongoose schema metadata.